### PR TITLE
Docbook output for apidocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,33 @@ updateapispec:
 api: cleanapi
 	go run gen-apidocs/main.go --config-dir=gen-apidocs/generators --munge-groups=false
 
+mdapi: cleanapi
+	go run gen-apidocs/main.go --backend=brodocs --config-dir=gen-apidocs/generators --munge-groups=false
+
+# DocBook / HTML / PDF generation
+dbapi: cleanapi
+	go run gen-apidocs/main.go --backend=docbook --config-dir=gen-apidocs/generators --munge-groups=false
+
+dbapi-html: gen-apidocs/generators/build/index.xml
+	(cd gen-apidocs/generators/build && \
+	 mkdir -p html && \
+	 cd html && \
+	 xsltproc /usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunk.xsl ../index.xml)
+
+dbapi-pdf-a4: gen-apidocs/generators/build/index.xml
+	(cd gen-apidocs/generators/build && \
+	 mkdir -p pdf-a4 && \
+	 cd pdf-a4 && \
+	 xsltproc --stringparam paper.type A4 -o index-a4.fo ../../../../xsl/api.xsl ../index.xml && \
+	 fop -pdf index-a4.pdf -fo index-a4.fo)
+
+dbapi-pdf-letter: gen-apidocs/generators/build/index.xml
+	(cd gen-apidocs/generators/build && \
+	 mkdir -p pdf-letter && \
+	 cd pdf-letter && \
+	 xsltproc --stringparam paper.type USletter -o index-letter.fo ../../../../xsl/api.xsl ../index.xml && \
+	 fop -pdf index-letter.pdf -fo index-letter.fo)
+
 # NOTE: The following "sudo" may go away when we remove docker based api doc generator
 cleanapi:
 	sudo rm -rf $(shell pwd)/gen-apidocs/generators/build

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ dbapi-html: gen-apidocs/generators/build/index.xml
 	(cd gen-apidocs/generators/build && \
 	 mkdir -p html && \
 	 cd html && \
-	 xsltproc /usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunk.xsl ../index.xml)
+     xsltproc ../../../../xsl/api-html.xsl ../index.xml)
 
 dbapi-pdf-a4: gen-apidocs/generators/build/index.xml
 	(cd gen-apidocs/generators/build && \

--- a/Makefile
+++ b/Makefile
@@ -80,14 +80,14 @@ dbapi-pdf-a4: gen-apidocs/generators/build/index.xml
 	(cd gen-apidocs/generators/build && \
 	 mkdir -p pdf-a4 && \
 	 cd pdf-a4 && \
-	 xsltproc --stringparam paper.type A4 -o index-a4.fo ../../../../xsl/api.xsl ../index.xml && \
+	 xsltproc --stringparam fop1.extensions 1 --stringparam paper.type A4 -o index-a4.fo ../../../../xsl/api.xsl ../index.xml && \
 	 fop -pdf index-a4.pdf -fo index-a4.fo)
 
 dbapi-pdf-letter: gen-apidocs/generators/build/index.xml
 	(cd gen-apidocs/generators/build && \
 	 mkdir -p pdf-letter && \
 	 cd pdf-letter && \
-	 xsltproc --stringparam paper.type USletter -o index-letter.fo ../../../../xsl/api.xsl ../index.xml && \
+	 xsltproc --stringparam fop1.extensions 1 --stringparam paper.type USletter -o index-letter.fo ../../../../xsl/api.xsl ../index.xml && \
 	 fop -pdf index-letter.pdf -fo index-letter.fo)
 
 # NOTE: The following "sudo" may go away when we remove docker based api doc generator

--- a/gen-apidocs/generators/docbook.go
+++ b/gen-apidocs/generators/docbook.go
@@ -1,0 +1,491 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"fmt"
+	"html"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kubernetes-incubator/reference-docs/gen-apidocs/generators/api"
+)
+
+type DocbookTOCItem struct {
+	Level       int
+	Title       string
+	Link        string
+	File        string
+	FileClose   string
+	SubSections []*DocbookTOCItem
+}
+
+type DocbookTOC struct {
+	Title     string
+	Copyright string
+	Sections  []*DocbookTOCItem
+}
+
+type DocbookWriter struct {
+	Config         *api.Config
+	TOC            DocbookTOC
+	CurrentSection *DocbookTOCItem
+}
+
+func NewDocbookWriter(config *api.Config, copyright, title string) DocWriter {
+	writer := DocbookWriter{
+		Config: config,
+		TOC: DocbookTOC{
+			Copyright: copyright,
+			Title:     title,
+			Sections:  []*DocbookTOCItem{},
+		},
+	}
+	return &writer
+}
+
+func (h *DocbookWriter) Extension() string {
+	return ".xml"
+}
+
+func (h *DocbookWriter) DefaultStaticContent(title string) string {
+	titleID := strings.ToLower(strings.Replace(title, " ", "-", -1))
+	return fmt.Sprintf("<part id=\"strong-%s-strong\"><title>%s</title>\n", titleID, title)
+}
+
+func (h *DocbookWriter) WriteOverview() {
+	fn := "_overview.xml"
+	writeStaticFile("Overview", fn, h.DefaultStaticContent("Overview"))
+	item := DocbookTOCItem{
+		Level: 1,
+		Title: "Overview",
+		Link:  "strong-api-overview-strong",
+		File:  fn,
+	}
+	h.TOC.Sections = append(h.TOC.Sections, &item)
+	h.CurrentSection = &item
+}
+
+func (h *DocbookWriter) WriteResourceCategory(name, file string) {
+	writeStaticFile(name, "_"+file+".xml", h.DefaultStaticContent(name))
+	link := strings.Replace(strings.ToLower(name), " ", "-", -1)
+	item := DocbookTOCItem{
+		Level:     1,
+		Title:     strings.ToUpper(name),
+		Link:      "strong-" + link + "-strong",
+		File:      "_" + file + ".xml",
+		FileClose: "_" + file + "_close.xml",
+	}
+	h.TOC.Sections = append(h.TOC.Sections, &item)
+	h.CurrentSection = &item
+
+	writeStaticFile(name, "_"+file+"_close.xml", h.staticContentClose())
+}
+
+func (h *DocbookWriter) WriteResource(r *api.Resource) {
+	fn := "_" + conceptFileName(r.Definition) + ".xml"
+	fnClose := "_" + conceptFileName(r.Definition) + "_close.xml"
+
+	pathClose := *api.ConfigDir + "/includes/" + fnClose
+	wClose, err := os.Create(pathClose)
+	defer wClose.Close()
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("%v", err))
+		os.Exit(1)
+	}
+	fmt.Fprintf(wClose, "</chapter>\n")
+
+	path := *api.ConfigDir + "/includes/" + fn
+	w, err := os.Create(path)
+	defer w.Close()
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("%v", err))
+		os.Exit(1)
+	}
+
+	dvg := fmt.Sprintf("%s %s %s", r.Name, r.Definition.Version, r.Definition.GroupDisplayName())
+	linkID := getLink(dvg)
+	fmt.Fprintf(w, "<chapter id=\"%s\"><title>%s</title>\n", linkID, dvg)
+	h.writeSample(w, r.Definition)
+
+	// GVK
+	fmt.Fprintf(w, "<informaltable>\n<tgroup cols=\"3\"><thead><row><entry>Group</entry><entry>Version</entry><entry>Kind</entry></row></thead>\n<tbody>\n")
+	fmt.Fprintf(w, "<row><entry><systemitem>%s</systemitem></entry><entry><systemitem>%s</systemitem></entry><entry><systemitem>%s</systemitem></entry></row>\n",
+		r.Definition.GroupDisplayName(), r.Definition.Version.String(), r.Name)
+	fmt.Fprintf(w, "</tbody></tgroup>\n</informaltable>\n")
+
+	if r.DescriptionWarning != "" {
+		fmt.Fprintf(w, "<warning><para>%s</para></warning>\n", a2link(r.DescriptionWarning))
+	}
+	if r.DescriptionNote != "" {
+		fmt.Fprintf(w, "<note><para>%s</para></note>\n", a2link(r.DescriptionNote))
+	}
+
+	h.writeOtherVersions(w, r.Definition)
+	h.writeAppearsIn(w, r.Definition)
+	h.writeFields(w, r.Definition)
+
+	// Inline
+	if r.Definition.Inline.Len() > 0 {
+		for _, d := range r.Definition.Inline {
+			fmt.Fprintf(w, "<sect1 id=\"%s\"><title>%s %s %s</title>\n", d.LinkID(), d.Name, d.Version, d.Group)
+			h.writeAppearsIn(w, d)
+			h.writeFields(w, d)
+			fmt.Fprintf(w, "</sect1>")
+		}
+	}
+
+	item := DocbookTOCItem{
+		Level:     1,
+		Title:     dvg,
+		Link:      linkID,
+		File:      fn,
+		FileClose: fnClose,
+	}
+	h.CurrentSection.SubSections = append(h.CurrentSection.SubSections, &item)
+
+	// Operations
+	if len(r.Definition.OperationCategories) == 0 {
+		return
+	}
+
+	for i, c := range r.Definition.OperationCategories {
+		if len(c.Operations) == 0 {
+			continue
+		}
+		catID := strings.Replace(strings.ToLower(c.Name), " ", "-", -1) + "-" + r.Definition.LinkID()
+		catID = "strong-" + catID + "-strong"
+		if i > 0 {
+			fmt.Fprintf(w, "</sect1>\n")
+		}
+		fmt.Fprintf(w, "<sect1 id=\"%s\"><title>%s</title>\n", catID, c.Name)
+		OCItem := DocbookTOCItem{
+			Level: 2,
+			Title: c.Name,
+			Link:  catID,
+		}
+		h.CurrentSection.SubSections = append(h.CurrentSection.SubSections, &OCItem)
+
+		for j, o := range c.Operations {
+			opID := strings.Replace(strings.ToLower(o.Type.Name), " ", "-", -1) + "-" + r.Definition.LinkID()
+			if j > 0 {
+				fmt.Fprintf(w, "</simplesect>\n")
+			}
+			fmt.Fprintf(w, "<simplesect id=\"%s\"><title>%s</title>\n", opID, o.Type.Name)
+			OPItem := DocbookTOCItem{
+				Level: 2,
+				Title: o.Type.Name,
+				Link:  opID,
+			}
+			OCItem.SubSections = append(OCItem.SubSections, &OPItem)
+
+			// Example requests
+			requests := o.GetExampleRequests()
+			if len(requests) > 0 {
+				h.writeOperationSample(w, true, opID, requests)
+			}
+			// Example responses
+			responses := o.GetExampleResponses()
+			if len(responses) > 0 {
+				h.writeOperationSample(w, false, opID, responses)
+			}
+
+			fmt.Fprintf(w, "<bridgehead renderas=\"sect4\">HTTP Request</bridgehead>\n")
+			fmt.Fprintf(w, "<para>%s</para>\n", o.Description())
+			fmt.Fprintf(w, "<synopsis>%s</synopsis>\n", o.GetDisplayHttp())
+
+			h.writeRequestParams(w, o)
+			h.writeResponseParams(w, o)
+		}
+		fmt.Fprintf(w, "</simplesect>\n")
+	}
+	fmt.Fprintf(w, "</sect1>\n")
+}
+
+func (h *DocbookWriter) WriteDefinitionsOverview() {
+	writeStaticFile("Definitions", "_definitions.xml", h.DefaultStaticContent("Definitions"))
+	item := DocbookTOCItem{
+		Level:     1,
+		Title:     "DEFINITIONS",
+		Link:      "strong-definitions-strong",
+		File:      "_definitions.xml",
+		FileClose: "_definitions_close.xml",
+	}
+	h.TOC.Sections = append(h.TOC.Sections, &item)
+	h.CurrentSection = &item
+
+	writeStaticFile("Definitions", "_definitions_close.xml", h.staticContentClose())
+}
+
+func (h *DocbookWriter) WriteDefinition(d *api.Definition) {
+	fn := "_" + definitionFileName(d) + ".xml"
+	path := *api.ConfigDir + "/includes/" + fn
+	f, err := os.Create(path)
+	defer f.Close()
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("%v", err))
+		os.Exit(1)
+	}
+	nvg := fmt.Sprintf("%s %s %s", d.Name, d.Version, d.GroupDisplayName())
+	linkID := getLink(nvg)
+	fmt.Fprintf(f, "<sect1 id=\"%s\"><title>%s</title>\n", linkID, nvg)
+	fmt.Fprintf(f, "<informaltable>\n<tgroup cols=\"3\"><thead><row><entry>Group</entry><entry>Version</entry><entry>Kind</entry></row></thead>\n<tbody>\n")
+	fmt.Fprintf(f, "<row><entry><systemitem>%s</systemitem></entry><entry><systemitem>%s</systemitem></entry><entry><systemitem>%s</systemitem></entry></row>\n",
+		d.GroupDisplayName(), d.Version, d.Name)
+	fmt.Fprintf(f, "</tbody></tgroup>\n</informaltable>\n")
+
+	fmt.Fprintf(f, "<para>%s</para>\n", d.DescriptionWithEntities)
+	h.writeOtherVersions(f, d)
+	h.writeAppearsIn(f, d)
+	h.writeFields(f, d)
+
+	fmt.Fprintf(f, "</sect1>\n")
+	item := DocbookTOCItem{
+		Level: 2,
+		Title: nvg,
+		Link:  linkID,
+		File:  fn,
+	}
+	h.CurrentSection.SubSections = append(h.CurrentSection.SubSections, &item)
+}
+
+func (h *DocbookWriter) WriteOldVersionsOverview() {
+	writeStaticFile("Old Versions", "_oldversions.xml", h.DefaultStaticContent("Old Versions"))
+	item := DocbookTOCItem{
+		Level:     1,
+		Title:     "OLD API VERSIONS",
+		Link:      "strong-old-api-versions-strong",
+		File:      "_oldversions.xml",
+		FileClose: "_oldversions_close.xml",
+	}
+	h.TOC.Sections = append(h.TOC.Sections, &item)
+	h.CurrentSection = &item
+	writeStaticFile("Old Versions", "_oldversions_close.xml", h.staticContentClose())
+}
+
+func (h *DocbookWriter) staticContentClose() string {
+	return fmt.Sprintf("</part>\n")
+}
+
+func (h *DocbookWriter) writeOtherVersions(w io.Writer, d *api.Definition) {
+	if d.OtherVersions.Len() == 0 {
+		return
+	}
+
+	fmt.Fprint(w, "<caution><para>Other API versions of this object exist: ")
+	for _, v := range d.OtherVersions {
+		fmt.Fprintf(w, "%s\n", a2link(v.VersionLink()))
+	}
+	fmt.Fprintf(w, "</para></caution>\n")
+}
+
+func (h *DocbookWriter) writeAppearsIn(w io.Writer, d *api.Definition) {
+	if d.AppearsIn.Len() != 0 {
+		fmt.Fprintf(w, "<note><para> Appears In: <itemizedlist>\n")
+		for _, a := range d.AppearsIn {
+			fmt.Fprintf(w, "  <listitem><para>%s</para></listitem>\n", a2link(a.FullHrefLink()))
+		}
+		fmt.Fprintf(w, " </itemizedlist>\n</para></note>\n")
+	}
+}
+
+func (h *DocbookWriter) writeFields(w io.Writer, d *api.Definition) {
+	if len(d.Fields) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "<variablelist>\n")
+
+	for _, field := range d.Fields {
+		fmt.Fprintf(w, "<varlistentry><term>%s", field.Name)
+
+		if field.Link() != "" {
+			fmt.Fprintf(w, " (<emphasis>%s</emphasis>)", a2link(field.FullLink()))
+		}
+		fmt.Fprintf(w, "</term><listitem>")
+
+		if field.PatchStrategy != "" {
+			fmt.Fprintf(w, "<para>patch strategy: %s</para>", field.PatchStrategy)
+		}
+		if field.PatchMergeKey != "" {
+			fmt.Fprintf(w, "<para>patch merge key: %s</para>", field.PatchMergeKey)
+		}
+		fmt.Fprintf(w, "<para>%s</para></listitem></varlistentry>\n", field.DescriptionWithEntities)
+	}
+	fmt.Fprintf(w, "</variablelist>\n")
+}
+
+func (h *DocbookWriter) Finalize() {
+	// generate NavData
+	os.MkdirAll(*api.ConfigDir+"/build", os.ModePerm)
+	h.generateBook()
+}
+
+// END OF INTERFACE IMPLEMENTATION
+
+func (h *DocbookWriter) writeSample(w io.Writer, d *api.Definition) {
+	if d.Sample.Sample == "" {
+		return
+	}
+
+	note := d.Sample.Note
+	for _, s := range d.GetSamples() {
+		fmt.Fprintf(w, "<example><title>%s</title><programlisting>%s</programlisting></example>\n\n", note, html.EscapeString(s.Text))
+	}
+}
+
+func (h *DocbookWriter) writeOperationSample(w io.Writer, req bool, op string, examples []api.ExampleText) {
+
+	for _, e := range examples {
+		eType := strings.Split(e.Tab, ":")[1]
+		var sampleID string
+		if req {
+			sampleID = "req-" + eType + "-" + op
+		} else {
+			sampleID = "res-" + eType + "-" + op
+		}
+		msg := e.Msg
+		if eType == "curl" && strings.Contains(msg, "proxy") {
+			msg = "<command>curl</command> command (<emphasis>requires <command>kubectl proxy</command> to be running</emphasis>)"
+		} else if eType == "kubectl" && strings.Contains(msg, "Command") { // `kubectl` command
+			msg = "<command>kubectl</command> command"
+		}
+		fmt.Fprintf(w, "<example id=\"%s\"><title>%s</title><programlisting>%s</programlisting></example>", sampleID, msg, e.Text)
+	}
+}
+
+func (h *DocbookWriter) writeParams(w io.Writer, title string, params api.Fields) {
+	fmt.Fprintf(w, "<bridgehead renderas=\"sect4\">%s</bridgehead>\n", title)
+	fmt.Fprintf(w, "<variablelist>\n")
+
+	for _, p := range params {
+		fmt.Fprintf(w, "<varlistentry><term>%s", p.Name)
+
+		if p.Link() != "" {
+			fmt.Fprintf(w, " (<emphasis>%s</emphasis>)", a2link(p.FullLink()))
+		}
+		fmt.Fprintf(w, "</term><listitem>")
+
+		fmt.Fprintf(w, "<para>%s</para></listitem></varlistentry>\n", p.Description)
+	}
+	fmt.Fprintf(w, "</variablelist>\n")
+}
+
+func (h *DocbookWriter) writeRequestParams(w io.Writer, o *api.Operation) {
+	// Operation path params
+	if o.PathParams.Len() > 0 {
+		h.writeParams(w, "Path Parameters", o.PathParams)
+	}
+
+	// operation query params
+	if o.QueryParams.Len() > 0 {
+		h.writeParams(w, "Query Parameters", o.QueryParams)
+	}
+
+	// operation body params
+	if o.BodyParams.Len() > 0 {
+		h.writeParams(w, "Body Parameters", o.BodyParams)
+	}
+}
+
+func (h *DocbookWriter) writeResponseParams(w io.Writer, o *api.Operation) {
+	if o.HttpResponses.Len() == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "<bridgehead renderas=\"sect4\">Response</bridgehead><informaltable>\n<tgroup cols=\"2\"><thead><row><entry>Code</entry><entry>Description</entry></row></thead>\n<tbody>\n")
+	for _, p := range o.HttpResponses {
+		fmt.Fprintf(w, "<row><entry>%s", p.Name)
+		if p.Field.Link() != "" {
+			fmt.Fprintf(w, " (<emphasis>%s</emphasis>)", a2link(p.Field.FullLink()))
+		}
+		fmt.Fprintf(w, "</entry><entry>%s</entry></row>\n", p.Field.Description)
+	}
+	fmt.Fprintf(w, "</tbody></tgroup>\n</informaltable>\n")
+}
+
+func (h *DocbookWriter) generateBook() {
+	html, err := os.Create(*api.ConfigDir + "/build/index.xml")
+	defer html.Close()
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("%v", err))
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(html, "<?xml version=\"1.0\"?>\n<!DOCTYPE book PUBLIC \"-//OASIS//DTD DocBook XML V4.5//EN\" \"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd\">\n")
+	fmt.Fprintf(html, "<book>\n")
+	fmt.Fprintf(html, "<bookinfo>\n")
+	fmt.Fprintf(html, "<releaseinfo>%s</releaseinfo>\n", a2ulink(h.TOC.Copyright))
+	fmt.Fprintf(html, "<releaseinfo>Generated at %s</releaseinfo>\n", time.Now().Format("2006-01-02 15:04:05 (MST)"))
+
+	pos := strings.LastIndex(h.Config.SpecVersion, ".")
+	release := fmt.Sprintf("release-%s", h.Config.SpecVersion[1:pos])
+	specLink := "https://github.com/kubernetes/kubernetes/blob/" + release + "/api/openapi-spec/swagger.json"
+	fmt.Fprintf(html, "<releaseinfo>API Version: <ulink url=\"%s\">%s</ulink></releaseinfo>\n", specLink, h.Config.SpecVersion)
+	fmt.Fprintf(html, "<title>%s</title><subtitle>%s</subtitle>\n", h.TOC.Title, h.Config.SpecVersion)
+	fmt.Fprintf(html, "</bookinfo>\n")
+
+	buf := ""
+	for _, sec := range h.TOC.Sections {
+		fmt.Printf("Collecting %s ... ", sec.File)
+		content, err := ioutil.ReadFile(filepath.Join(*api.ConfigDir, "includes", sec.File))
+		if err == nil {
+			buf += string(content)
+		}
+
+		for _, sub := range sec.SubSections {
+			if len(sub.File) > 0 {
+				subdata, err := ioutil.ReadFile(filepath.Join(*api.ConfigDir, "includes", sub.File))
+				fmt.Printf("Collecting %s ... ", sub.File)
+				if err == nil {
+					buf += string(subdata)
+					fmt.Printf("OK\n")
+				}
+			}
+
+			if len(sub.FileClose) > 0 {
+				subdata, err := ioutil.ReadFile(filepath.Join(*api.ConfigDir, "includes", sub.FileClose))
+				fmt.Printf("Collecting %s ... ", sub.FileClose)
+				if err == nil {
+					buf += string(subdata)
+					fmt.Printf("OK\n")
+				}
+			}
+		}
+		content, err = ioutil.ReadFile(filepath.Join(*api.ConfigDir, "includes", sec.FileClose))
+		if err == nil {
+			buf += string(content)
+		}
+		fmt.Printf("OK\n")
+	}
+	fmt.Fprintf(html, "%s", string(buf))
+
+	fmt.Fprintf(html, "</book>\n")
+}
+
+func a2link(str string) string {
+	result := strings.Replace(str, "<a href=\"#", "<link linkend=\"", -1)
+	return strings.Replace(result, "</a>", "</link>", -1)
+}
+
+func a2ulink(str string) string {
+	result := strings.Replace(str, "<a href=", "<ulink url=", -1)
+	return strings.Replace(result, "</a>", "</ulink>", -1)
+}

--- a/gen-apidocs/generators/static_includes/_cluster.xml
+++ b/gen-apidocs/generators/static_includes/_cluster.xml
@@ -1,0 +1,7 @@
+<part id="strong-cluster-apis-strong">
+ <title>Cluster</title>
+
+<partintro>
+ <para>Cluster resources are responsible for defining configuration of the
+     cluster itself, and are generally only used by cluster operators.</para>
+</partintro>

--- a/gen-apidocs/generators/static_includes/_config.xml
+++ b/gen-apidocs/generators/static_includes/_config.xml
@@ -1,0 +1,33 @@
+<part id="strong-config-and-storage-apis-strong">
+ <title>Config &amp; Storage</title>
+
+ <partintro>
+  <para>Config and Storage resources are responsible for injecting data into your
+      applications and persisting data externally to your container.</para>
+
+  <para>Common resource types:
+   <variablelist>
+    <varlistentry>
+     <term><link linkend="configmap-v1-core">ConfigMaps</link></term>
+     <listitem>
+      <para>for providing text key value pairs injected into the application
+          through environment variables, command line arguments, or files</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><link linkend="secret-v1-core">Secrets</link></term>
+     <listitem>
+      <para>for providing binary data injected into the application through files</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><link linkend="volume-v1-core">Volumes</link></term>
+     <listitem>
+      <para>for providing a filesystem external to the Container.  Maybe shared
+          across Containers within the same Pod and have a lifetime persisting
+          beyond a Container or Pod.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </partintro>

--- a/gen-apidocs/generators/static_includes/_definitions.xml
+++ b/gen-apidocs/generators/static_includes/_definitions.xml
@@ -1,0 +1,7 @@
+<part id="strong-definitions-strong">
+ <title>Definitions</title>
+ <partintro>
+  <para>This section contains definitions for objects used in the Kubernetes APIs.</para>
+ </partintro>
+ <chapter>
+  <title>Definitions</title>

--- a/gen-apidocs/generators/static_includes/_definitions_close.xml
+++ b/gen-apidocs/generators/static_includes/_definitions_close.xml
@@ -1,0 +1,2 @@
+ </chapter>
+</part>

--- a/gen-apidocs/generators/static_includes/_meta.xml
+++ b/gen-apidocs/generators/static_includes/_meta.xml
@@ -1,0 +1,31 @@
+<part id="strong-metadata-apis-strong">
+ <title>Metadata</title>
+
+ <partintro>
+  <para>Metadata resources are responsible for configuring behavior of your other
+      Resources within the Cluster.</para>
+
+  <para>Common resource types:
+   <variablelist>
+    <varlistentry>
+     <term><link linkend="horizontalpodautoscaler-v1-autoscaling">HorizontalPodAutoscaler</link></term>
+     <listitem>
+      <para>(HPA) for automatically scaling the replicacount of your workloads
+          in response to load.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><link linkend="poddisruptionbudget-v1beta1-policy">PodDisruptionBudget</link></term>
+     <listitem>
+      <para>for configuring how many replicas in a given workload maybe made
+          concurrently unavailable when performing maintenance.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><link linkend="event-v1-core">Event</link></term>
+     <listitem><para>for notification of resource lifecycle events in the cluster.</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </partintro>

--- a/gen-apidocs/generators/static_includes/_oldversions.xml
+++ b/gen-apidocs/generators/static_includes/_oldversions.xml
@@ -1,0 +1,6 @@
+<part id="strong-old-api-versions-strong">
+ <title>Old API Versions</title>
+
+ <partintro>
+  <para>This section contains older versions of resources shown above.</para>
+ </partintro>

--- a/gen-apidocs/generators/static_includes/_overview.xml
+++ b/gen-apidocs/generators/static_includes/_overview.xml
@@ -1,0 +1,185 @@
+<preface id="strong-api-overview-strong">
+ <title>API Overview</title>
+
+ <para>Welcome to the Kubernetes API.  You can use the Kubernetes API to read
+       and write Kubernetes resource objects via a Kubernetes API endpoint.</para>
+
+ <sect1 id="resource-categories">
+  <title>Resource Categories</title>
+
+  <para>This is a high-level overview of the basic types of resources provided
+        by the Kubernetes API and their primary functions.</para>
+  <para><firstterm>Workloads</firstterm> are objects you use to manage and run
+        your containers on the cluster.</para>
+  <para><firstterm>Discovery &amp; LB</firstterm> resources are objects you use
+        to "stitch" your workloads together into an externally accessible,
+        load-balanced Service.</para>
+  <para><firstterm>Config &amp; Storage</firstterm> resources are objects you
+		use to inject initialization data into your applications, and to persist
+		data that is external to your container.</para>
+  <para><firstterm>Cluster</firstterm> resources objects define how the cluster
+        itself is configured; these are typically used only by cluster operators.</para>
+  <para><firstterm>Metadata</firstterm> resources are objects you use to
+	    configure the behavior of other resources within the cluster, such as
+	    <systemitem>HorizontalPodAutoscaler</systemitem> for scaling workloads.</para>
+ </sect1>
+
+ <sect1 id="resource-objects">
+  <title>Resource Objects</title>
+
+  <para>Resource objects typically have 3 components:</para>
+  <variablelist>
+   <varlistentry>
+	<term>Resource ObjectMeta</term>
+	<listitem><para>This is metadata about the resource, such as its name, type,
+		api version, annotations, and labels.  This contains fields that maybe
+		updated both by the end user and the system (e.g. annotations).</para>
+	</listitem>
+   </varlistentry>
+   <varlistentry>
+	<term>ResourceSpec</term>
+	<listitem><para>This is defined by the user and describes the desired state
+		of system.  Fill this in when creating or updating an object.</para>
+	</listitem>
+   </varlistentry>
+   <varlistentry>
+	<term>ResourceStatus</term>
+	<listitem><para>This is filled in by the server and reports the current
+		state of the system.  In most cases, users don't need to change this.</para>
+	</listitem>
+   </varlistentry>
+  </variablelist>
+ </sect1>
+
+ <sect1 id="resource-operations">
+  <title>Resource Operations</title>
+
+  <para>Most resources provide the following Operations:</para>
+
+  <sect2 id="resource-operations-create">
+   <title>Create</title>
+
+   <para>Create operations will create the resource in the storage backend.
+	   After a resource is create the system will apply the desired state.</para>
+  </sect2>
+
+  <sect2 id="resource-operations-update">
+   <title>Update</title>
+
+	<para>Updates come in 2 forms, <firstterm>Replace</firstterm> and
+		<firstterm>Patch</firstterm>:
+
+     <variablelist>
+      <varlistentry>
+	   <term>Replace</term>
+       <listitem>
+        <para>Replacing a resource object will update the resource by replacing
+			the existing spec with the provided one.  For read-then-write 
+			operations this is safe because an optimistic lock failure will
+			occur if the resource was modified between the read and write.
+
+		 <note><para>The <emphasis>ResourceStatus</emphasis> will be ignored by
+			the system and will not be updated. To update the status, one must
+			invoke the specific status update operation.</para></note>
+
+         <note><para>Replacing a resource object may not result immediately in
+			changes being propagated to downstream objects.  For instance
+			replacing a <systemitem>ConfigMap</systemitem> or <systemitem>Secret</systemitem>
+			resource will not result in all <emphasis>Pod</emphasis>s seeing the
+			changes unless the <emphasis>Pod</emphasis>s are restarted out of band.</para></note>
+        </para>
+	   </listitem>
+	  </varlistentry>
+
+      <varlistentry>
+	  <term>Patch</term>
+      <listitem><para>Patch will apply a change to a specific field.  How the
+		  change is merged is defined per field.  Lists may either be replaced
+		  or merged.  Merging lists will not preserve ordering.</para>
+
+       <para><emphasis>Patches will never cause optimistic locking failures,
+		   and the last write will win.</emphasis>  Patches are recommended
+		   when the full state is not read before an update, or when failing
+		   on optimistic locking is undesirable. <emphasis>When patching complex
+		   types, arrays and maps, how the patch is applied is defined on a
+		   per-field basis and may either replace the field's current value,
+		   or merge the contents into the current value.</emphasis></para>
+	  </listitem>
+	 </varlistentry>
+    </variablelist>
+   </para>
+  </sect2>
+
+  <sect2 id="resource-operations-read">
+   <title>Read</title>
+
+   <para>Reads come in 3 forms, <emphasis>Get</emphasis>, <emphasis>List</emphasis>
+	and <emphasis>Watch</emphasis>:
+
+    <variablelist>
+     <varlistentry>
+	  <term>Get</term>
+	  <listitem><para>Get will retrieve a specific resource object by name.</para>
+	  </listitem>
+	 </varlistentry>
+     <varlistentry>
+	  <term>List</term>
+	  <listitem><para>List will retrieve all resource objects of a specific type
+		  within a namespace, and the results can be restricted to resources
+		  matching a selector query.</para>
+	  </listitem>
+	 </varlistentry>
+     <varlistentry>
+	  <term>List All Namespaces</term>
+	  <listitem><para>Like <emphasis>List</emphasis> but retrieves resources
+		across all namespaces.</para>
+	  </listitem>
+	 </varlistentry>
+     <varlistentry>
+	  <term>Watch</term>
+	  <listitem><para>Watch will stream results for an object(s) as it is
+		  updated.  Similar to a callback, watch is used to respond to resource
+		  changes.</para>
+	  </listitem>
+	 </varlistentry>
+    </variablelist>
+   </para>
+  </sect2>
+
+  <sect2 id="resource-operations-delete">
+   <title>Delete</title>
+
+   <para>Delete will delete a resource.  Depending on the specific resource,
+	   child objects may or may not be garbage collected by the server.  See
+	   notes on specific resource objects for details.</para>
+  </sect2>
+
+  <sect2 id="resource-operations-additional">
+   <title>Additional Operations</title>
+
+   <para>Resources may define additional operations specific to that resource
+	   type.</para>
+
+   <variablelist>
+	<varlistentry>
+	 <term>Rollback</term>
+	 <listitem><para>Rollback a PodTemplate to a previous version.  Only available
+		 for some resource types.</para>
+	 </listitem>
+	</varlistentry>
+	<varlistentry>
+	 <term>Read / Write Scale</term>
+	 <listitem><para>Read or Update the number of replicas for the given resource.
+		 Only available for some resource types.</para>
+	 </listitem>
+    </varlistentry>
+	<varlistentry>
+	 <term>Read / Write Status</term>
+	 <listitem><para>Read or Update the Status for a resource object.  The
+		 Status can only changed through these update operations.</para>
+	 </listitem>
+	</varlistentry>
+   </variablelist>
+  </sect2>
+ </sect1>
+</preface>

--- a/gen-apidocs/generators/static_includes/_servicediscovery.xml
+++ b/gen-apidocs/generators/static_includes/_servicediscovery.xml
@@ -1,0 +1,32 @@
+<part id="strong-service-apis-strong">
+ <title>Service APIs</title>
+
+ <partintro>
+  <para>Service API resources are responsible for stitching your workloads
+	  together into an accessible Loadbalanced Service.  By default,
+	  <link linkend="strong-workloads-apis-strong">Workloads</link> are only accessible
+	  within the cluster, and they must be exposed externally using a either a 
+	  *LoadBalancer* or *NodePort* <link linkend="service-v1-core">Service</link>.
+	  For development, internally accessible Workloads can be accessed via proxy
+	  through the api master using the <command>kubectl proxy</command> command.</para>
+
+  <para>Common resource types:
+
+   <variablelist>
+    <varlistentry>
+	 <term><link linkend="service-v1-core">Services</link></term>
+	 <listitem>
+	  <para>for providing a single ip endpoint loadbalanced across multiple
+		  Workload replicas.</para>
+	 </listitem>
+	</varlistentry>
+    <varlistentry>
+	 <term><link linkend="ingress-v1beta1-extensions">Ingress</link></term>
+	 <listitem>
+      <para>for providing a https(s) endpoint http(s) routed to one or more
+		  *Services*.</para>
+	 </listitem>
+	</varlistentry>
+   </variablelist>
+  </para>
+ </partintro>

--- a/gen-apidocs/generators/static_includes/_workloads.xml
+++ b/gen-apidocs/generators/static_includes/_workloads.xml
@@ -1,0 +1,19 @@
+<part id="strong-workloads-apis-strong">
+ <title>Workloads</title>
+ <partintro>
+  <para>Workloads resources are responsible for managing and running your
+      containers on the cluster. <link linkend="container-v1-core">Containers</link>
+      are created by Controllers through <link linkend="pod-v1-core">Pods</link>.
+      Pods run Containers and provide environmental dependencies such as shared or
+      persistent storage <link linkend="volume-v1-core">Volumes</link> and
+      <link linkend="configmap-v1-core">Configuration</link> or
+      <link linkend="secret-v1-core">Secret</link> data injected into the container.</para>
+
+  <para>The most common Controllers are:
+   <itemizedlist>
+    <listitem><para><link linkend="deployment-v1-apps">Deployments</link> for stateless persistent apps (e.g. HTTP servers).</para></listitem>
+    <listitem><para><link linkend="statefulset-v1-apps">StatefulSets</link> for stateful persistent apps (e.g. databases).</para></listitem>
+    <listitem><para><link linkend="job-v1-batch">Jobs</link> for run-to-completion apps (e.g. batch Jobs).</para></listitem>
+   </itemizedlist>
+  </para>
+ </partintro>

--- a/gen-apidocs/generators/writer.go
+++ b/gen-apidocs/generators/writer.go
@@ -44,7 +44,7 @@ type DocWriter interface {
 }
 
 var Backend = flag.String("backend", "go",
-                          "Specify the backend to use for doc generation. Valid options are 'brodocs', 'go'.")
+	"Specify the backend to use for doc generation. Valid options are 'brodocs', 'go', 'docbook'.")
 
 func GenerateFiles() {
 	// Load the yaml config
@@ -67,6 +67,8 @@ func GenerateFiles() {
 		writer = NewMarkdownWriter(config, copyright, title)
 	} else if *Backend == "go" {
 		writer = NewHTMLWriter(config, copyright, title)
+	} else if *Backend == "docbook" {
+		writer = NewDocbookWriter(config, copyright, title)
 	} else {
 		panic(fmt.Sprintf("Unknown backend specified: %s", *Backend))
 	}

--- a/xsl/api-html.xsl
+++ b/xsl/api-html.xsl
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="1.0">
+    <xsl:import href="/usr/share/xml/docbook/stylesheet/docbook-xsl/html/chunkfast.xsl"/>
+
+    <xsl:param name="generate.toc">
+            book      title
+            part      title
+    </xsl:param>
+        
+    <!-- UTF-8 encoding -->
+    <xsl:param name="chunker.output.encoding">UTF-8</xsl:param>
+
+    <xsl:param name="chunk.section.depth">0</xsl:param>
+
+    <!-- add meta viewport in HEAD -->
+    <xsl:template name="user.head.content">
+        <meta name="viewport" content="width=device-width, user-scalable=no"/>
+        <link rel="shortcut icon" type="image/png" href="images/favicon.png"/>
+        <link rel="stylesheet" href="css/style.css"/>
+        <link rel="stylesheet" href="css/base_fonts.css"/>
+        <link rel="stylesheet" href="css/jquery-ui.min.css"/>
+        <link rel="stylesheet" href="css/callouts.css"/>
+        <script src="js/anchor-4.1.1.min.js"></script>
+        <script src="js/jquery-3.2.1.min.js"></script>
+        <script src="js/jquery-ui-1.12.1.min.js"></script>
+        <script src="js/bootstrap-4.3.1.min.js"></script>
+        <script src="js/sweetalert-2.1.2.min.js"></script>
+        <script src="js/script.js"></script>
+    </xsl:template>
+
+    <!-- page content -->
+    <xsl:template name="chunk-element-content">
+        <xsl:param name="content">
+            <xsl:apply-imports/>
+        </xsl:param>
+
+        <html id="docs">
+            <xsl:call-template name="root.attributes"/>
+            <xsl:call-template name="html.head">
+            </xsl:call-template>
+
+            <body>
+                <xsl:call-template name="body.attributes"/>
+
+                <div id="cellophane" onclick="kub.toggleMenu()"></div>
+                <header>
+                    <a href="/" class="logo"></a>
+                    <div class="nav-buttons" data-auto-burger="primary">
+                        <ul class="global-nav">
+                            <li><a href="/docs/" class="active">Documentation</a></li>
+                            <li><a href="/blog/">Blog</a></li>
+                            <li><a href="/partners/">Partners</a></li>
+                            <li><a href="/community/">Community</a></li>
+                            <li><a href="/case-studies/">Case Studies</a></li>
+                        </ul>
+                    </div>
+                </header>
+                <section id="hero" class="light-text no-sub">
+                    <h1>Reference</h1>
+                    <h5></h5>
+                    <div id="vendorStrip" class="light-text">
+                        <ul>
+                            <li><a href="/docs/home/">HOME</a></li>
+                            <li><a href="/docs/setup/">GETTING STARTED</a></li>
+                            <li><a href="/docs/concepts/">CONCEPTS</a></li>
+                            <li><a href="/docs/tasks/">TASKS</a></li>
+                            <li><a href="/docs/tutorials/">TUTORIALS</a></li>
+                            <li><a href="/docs/reference/" class="YAH">REFERENCE</a></li>
+                            <li><a href="/docs/contribute/">CONTRIBUTE</a></li>
+                        </ul>
+                    </div>
+                </section>
+
+                <section id="encyclopedia">
+                    <div id="docsToc">                            
+                            <!-- insert ToC here -->
+                            <xsl:call-template name="user.header.content"/>
+                            <!-- end of ToC -->
+                            
+                            <button class="push-menu-close-button" onclick="kub.toggleToc()"></button>
+                        </div>
+                        <div id="docsContent">
+                            
+                            <!-- Insert content here-->
+                            <xsl:copy-of select="$content"/>
+                            <!-- end of content -->
+            
+                        </div>
+                    </section>
+                    <footer>
+                        <main class="light-text">
+                            <nav>
+                                <a href="/docs/home/">Home</a>
+                                <a href="/blog/">Blog</a>
+                                <a href="/partners/">Partners</a>
+                                <a href="/community/">Community</a>
+                                <a href="/case-studies/">Case Studies</a>
+                            </nav>
+                            <div id="miceType" class="center">(C) 2019 The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a></div>
+                            <div id="miceType" class="center">Copyright (C) 2019 The Linux Foundation (R) All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a></div>
+                            <div id="miceType" class="center">ICP license: 京ICP备17074266号-3</div>
+                        </main>
+                    </footer>
+                    <button class="flyout-button" onclick="kub.toggleToc()"></button>
+
+            </body>
+        </html>
+        <xsl:value-of select="$chunk.append"/>
+    </xsl:template>
+
+
+    <xsl:variable name="toc.listitem.type">para</xsl:variable>
+
+
+    <!-- insert ToC on each chunk -*- based on make.toc template -->
+    <xsl:template name="user.header.content">
+        <xsl:param name="toc-context" select="/"/>
+        <xsl:param name="toc.title.p" select="true()"/>
+        <xsl:param name="nodes" select="/NOT-AN-ELEMENT"/>
+        <xsl:variable name="root-nodes" select="/"/>
+
+        <xsl:variable name="nodes.plus" select="$root-nodes | qandaset"/>
+          
+        <xsl:variable name="toc.title">
+            <a class="item" data-title="Kubernetes API v1.16" href="/docs/concepts/"></a>
+        </xsl:variable>
+          
+        <div class="pi-accordion">
+                <xsl:if test="$root-nodes">
+                    <xsl:copy-of select="$toc.title"/>
+                        <xsl:apply-templates select="$root-nodes" mode="toc">
+                            <xsl:with-param name="toc-context" select="$toc-context"/>
+                        </xsl:apply-templates>
+                </xsl:if>          
+        </div>
+    </xsl:template>
+
+
+    <xsl:template name="subtoc">
+        <xsl:param name="toc-context" select="."/>
+        <xsl:param name="nodes" select="NOT-AN-ELEMENT"/>
+
+        <xsl:variable name="nodes.plus" select="$nodes | qandaset"/>
+
+        <xsl:variable name="subtoc">
+                <xsl:choose>
+                    <xsl:when test="$qanda.in.toc != 0">
+                        <xsl:apply-templates mode="toc" select="$nodes.plus">
+                            <xsl:with-param name="toc-context" select="$toc-context"/>
+                        </xsl:apply-templates>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:apply-templates mode="toc" select="$nodes">
+                            <xsl:with-param name="toc-context" select="$toc-context"/>
+                        </xsl:apply-templates>
+                    </xsl:otherwise>
+                </xsl:choose>
+        </xsl:variable>
+
+        <xsl:variable name="depth">
+            <xsl:choose>
+                <xsl:when test="local-name(.) = 'section'">
+                    <xsl:value-of select="count(ancestor::section) + 1"/>
+                </xsl:when>
+                <xsl:when test="local-name(.) = 'sect1'">1</xsl:when>
+                <xsl:when test="local-name(.) = 'sect2'">2</xsl:when>
+                <xsl:when test="local-name(.) = 'sect3'">3</xsl:when>
+                <xsl:when test="local-name(.) = 'sect4'">4</xsl:when>
+                <xsl:when test="local-name(.) = 'sect5'">5</xsl:when>
+                <xsl:when test="local-name(.) = 'refsect1'">1</xsl:when>
+                <xsl:when test="local-name(.) = 'refsect2'">2</xsl:when>
+                <xsl:when test="local-name(.) = 'refsect3'">3</xsl:when>
+                <xsl:when test="local-name(.) = 'topic'">1</xsl:when>
+                <xsl:when test="local-name(.) = 'simplesect'">
+                    <!-- sigh... -->
+                    <xsl:choose>
+                        <xsl:when test="local-name(..) = 'section'">
+                            <xsl:value-of select="count(ancestor::section)"/>
+                        </xsl:when>
+                        <xsl:when test="local-name(..) = 'sect1'">2</xsl:when>
+                        <xsl:when test="local-name(..) = 'sect2'">3</xsl:when>
+                        <xsl:when test="local-name(..) = 'sect3'">4</xsl:when>
+                        <xsl:when test="local-name(..) = 'sect4'">5</xsl:when>
+                        <xsl:when test="local-name(..) = 'sect5'">6</xsl:when>
+                        <xsl:when test="local-name(..) = 'topic'">2</xsl:when>
+                        <xsl:when test="local-name(..) = 'refsect1'">2</xsl:when>
+                        <xsl:when test="local-name(..) = 'refsect2'">3</xsl:when>
+                        <xsl:when test="local-name(..) = 'refsect3'">4</xsl:when>
+                        <xsl:otherwise>1</xsl:otherwise>
+                    </xsl:choose>
+                </xsl:when>
+                <xsl:otherwise>0</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:variable name="depth.from.context" select="count(ancestor::*)-count($toc-context/ancestor::*)"/>
+
+        <xsl:variable name="subtoc.list">
+            <xsl:choose>
+                <xsl:when test="$toc.dd.type = ''">
+                    <xsl:copy-of select="$subtoc"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:copy-of select="$subtoc"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:choose>
+            <xsl:when test="$toc.listitem.type != 'li' and
+                  ( (self::set or self::book or self::part) or 
+                        $toc.section.depth > $depth) and 
+                ( ($qanda.in.toc = 0 and count($nodes)&gt;0) or
+                  ($qanda.in.toc != 0 and count($nodes.plus)&gt;0) )
+                and $toc.max.depth > $depth.from.context">
+
+                <div class="item">
+                    <xsl:attribute name="data-title">
+                        <xsl:apply-templates select="." mode="titleabbrev.markup"/>
+                    </xsl:attribute>
+                    <xsl:call-template name="toc.line">
+                        <xsl:with-param name="toc-context" select="$toc-context"/>
+                    </xsl:call-template>                
+                    <div class="container">
+                        <xsl:copy-of select="$subtoc.list"/>
+                    </div>
+                </div>
+                        
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="toc.line">
+                    <xsl:with-param name="toc-context" select="$toc-context"/>
+                </xsl:call-template>                
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Line -->
+    <xsl:template name="toc.line">
+        <xsl:param name="toc-context" select="."/>
+        <xsl:param name="depth" select="1"/>
+        <xsl:param name="depth.from.context" select="8"/>
+          
+          
+        <a class="item">
+            <xsl:attribute name="href">
+                <xsl:call-template name="href.target">
+                    <xsl:with-param name="context" select="$toc-context"/>
+                    <xsl:with-param name="toc-context" select="$toc-context"/>
+                </xsl:call-template>
+            </xsl:attribute>
+                        
+            <!-- * if $autotoc.label.in.hyperlink is non-zero, then output the label -->
+            <!-- * as part of the hyperlinked title -->
+            <!--xsl:if test="not($autotoc.label.in.hyperlink = 0)">
+                <xsl:variable name="label">
+                <xsl:apply-templates select="." mode="label.markup"/>
+                </xsl:variable>
+                <xsl:copy-of select="$label"/>
+                <xsl:if test="$label != ''">
+                <xsl:value-of select="$autotoc.label.separator"/>
+                </xsl:if>
+            </xsl:if-->
+            <xsl:attribute name="data-title">
+                <xsl:apply-templates select="." mode="titleabbrev.markup"/>
+            </xsl:attribute>
+            <div class="title">
+                <xsl:apply-templates select="." mode="titleabbrev.markup"/>
+            </div>
+        </a>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/xsl/api-html.xsl
+++ b/xsl/api-html.xsl
@@ -6,12 +6,32 @@
     <xsl:param name="generate.toc">
             book      title
             part      title
+            chapter   toc
     </xsl:param>
         
     <!-- UTF-8 encoding -->
     <xsl:param name="chunker.output.encoding">UTF-8</xsl:param>
 
     <xsl:param name="chunk.section.depth">0</xsl:param>
+
+    <xsl:param name="toc.section.depth">0</xsl:param>
+
+    <xsl:variable name="toc.list.type">div</xsl:variable>
+
+    <xsl:variable name="toc.listitem.type">
+        <xsl:choose>
+            <xsl:when test="$toc.list.type = 'div'">dt</xsl:when>
+            <xsl:otherwise>li</xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+
+    <!-- this is just hack because dl and ul aren't completely isomorphic -->
+    <xsl:variable name="toc.dd.type">
+        <xsl:choose>
+            <xsl:when test="$toc.list.type = 'div'">dd</xsl:when>
+            <xsl:otherwise></xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
 
     <!-- add meta viewport in HEAD -->
     <xsl:template name="user.head.content">
@@ -21,6 +41,7 @@
         <link rel="stylesheet" href="css/base_fonts.css"/>
         <link rel="stylesheet" href="css/jquery-ui.min.css"/>
         <link rel="stylesheet" href="css/callouts.css"/>
+        <link rel="stylesheet" href="css/toc.css"/>
         <script src="js/anchor-4.1.1.min.js"></script>
         <script src="js/jquery-3.2.1.min.js"></script>
         <script src="js/jquery-ui-1.12.1.min.js"></script>
@@ -73,45 +94,43 @@
                 </section>
 
                 <section id="encyclopedia">
-                    <div id="docsToc">                            
-                            <!-- insert ToC here -->
-                            <xsl:call-template name="user.header.content"/>
-                            <!-- end of ToC -->
+                    <div id="docsToc">
+                        <!-- insert ToC here -->
+                        <xsl:call-template name="user.header.content"/>
+                        <!-- end of ToC -->
                             
-                            <button class="push-menu-close-button" onclick="kub.toggleToc()"></button>
-                        </div>
-                        <div id="docsContent">
-                            
-                            <!-- Insert content here-->
-                            <xsl:copy-of select="$content"/>
-                            <!-- end of content -->
-            
-                        </div>
-                    </section>
-                    <footer>
-                        <main class="light-text">
-                            <nav>
-                                <a href="/docs/home/">Home</a>
-                                <a href="/blog/">Blog</a>
-                                <a href="/partners/">Partners</a>
-                                <a href="/community/">Community</a>
-                                <a href="/case-studies/">Case Studies</a>
-                            </nav>
-                            <div id="miceType" class="center">(C) 2019 The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a></div>
-                            <div id="miceType" class="center">Copyright (C) 2019 The Linux Foundation (R) All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a></div>
-                            <div id="miceType" class="center">ICP license: 京ICP备17074266号-3</div>
-                        </main>
-                    </footer>
-                    <button class="flyout-button" onclick="kub.toggleToc()"></button>
+                        <button class="push-menu-close-button" onclick="kub.toggleToc()"></button>
+                    </div>
+                    <div id="docsContent">
+                        <xsl:copy-of select="$content"/>
+                    </div>
+                    <div id="tocContent">
+                        <xsl:call-template name="make.toc">
+                            <xsl:with-param name="nodes" select="sect1"/>
+                            <xsl:with-param name="toc.title.p"></xsl:with-param>
+                        </xsl:call-template>
+                    </div>
+                </section>
+                <footer>
+                    <main class="light-text">
+                        <nav>
+                            <a href="/docs/home/">Home</a>
+                            <a href="/blog/">Blog</a>
+                            <a href="/partners/">Partners</a>
+                            <a href="/community/">Community</a>
+                            <a href="/case-studies/">Case Studies</a>
+                        </nav>
+                        <div id="miceType" class="center">(C) 2019 The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a></div>
+                        <div id="miceType" class="center">Copyright (C) 2019 The Linux Foundation (R) All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a></div>
+                        <div id="miceType" class="center">ICP license: 京ICP备17074266号-3</div>
+                    </main>
+                </footer>
+                <button class="flyout-button" onclick="kub.toggleToc()"></button>
 
             </body>
         </html>
         <xsl:value-of select="$chunk.append"/>
     </xsl:template>
-
-
-    <xsl:variable name="toc.listitem.type">para</xsl:variable>
-
 
     <!-- insert ToC on each chunk -*- based on make.toc template -->
     <xsl:template name="user.header.content">

--- a/xsl/api-html.xsl
+++ b/xsl/api-html.xsl
@@ -37,17 +37,17 @@
     <xsl:template name="user.head.content">
         <meta name="viewport" content="width=device-width, user-scalable=no"/>
         <link rel="shortcut icon" type="image/png" href="images/favicon.png"/>
-        <link rel="stylesheet" href="css/style.css"/>
-        <link rel="stylesheet" href="css/base_fonts.css"/>
-        <link rel="stylesheet" href="css/jquery-ui.min.css"/>
-        <link rel="stylesheet" href="css/callouts.css"/>
-        <link rel="stylesheet" href="css/toc.css"/>
-        <script src="js/anchor-4.1.1.min.js"></script>
-        <script src="js/jquery-3.2.1.min.js"></script>
-        <script src="js/jquery-ui-1.12.1.min.js"></script>
-        <script src="js/bootstrap-4.3.1.min.js"></script>
-        <script src="js/sweetalert-2.1.2.min.js"></script>
-        <script src="js/script.js"></script>
+        <link rel="stylesheet" href="/css/style.css"/>
+        <link rel="stylesheet" href="/css/base_fonts.css"/>
+        <link rel="stylesheet" href="/css/jquery-ui.min.css"/>
+        <link rel="stylesheet" href="/css/callouts.css"/>
+        <link rel="stylesheet" href="/css/toc.css"/>
+        <script src="/js/anchor-4.1.1.min.js"></script>
+        <script src="/js/jquery-3.2.1.min.js"></script>
+        <script src="/js/jquery-ui-1.12.1.min.js"></script>
+        <script src="/js/bootstrap-4.3.1.min.js"></script>
+        <script src="/js/sweetalert-2.1.2.min.js"></script>
+        <script src="/js/script.js"></script>
     </xsl:template>
 
     <!-- page content -->

--- a/xsl/api.xsl
+++ b/xsl/api.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format"
+                version="1.0">
+  <xsl:import href="/usr/share/xml/docbook/stylesheet/docbook-xsl/fo/docbook.xsl"/>
+
+  <xsl:param name="paper.type">A4</xsl:param>
+  <xsl:param name="double.sided">1</xsl:param>
+  <xsl:param name="variablelist.as.blocks">1</xsl:param>
+  <xsl:param name="section.autolabel">1</xsl:param>
+  <xsl:param name="generate.toc">
+    book      toc,title
+    part      title
+  </xsl:param>
+  <xsl:attribute-set name="monospace.verbatim.properties">
+    <xsl:attribute name="wrap-option">wrap</xsl:attribute>
+  </xsl:attribute-set>
+  <xsl:param name="insert.link.page.number">yes</xsl:param>
+</xsl:stylesheet>

--- a/xsl/css/style.css
+++ b/xsl/css/style.css
@@ -1112,7 +1112,7 @@ dd {
 
 #docsContent {
     position: relative;
-    float: right;
+    flex: 1;
     width: 100%
 }
 
@@ -2772,15 +2772,15 @@ html.search #docsContent h1 {
     }
     #encyclopedia {
         padding: 50px 50px 100px 100px;
-        clear: both
+        clear: both;
+        display: flex;
     }
     #docsToc {
         position: relative;
-        float: left;
+        flex: 0 0 350px;
         padding: 0 20px;
         left: 0;
-        width: 350px;
-        z-index: auto
+        z-index: auto;
     }
     #docsToc .push-menu-close-button {
         display: none

--- a/xsl/css/style.css
+++ b/xsl/css/style.css
@@ -1,0 +1,2988 @@
+html,
+body {
+    margin: 0;
+    padding: 0
+}
+
+input,
+button {
+    outline: none
+}
+
+button {
+    cursor: pointer
+}
+
+ul,
+li {
+    list-style: none
+}
+
+ul {
+    margin: 0;
+    padding: 0
+}
+
+a {
+    text-decoration: none
+}
+
+.clear {
+    display: block;
+    clear: both
+}
+
+.light-text {
+    color: white
+}
+
+.right {
+    float: right
+}
+
+.left {
+    float: left
+}
+
+.center {
+    text-align: center
+}
+
+*,
+.button {
+    box-sizing: border-box;
+    font-family: "Roboto", sans-serif;
+    background: none;
+    margin: 0;
+    border: 0
+}
+
+body {
+    font-family: "Roboto", sans-serif
+}
+
+h1,
+h2,
+h5,
+p {
+    font-weight: 300
+}
+
+h3,
+h4 {
+    font-weight: 400
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0
+}
+
+input,
+button {
+    outline: none
+}
+
+button {
+    cursor: pointer
+}
+
+ul,
+li {
+    list-style: none
+}
+
+ul {
+    margin: 0;
+    padding: 0
+}
+
+a {
+    text-decoration: none
+}
+
+.clear {
+    display: block;
+    clear: both
+}
+
+.light-text {
+    color: white
+}
+
+.right {
+    float: right
+}
+
+.left {
+    float: left
+}
+
+.center {
+    text-align: center
+}
+
+h1 {
+    font-size: 32px;
+    line-height: 40px
+}
+
+h2 {
+    font-size: 28px;
+    line-height: 60px
+}
+
+h3 {
+    font-size: 24px;
+    line-height: 32px
+}
+
+h4 {
+    font-size: 20px;
+    line-height: 40px
+}
+
+h5 {
+    font-size: 16px;
+    line-height: 36px
+}
+
+p {
+    font-size: 14px;
+    line-height: 22px
+}
+
+section,
+header,
+#vendorStrip {
+    padding-left: 20px;
+    padding-right: 20px
+}
+
+section main,
+header main,
+#vendorStrip main {
+    width: 100%;
+    max-width: 100%
+}
+
+header {
+    height: 80px
+}
+
+.nav-buttons {
+    height: 80px;
+    line-height: 80px
+}
+
+.nav-buttons .button+* {
+    margin-left: 30px
+}
+
+#hamburger {
+    width: 50px;
+    height: 50px
+}
+
+#mainNav {
+    padding: 140px 0 30px
+}
+
+#mainNav h5 {
+    margin-bottom: 1em
+}
+
+#mainNav h3 {
+    margin-bottom: .6em
+}
+
+#mainNav .nav-box {
+    width: 20%
+}
+
+#mainNav .nav-box+.nav-box {
+    margin-left: calc(20% / 3)
+}
+
+#mainNav main+main {
+    margin-top: 60px
+}
+
+#mainNav .left .button {
+    height: 50px;
+    line-height: 50px;
+    font-size: 18px
+}
+
+.open-nav #tryKubernetes,
+.y-enough #tryKubernetes {
+    margin-left: 30px
+}
+
+#hero {
+    padding-top: 80px
+}
+
+#docs #hero h1,
+#docs #hero h5 {
+    padding-left: 20px;
+    padding-right: 20px
+}
+
+#vendorStrip {
+    height: 88px;
+    line-height: 88px;
+    font-size: 16px
+}
+
+body {
+    background-color: white
+}
+
+section {
+    position: relative;
+    background-color: white
+}
+
+section main,
+header main,
+footer main {
+    position: relative;
+    margin: auto
+}
+
+p {
+    font-size: 14px;
+    font-weight: 400
+}
+
+.button {
+    display: inline-block;
+    border-radius: 6px;
+    padding: 0 20px;
+    line-height: 40px;
+    color: white;
+    background-color: #3371e3;
+    text-decoration: none;
+    font-size: 1rem
+}
+
+#cellophane {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: none
+}
+
+header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 8888;
+    background-color: transparent;
+    box-shadow: 0 0 0 transparent;
+    overflow: hidden;
+    transition: 0.3s;
+    text-align: center
+}
+
+.logo {
+    position: relative;
+    float: left;
+    display: block;
+    width: 180px;
+    height: 88px;
+    top: 0;
+    left: 0;
+    transform: none;
+    background-image: url(../images/nav_logo.svg);
+    background-size: contain;
+    background-position: center center;
+    background-repeat: no-repeat
+}
+
+.blog-content table {
+    max-width: 100%;
+    border: 1px solid #ccc;
+    border-spacing: 0;
+    margin-top: 30px;
+    margin-bottom: 30px
+}
+
+.blog-content table thead {
+    border-bottom: 2px solid #ccc
+}
+
+.blog-content table thead tr th {
+    padding: .5rem;
+    font-size: 1.5rem
+}
+
+.blog-content table tbody tr td {
+    padding: .5rem;
+    border-bottom: 1px solid #ccc;
+    border-left: 1px solid #ccc;
+    padding-right: 5rem
+}
+
+#docs .flyout-button {
+    position: fixed;
+    top: 20px;
+    left: 20px;
+    width: 50px;
+    height: 50px;
+    background-image: url(../images/toc_icon.png);
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: auto;
+    border-radius: 50%;
+    transition: 0.3s;
+    z-index: 99999
+}
+
+#docs.open-nav .flyout-button {
+    display: none
+}
+
+#docs .logo {
+    position: absolute;
+    top: 40px;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: block;
+    width: 45px;
+    height: 44px;
+    background-image: url(../images/favicon.png)
+}
+
+#docs.flip-nav .flyout-button {
+    background-image: url(../images/toc_icon_grey.png)
+}
+
+.nav-buttons {
+    float: right
+}
+
+#viewDocs,
+#tryKubernetes {
+    display: none
+}
+
+#viewDocs {
+    border: 2px solid white;
+    background-color: transparent;
+    transition: 0.3s
+}
+
+#viewDocs:hover {
+    background-color: white;
+    color: #303030
+}
+
+#tryKubernetes {
+    width: 0;
+    padding: 0 0;
+    border: 1px solid transparent;
+    background-color: transparent;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    overflow: hidden;
+    transition: 0.3s
+}
+
+#hamburger {
+    display: inline-block;
+    position: relative;
+    vertical-align: middle;
+    padding: 0;
+    border: 0;
+    background: none
+}
+
+#hamburger div,
+#hamburger:before,
+#hamburger:after {
+    position: absolute;
+    left: 15%;
+    width: 70%;
+    height: 2px;
+    background-color: #3371e3;
+    transition: 0.3s;
+    content: ""
+}
+
+#hamburger div {
+    top: calc(50% - 1px)
+}
+
+#hamburger:before {
+    top: 24%
+}
+
+#hamburger:after {
+    bottom: 24%
+}
+
+#hamburger:hover div,
+#hamburger:hover:before,
+#hamburger:hover:after {
+    background-color: white
+}
+
+#mainNav h5 {
+    color: #3371e3;
+    font-weight: normal
+}
+
+#mainNav main {
+    white-space: nowrap;
+    overflow: hidden;
+    clear: both
+}
+
+#mainNav .nav-box {
+    float: left;
+    white-space: normal
+}
+
+#mainNav h3 a {
+    color: #3371e3;
+    text-decoration: none
+}
+
+ul.global-nav {
+    display: none
+}
+
+ul.global-nav li {
+    display: inline-block;
+    margin-right: 14px
+}
+
+ul.global-nav li a {
+    color: #fff;
+    font-weight: 400;
+    padding: 0;
+    position: relative
+}
+
+ul.global-nav li a.active:after {
+    position: absolute;
+    width: 100%;
+    height: 2px;
+    content: '';
+    bottom: -4px;
+    left: 0;
+    background: #fff
+}
+
+ul.global-nav li a .ui-icon {
+    filter: brightness(0) invert(1)
+}
+
+ul.global-nav li ul {
+    display: none;
+    position: fixed;
+    top: 40px;
+    text-align: left
+}
+
+ul.global-nav li ul li {
+    display: block;
+    height: 28px
+}
+
+ul.global-nav li ul li a {
+    background: #303030;
+    color: #fff;
+    padding: 7px
+}
+
+ul.global-nav li ul li:last-child a {
+    border-radius: 7px
+}
+
+ul.global-nav li:hover ul {
+    display: block
+}
+
+.flip-nav ul.global-nav li a,
+.open-nav ul.global-nav li a {
+    color: #303030
+}
+
+.flip-nav ul.global-nav li a .ui-icon,
+.open-nav ul.global-nav li a .ui-icon {
+    filter: brightness(0)
+}
+
+.flip-nav ul.global-nav li ul li a {
+    background: #fff;
+    color: #303030
+}
+
+.flip-nav ul.global-nav li a.active:after,
+.flip-nav ul.global-nav li ul li a.active:after,
+.open-nav ul.global-nav li a.active:after {
+    background: #3371e3
+}
+
+.flip-nav header {
+    background-color: white
+}
+
+.open-nav body {
+    overflow: hidden
+}
+
+.open-nav #cellophane {
+    display: block;
+    z-index: 9998
+}
+
+.open-nav header {
+    background-color: #e8e8e8;
+    z-index: 9999
+}
+
+.open-nav #hamburger div {
+    opacity: 0
+}
+
+.open-nav #hamburger:before,
+.open-nav #hamburger:after {
+    left: 12px;
+    transform-origin: 0 1px
+}
+
+.open-nav #hamburger:before {
+    transform: rotate(45deg)
+}
+
+.open-nav #hamburger:after {
+    transform: rotate(-45deg)
+}
+
+.open-nav #tryKubernetes,
+.y-enough #tryKubernetes {
+    width: auto;
+    padding: 0 20px;
+    background-color: #3371e3;
+    border-color: #3371e3
+}
+
+.flip-nav header,
+.open-nav header {
+    box-shadow: 0 1px 2px #4c4c4c
+}
+
+.flip-nav #viewDocs,
+.open-nav #viewDocs {
+    border-color: #303030;
+    color: #303030
+}
+
+.flip-nav #viewDocs:hover,
+.open-nav #viewDocs:hover {
+    border-color: #3371e3;
+    background-color: #3371e3;
+    color: white
+}
+
+.flip-nav #hamburger:hover div,
+.flip-nav #hamburger:hover:before,
+.flip-nav #hamburger:hover:after,
+.open-nav #hamburger:hover div,
+.open-nav #hamburger:hover:before,
+.open-nav #hamburger:hover:after {
+    background-color: #303030
+}
+
+#hero {
+    background-image: url(../images/texture.png);
+    background-color: #303030;
+    text-align: center;
+    padding-left: 0;
+    padding-right: 0;
+    margin-bottom: 0;
+    position: relative
+}
+
+#hero.bot-bar:after {
+    display: block;
+    margin-bottom: -20px;
+    height: 8px;
+    width: 100%;
+    background-color: rgba(255, 255, 255, 0.1);
+    content: ''
+}
+
+#hero.no-sub h5 {
+    display: none
+}
+
+#hero.no-sub h1 {
+    margin-bottom: 20px
+}
+
+#home #hero:after {
+    display: none
+}
+
+#vendorStrip {
+    position: relative;
+    background-color: rgba(255, 255, 255, 0.1);
+    font-weight: 100;
+    white-space: nowrap;
+    text-align: center
+}
+
+#vendorStrip li a {
+    color: rgba(255, 255, 255, 0.5)
+}
+
+#vendorStrip li a.YAH {
+    color: white;
+    position: relative
+}
+
+footer {
+    width: 100%;
+    background-image: url(../images/texture.png);
+    background-color: #303030
+}
+
+footer main {
+    padding: 20px 0
+}
+
+footer nav a {
+    width: 100%;
+    text-align: center;
+    display: inline-block;
+    margin: 10px 0;
+    font-size: 24px;
+    font-weight: 300;
+    color: white;
+    text-decoration: none
+}
+
+footer .social {
+    margin: 20px 0
+}
+
+footer .social div {
+    text-align: center;
+    margin-bottom: 20px
+}
+
+footer .social div:last-child {
+    margin: 30px 0
+}
+
+footer .social span {
+    display: block;
+    margin-bottom: 8px
+}
+
+footer .social input {
+    text-align: center
+}
+
+#search,
+#wishField {
+    background-color: transparent;
+    padding: 10px;
+    font-size: 16px;
+    font-weight: 100;
+    color: white;
+    border: 1px solid white;
+    transition: 0.3s
+}
+
+#search:focus,
+#wishField:focus {
+    background-color: #f7f7f7;
+    color: #303030
+}
+
+.social a {
+    display: inline-block;
+    background-image: url(../images/social_sprite.png);
+    background-repeat: no-repeat;
+    background-size: auto;
+    width: 50px;
+    height: 50px;
+    border-radius: 5px;
+    margin-right: 10px
+}
+
+.social a:hover {
+    background-color: #fff
+}
+
+.social a span {
+    position: absolute;
+    display: block;
+    height: 0;
+    overflow: hidden
+}
+
+.social a.button {
+    background-image: none;
+    width: auto;
+    height: auto
+}
+
+.social a.button:hover {
+    color: #3371e3
+}
+
+a.twitter {
+    background-position: 0 0
+}
+
+a.twitter:hover {
+    background-position: 0 100%
+}
+
+a.stack-overflow {
+    background-position: -50px 0
+}
+
+a.stack-overflow:hover {
+    background-position: -50px 100%
+}
+
+a.slack {
+    background-position: -100px 0
+}
+
+a.slack:hover {
+    background-position: -100px 100%
+}
+
+a.github {
+    background-position: -150px 0
+}
+
+a.github:hover {
+    background-position: -150px 100%
+}
+
+a.mailing-list {
+    background-position: -200px 0
+}
+
+a.mailing-list:hover {
+    background-position: -200px 100%
+}
+
+a.calendar {
+    background-position: -250px 0
+}
+
+a.calendar:hover {
+    background-position: -250px 100%
+}
+
+#viewDocs {
+    display: none
+}
+
+section {
+    background-color: white
+}
+
+#hero {
+    background-color: #303030
+}
+
+#hero h5 {
+    margin: 20px 0;
+    line-height: 28px
+}
+
+#vendorStrip {
+    position: relative
+}
+
+#vendorStrip ul {
+    float: left
+}
+
+#vendorStrip li {
+    display: inline-block;
+    height: 100%
+}
+
+#vendorStrip a {
+    display: block;
+    height: 100%;
+    color: white;
+    font-size: 0.75em;
+    font-weight: bold
+}
+
+#vendorStrip li+li {
+    margin-left: 0
+}
+
+#docs #hero.light-text.no-sub {
+    padding-bottom: 0px
+}
+
+#docs #vendorStrip {
+    line-height: 44px;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch
+}
+
+#docs #vendorStrip ul {
+    float: none
+}
+
+#docs #vendorStrip #searchBox {
+    float: none;
+    display: block;
+    width: 80%;
+    margin: 0 auto;
+    height: 44px;
+    line-height: 44px;
+    position: relative
+}
+
+#docs #vendorStrip #searchBox:before {
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    content: '';
+    right: 8px;
+    top: 7px;
+    background-image: url(../images/search-icon.svg);
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    z-index: 1
+}
+
+#docs #vendorStrip #search {
+    width: 100%;
+    padding: 0 10px;
+    height: 30px;
+    line-height: 30px;
+    font-size: 16px;
+    vertical-align: top;
+    background: #fff;
+    border: none;
+    border-radius: 4px;
+    position: relative
+}
+
+#encyclopedia {
+    position: relative;
+    padding: 50px 20px 20px 20px;
+    overflow: hidden;
+    font-size: 14px
+}
+
+#docsToc {
+    position: fixed;
+    background-color: white;
+    top: 0;
+    left: 0;
+    width: 0;
+    overflow: hidden;
+    padding: 50px 0;
+    z-index: 999999;
+    transition: 0.3s
+}
+
+#docsToc .yah>.title {
+    background-color: #f7f7f7;
+    border-left: 3px solid #3371e3;
+    padding: 7.5px 10px 7.5px 18px;
+    margin-left: -3px;
+    color: #3371e3
+}
+
+.open-toc body {
+    overflow: hidden
+}
+
+.open-toc #docsToc {
+    padding: 50px 20px;
+    width: 400px;
+    max-width: 100vw;
+    overflow-y: auto
+}
+
+.pi-accordion>.container:first-child>.item:first-child>.title:first-child {
+    padding-left: 0;
+    font-size: 1.5em;
+    font-weight: 700
+}
+
+.pi-accordion>.container:first-child>.item.yah:first-child>.title:first-child {
+    margin-left: -20px !important
+}
+
+.pi-accordion .item {
+    overflow: hidden
+}
+
+.pi-accordion .title {
+    color: #303030;
+    position: relative;
+    padding: 7.5px 10px 7.5px 18px;
+    cursor: pointer;
+    transition: 0.3s
+}
+
+.pi-accordion .title:hover {
+    color: #3371e3
+}
+
+.pi-accordion a.item>.title {
+    color: black
+}
+
+.pi-accordion a.item>.title:hover {
+    color: #3371e3
+}
+
+.pi-accordion div.item>.title:before {
+    content: "";
+    position: absolute;
+    top: 12px;
+    left: 2px;
+    border-style: solid;
+    border-width: 5px 0 5px 8px;
+    border-color: transparent transparent transparent #3371e3;
+    transform: rotate(0deg);
+    transition: 0.3s
+}
+
+.pi-accordion .wrapper {
+    position: relative;
+    width: 100%;
+    transition: height 0.3s
+}
+
+.pi-accordion .content {
+    padding-left: 20px;
+    opacity: 0;
+    transition: 0.3s
+}
+
+.pi-accordion .item.on>.title:before {
+    transform: rotate(90deg)
+}
+
+.pi-accordion .item.on>.wrapper>.content {
+    opacity: 1
+}
+
+dt {
+    margin-bottom: 8px
+}
+
+dd {
+    margin-bottom: 16px
+}
+
+.pi-pushmenu {
+    display: none;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    transition: opacity 0.3s
+}
+
+.pi-pushmenu.on {
+    opacity: 1
+}
+
+.pi-pushmenu .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4)
+}
+
+.pi-pushmenu .sled {
+    position: absolute;
+    top: 0;
+    width: 0;
+    height: 100%;
+    background-color: white;
+    overflow: auto;
+    transition: 0.3s
+}
+
+.pi-pushmenu.on .sled {
+    width: 400px;
+    max-width: 100vw
+}
+
+.pi-pushmenu .top-bar {
+    height: 0;
+    line-height: 60px;
+    background-color: #444
+}
+
+.pi-pushmenu ul {
+    margin-top: 25px
+}
+
+.pi-pushmenu li {
+    position: relative;
+    display: block;
+    width: 100%;
+    min-height: 45px;
+    padding: 0 60px 0 20px;
+    border-bottom: 1px solid #cccccc
+}
+
+.pi-pushmenu a {
+    display: inline-block;
+    width: 100%;
+    height: 45px;
+    line-height: 45px;
+    font-family: "Roboto", sans-serif;
+    font-size: 20px;
+    color: #3371e3
+}
+
+.pi-pushmenu .button {
+    background: none;
+    padding: 0
+}
+
+.pi-pushmenu ul ul {
+    padding: 0 20px
+}
+
+.pi-pushmenu ul ul li {
+    min-height: 40px
+}
+
+.pi-pushmenu ul ul a {
+    height: 40px;
+    line-height: 40px;
+    font-size: 18px;
+    color: #555
+}
+
+.push-menu-close-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 50px;
+    height: 50px
+}
+
+.push-menu-close-button:before,
+.push-menu-close-button:after {
+    content: "";
+    position: absolute;
+    top: calc(50% - 1px);
+    left: 25%;
+    width: 50%;
+    height: 2px;
+    background-color: black
+}
+
+.push-menu-close-button:before {
+    transform: rotate(45deg)
+}
+
+.push-menu-close-button:after {
+    transform: rotate(-45deg)
+}
+
+#docsContent {
+    position: relative;
+    float: right;
+    width: 100%
+}
+
+#docsContent *+h2,
+#docsContent *+h3,
+#docsContent *+h4,
+#docsContent *+h5,
+#docsContent *+h6 {
+    margin-top: 30px
+}
+
+#docsContent h1,
+#docsContent h2,
+#docsContent h3,
+#docsContent h4,
+#docsContent h5,
+#docsContent h6 {
+    line-height: normal;
+    font-weight: 500;
+    margin-bottom: 30px;
+    padding-bottom: 10px
+}
+
+#docsContent h1:before,
+#docsContent h2:before,
+#docsContent h3:before,
+#docsContent h4:before,
+#docsContent h5:before,
+#docsContent h6:before {
+    display: block;
+    content: " ";
+    margin-top: -100px;
+    height: 100px;
+    visibility: hidden
+}
+
+#docsContent h1,
+#docsContent h2 {
+    border-bottom: 1px solid #cccccc
+}
+
+#docsContent h1 {
+    font-size: 32px;
+    padding-right: 60px
+}
+
+#docsContent h2 {
+    font-size: 28px
+}
+
+#docsContent h3 {
+    font-size: 24px;
+    font-weight: 300;
+    margin-bottom: 5px
+}
+
+#docsContent h4 {
+    font-size: 20px;
+    margin-bottom: 0px
+}
+
+#docsContent h5,
+#docsContent h6 {
+    font-size: 16px;
+    font-weight: 500
+}
+
+#docsContent p {
+    font-size: 16px;
+    font-weight: 300;
+    line-height: 1.75em
+}
+
+#docsContent p+p {
+    margin-top: 10px
+}
+
+#docsContent code {
+    display: inline-block;
+    box-sizing: border-box;
+    background-color: #f7f7f7;
+    color: #303030;
+    font-family: "Roboto Mono", monospace;
+    vertical-align: baseline;
+    font-size: 14px;
+    font-weight: bold;
+    padding: 2px 4px
+}
+
+#docsContent a code {
+    color: #3371e3;
+    text-decoration: underline
+}
+
+#docsContent pre .pi,
+#docsContent pre .s {
+    margin: 0;
+    padding: 0
+}
+
+#docsContent .highlight code span,
+#docsContent code,
+#docsContent pre code {
+    font-family: "Roboto Mono", monospace
+}
+
+#docsContent code,
+#docsContent pre code {
+    color: #303030
+}
+
+#docsContent pre code {
+    padding: 0
+}
+
+#docsContent pre {
+    background-color: #f7f7f7;
+    display: block;
+    margin: 20px 0;
+    padding: 15px;
+    position: relative;
+    overflow-x: auto
+}
+
+#docsContent h1 code,
+#docsContent h2 code,
+#docsContent h3 code,
+#docsContent h4 code,
+#docsContent h5 code,
+#docsContent h6 code {
+    font-size: inherit;
+    background-color: transparent
+}
+
+#docsContent .includecode {
+    table-layout: fixed
+}
+
+#docsContent .includecode,
+#docsContent .includecode th,
+#docsContent .includecode td {
+    padding: 0 !important
+}
+
+#docsContent .includecode th {
+    text-align: right !important;
+    padding: 10px !important
+}
+
+#docsContent .includecode th a,
+#docsContent .includecode th a code {
+    color: white !important;
+    background-color: transparent !important
+}
+
+#docsContent .includecode pre {
+    margin: 0 !important
+}
+
+#docsContent ul li {
+    list-style: disc
+}
+
+#docsContent ol ul li {
+    list-style: disc
+}
+
+#docsContent ol li {
+    list-style: decimal
+}
+
+#docsContent ul,
+#docsContent ol {
+    margin: 20px 0;
+    padding-left: 30px;
+    font-weight: 300
+}
+
+#docsContent ul ul,
+#docsContent ol ol,
+#docsContent ul ol,
+#docsContent ol ul {
+    margin: 0.75em 0
+}
+
+#docsContent li {
+    margin-bottom: 0.75em;
+    font-size: 16px;
+    line-height: 1.75em
+}
+
+#docsContent table {
+    width: 100%;
+    border: 1px solid #ccc;
+    border-spacing: 0;
+    margin-top: 30px;
+    margin-bottom: 30px
+}
+
+#docsContent thead,
+#docsContent tr:nth-child(even) {
+    background-color: #f7f7f7
+}
+
+#docsContent thead {
+    background-color: #555;
+    color: white
+}
+
+#docsContent th,
+#docsContent td {
+    padding: 8px;
+    text-align: left;
+    margin: 0
+}
+
+#docsContent th {
+    font-weight: normal
+}
+
+#docsContent td {
+    font-size: 0.85em
+}
+
+#docsContent #editPageButton {
+    position: absolute;
+    top: -25px;
+    right: 5px;
+    width: 50px;
+    height: 50px;
+    line-height: 50px;
+    border-radius: 50%;
+    white-space: nowrap;
+    text-indent: 50px;
+    overflow: hidden;
+    background: #3371e3 url(../images/icon-pencil.svg) no-repeat;
+    background-position: 12px 10px;
+    background-size: 29px 29px
+}
+
+#docsContent #markdown-toc,
+#docsContent #TableOfContents {
+    margin-bottom: 20px
+}
+
+#docsContent #markdown-toc ul,
+#docsContent #markdown-toc li,
+#docsContent #TableOfContents ul,
+#docsContent #TableOfContents li {
+    list-style: disc;
+    color: #3371e3
+}
+
+#docsContent #markdown-toc ul,
+#docsContent #TableOfContents ul {
+    padding: 0 15px;
+    margin: 0
+}
+
+#docsContent #markdown-toc li,
+#docsContent #TableOfContents li {
+    padding: 0;
+    line-height: 1.5em;
+    margin-bottom: 0
+}
+
+#docsContent #markdown-toc a,
+#docsContent #TableOfContents a {
+    position: relative;
+    color: #3371e3;
+    font-weight: 700
+}
+
+#docsContent img {
+    max-width: 100%
+}
+
+#docsContent #TableOfContents>ul>li {
+    list-style: none
+}
+
+#docsContent #TableOfContents ul,
+#docsContent #TableOfContents li {
+    list-style: disk
+}
+
+#docsContent a.button {
+    border-radius: 2px;
+    text-decoration: none
+}
+
+#docsContent a.button:visited {
+    color: white
+}
+
+#docsContent a.issue {
+    margin-left: 0px
+}
+
+.feedback--no {
+    margin-left: 1em
+}
+
+.feedback--prompt {
+    margin-bottom: 1em
+}
+
+.feedback--response {
+    margin-top: 1em
+}
+
+.feedback--button__disabled {
+    background-color: #f7f7f7;
+    color: graytext
+}
+
+.feedback--response__hidden {
+    display: none
+}
+
+.fixed footer {
+    position: fixed;
+    bottom: 0
+}
+
+#miceType {
+    clear: both;
+    font-size: 11px;
+    line-height: 18px;
+    color: #aaa
+}
+
+html.search #docsContent {
+    position: relative;
+    float: none;
+    width: 90%;
+    max-width: 850px;
+    margin: 0 auto
+}
+
+html.search #docsContent #editPageButton {
+    display: none
+}
+
+html.search #docsContent table {
+    border: 0;
+    margin-bottom: 0
+}
+
+html.search #docsContent td {
+    padding: 0
+}
+
+html.search #docsContent h1 {
+    margin-bottom: 0;
+    border-bottom: 0;
+    padding-bottom: 0;
+    padding-left: 8px
+}
+
+#home.flip-nav .logo,
+#home.open-nav .logo {
+    background-image: url(../images/nav_logo2.svg)
+}
+
+#home #hero {
+    margin-bottom: 0;
+    padding-bottom: 1px
+}
+
+#home #hero main {
+    padding: 0 10px;
+    margin-bottom: 30px
+}
+
+#home #hero #vendorStrip {
+    display: none
+}
+
+#home section#cncf {
+    padding-top: 60px;
+    padding-bottom: 140px;
+    background-image: url(../images/cncf-color.png);
+    background-position: center 100px;
+    background-repeat: no-repeat;
+    background-size: 300px
+}
+
+#oceanNodes {
+    padding-top: 60px;
+    padding-bottom: 60px
+}
+
+#oceanNodes a {
+    color: #3371e3
+}
+
+#oceanNodes main {
+    margin-bottom: 60px;
+    min-height: 160px
+}
+
+#oceanNodes .image-wrapper {
+    max-width: 75%;
+    margin: 0 auto 20px;
+    text-align: center
+}
+
+#oceanNodes .image-wrapper img {
+    width: 100%;
+    max-width: 160px
+}
+
+#oceanNodes main:first-child .image-wrapper {
+    max-width: 100%
+}
+
+#oceanNodes main:first-child .image-wrapper img {
+    max-width: 491px
+}
+
+#oceanNodes h3 {
+    margin-bottom: 30px
+}
+
+#video {
+    height: 200px
+}
+
+#video {
+    width: 100%;
+    position: relative;
+    background-position: center center;
+    background-size: cover
+}
+
+#video>.light-text {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 75%;
+    width: 575px;
+    padding-right: 80px;
+    transform: translate(-50%, -50%);
+    color: white
+}
+
+#video h2 {
+    font-size: 32px;
+    line-height: 44px;
+    margin-bottom: 20px
+}
+
+#video p {
+    margin-bottom: 20px
+}
+
+#video #desktopKCButton {
+    position: relative;
+    font-size: 18px;
+    background-color: #303030;
+    border-radius: 8px;
+    color: #fff;
+    padding: 20px 10px 20px 10px
+}
+
+#video #desktopShowVideoButton {
+    position: relative;
+    font-size: 24px;
+    background-color: white;
+    border-radius: 8px;
+    color: #3371e3;
+    padding: 15px 30px 15px 80px;
+    margin-bottom: 15px
+}
+
+#video #desktopShowVideoButton:before {
+    content: "";
+    position: absolute;
+    position: absolute;
+    top: 50%;
+    left: 40px;
+    transform: translate(-50%, -50%);
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 10px 0 10px 20px;
+    border-color: transparent transparent transparent #3371e3
+}
+
+#video #mobileShowVideoButton {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background-color: transparent;
+    border: 5px solid rgba(255, 255, 255, 0.2);
+    overflow: visible
+}
+
+#video #mobileShowVideoButton:after {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    left: 40px;
+    content: "";
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 20px 0 20px 30px;
+    border-color: transparent transparent transparent #ffffff
+}
+
+#videoPlayer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.9);
+    display: none
+}
+
+#videoPlayer iframe {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80vw;
+    height: 45vw;
+    max-width: 142.22222222vh;
+    max-height: 80vh
+}
+
+#videoPlayer #closeButton {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    width: 50px;
+    height: 50px;
+    border: 2px solid transparent;
+    transition: 0.3s
+}
+
+#videoPlayer #closeButton:before,
+#videoPlayer #closeButton:after {
+    content: "";
+    position: absolute;
+    top: calc(50% - 1px);
+    left: 10%;
+    width: 80%;
+    height: 2px;
+    background-color: white
+}
+
+#videoPlayer #closeButton:before {
+    transform: rotate(45deg)
+}
+
+#videoPlayer #closeButton:after {
+    transform: rotate(-45deg)
+}
+
+#videoPlayer #closeButton:hover {
+    border-color: white
+}
+
+#kubeweekly {
+    background-color: #f7f7f7;
+    padding-top: 60px;
+    padding-bottom: 140px;
+    background-size: auto;
+    font-family: "Roboto Mono", monospace !important;
+    font-size: 24px;
+    font-weight: bold
+}
+
+#kubeweekly h5 {
+    font-size: 20px
+}
+
+.subscribe-button {
+    border-radius: 6px;
+    padding: 0 20px;
+    line-height: 31px;
+    color: white;
+    background-color: blue;
+    text-decoration: none;
+    font-size: 14px
+}
+
+#features {
+    padding-top: 140px;
+    background-color: #f7f7f7;
+    background-image: url(../images/wheel.png);
+    background-position: center 60px;
+    background-repeat: no-repeat;
+    background-size: auto
+}
+
+.feature-box {
+    width: 100%;
+    overflow: hidden;
+    clear: both
+}
+
+.feature-box h4 {
+    line-height: normal;
+    margin-bottom: 15px
+}
+
+.feature-box>div:first-child {
+    float: left
+}
+
+.feature-box>div:last-child {
+    float: right
+}
+
+#features h3 {
+    margin-bottom: 20px
+}
+
+#features .feature-box {
+    margin-bottom: 0
+}
+
+#features .feature-box>div {
+    width: 100%;
+    margin-bottom: 40px
+}
+
+#community.open-nav .logo,
+#community.flip-nav .logo,
+.gridPage.open-nav .logo,
+.gridPage.flip-nav .logo {
+    background-image: url(../images/nav_logo2.svg)
+}
+
+#community #hero,
+.gridPage #hero {
+    padding-bottom: 20px
+}
+
+#community #mainContent,
+.gridPage #mainContent {
+    padding: 20px 0
+}
+
+#community #mainContent main,
+.gridPage #mainContent main {
+    max-width: none
+}
+
+#community #mainContent a,
+.gridPage #mainContent a {
+    color: #3371e3
+}
+
+#community #mainContent .content,
+.gridPage #mainContent .content {
+    margin-bottom: 30px;
+    padding: 30px 0
+}
+
+#community #mainContent .content h1,
+#community #mainContent .content h2,
+#community #mainContent .content h3,
+#community #mainContent .content h4,
+#community #mainContent .content h5,
+#community #mainContent .content h6,
+#community #mainContent .content p,
+.gridPage #mainContent .content h1,
+.gridPage #mainContent .content h2,
+.gridPage #mainContent .content h3,
+.gridPage #mainContent .content h4,
+.gridPage #mainContent .content h5,
+.gridPage #mainContent .content h6,
+.gridPage #mainContent .content p {
+    line-height: normal;
+    max-width: 1200px;
+    padding: 0 20px;
+    margin: 0 auto 20px
+}
+
+#community #mainContent .content:nth-child(even),
+.gridPage #mainContent .content:nth-child(even) {
+    background-color: #f7f7f7
+}
+
+#community #mainContent .company-logos,
+.gridPage #mainContent .company-logos {
+    text-align: center;
+    max-width: 1200px;
+    margin: 0 auto
+}
+
+#community #mainContent .company-logos img,
+.gridPage #mainContent .company-logos img {
+    width: auto;
+    margin: 10px;
+    background-color: #f7f7f7
+}
+
+#community #mainContent .partner-logos,
+.gridPage #mainContent .partner-logos {
+    text-align: center;
+    max-width: 1200px;
+    margin: 0 auto
+}
+
+#community #mainContent .partner-logos img,
+.gridPage #mainContent .partner-logos img {
+    width: auto;
+    margin: 10px;
+    background-color: #fff;
+    box-shadow: 0 5px 5px rgba(0, 0, 0, 0.24), 0 0 5px rgba(0, 0, 0, 0.12)
+}
+
+#community #mainContent #calendarMeetings,
+.gridPage #mainContent #calendarMeetings {
+    position: relative;
+    width: 80vw;
+    height: 60vw;
+    max-width: 1200px;
+    max-height: 900px;
+    margin: 20px auto
+}
+
+#community #mainContent #calendarEvents,
+.gridPage #mainContent #calendarEvents {
+    position: relative;
+    width: 80vw;
+    height: 30vw;
+    max-width: 1200px;
+    max-height: 450px;
+    margin: 20px auto
+}
+
+#community #mainContent iframe,
+.gridPage #mainContent iframe {
+    position: absolute;
+    border: 0;
+    width: 100%;
+    height: 100%
+}
+
+.ui-icon {
+    display: inline-block !important
+}
+
+#feature-state-dialog-link {
+    text-decoration: none !important;
+    padding: 5px !important
+}
+
+#feature-state-dialog-link a:visited {
+    color: #454545 !important
+}
+
+#feature-state-dialog-link a code {
+    display: inline-block !important;
+    box-sizing: border-box !important;
+    background-color: #f7f7f7 !important;
+    color: #303030 !important;
+    font-family: "Roboto Mono", monospace !important;
+    vertical-align: baseline !important;
+    font-size: 14px !important;
+    font-weight: bold !important;
+    padding: 0px 4px !important
+}
+
+#feature-state-dialog {
+    background: #fff !important;
+    border: 1px solid #ddd !important;
+    padding: 0.5em 1em !important
+}
+
+#feature-state-dialog ul,
+#feature-state-dialog li {
+    list-style: disc !important;
+    margin: 4px 12px !important
+}
+
+#feature-state-dialog p {
+    margin: 8px 0px !important
+}
+
+#feature-state-dialog code {
+    display: inline-block !important;
+    box-sizing: border-box !important;
+    background-color: #f7f7f7 !important;
+    color: #303030 !important;
+    font-family: "Roboto Mono", monospace !important;
+    vertical-align: baseline !important;
+    font-size: 14px !important;
+    font-weight: bold !important;
+    padding: 0px 4px !important
+}
+
+.ui-dialog {
+    background: #f7f7f7 !important;
+    padding: 0.5em
+}
+
+.ui-dialog-content {
+    position: relative;
+    float: right;
+    width: 100%
+}
+
+.ui-dialog-content *+h2,
+.ui-dialog-content *+h3,
+.ui-dialog-content *+h4,
+.ui-dialog-content *+h5,
+.ui-dialog-content *+h6 {
+    margin-top: 30px
+}
+
+.ui-dialog-content h1,
+.ui-dialog-content h2,
+.ui-dialog-content h3,
+.ui-dialog-content h4,
+.ui-dialog-content h5,
+.ui-dialog-content h6 {
+    line-height: normal;
+    font-weight: 500;
+    margin-bottom: 30px;
+    padding-bottom: 10px
+}
+
+.ui-dialog-content h1:before,
+.ui-dialog-content h2:before,
+.ui-dialog-content h3:before,
+.ui-dialog-content h4:before,
+.ui-dialog-content h5:before,
+.ui-dialog-content h6:before {
+    display: block;
+    content: " ";
+    margin-top: -100px;
+    height: 100px;
+    visibility: hidden
+}
+
+.ui-dialog-content h1,
+.ui-dialog-content h2 {
+    border-bottom: 1px solid #cccccc
+}
+
+.ui-dialog-content h1 {
+    font-size: 32px;
+    padding-right: 60px
+}
+
+.ui-dialog-content h2 {
+    font-size: 28px
+}
+
+.ui-dialog-content h3 {
+    font-size: 24px;
+    font-weight: 300;
+    margin-bottom: 5px
+}
+
+.ui-dialog-content h4 {
+    font-size: 20px;
+    margin-bottom: 0px
+}
+
+.ui-dialog-content h5,
+.ui-dialog-content h6 {
+    font-size: 16px;
+    font-weight: 500
+}
+
+.ui-dialog-content p {
+    font-size: 16px;
+    font-weight: 300;
+    line-height: 1.75em
+}
+
+.ui-dialog-content p+p {
+    margin-top: 10px
+}
+
+.ui-dialog-content code {
+    display: inline-block;
+    box-sizing: border-box;
+    background-color: #f7f7f7;
+    color: #303030;
+    font-family: "Roboto Mono", monospace;
+    vertical-align: baseline;
+    font-size: 14px;
+    font-weight: bold;
+    padding: 2px 4px
+}
+
+.ui-dialog-content a code {
+    color: #3371e3;
+    text-decoration: underline
+}
+
+.ui-dialog-content pre .pi,
+.ui-dialog-content pre .s {
+    margin: 0;
+    padding: 0
+}
+
+.ui-dialog-content .highlight code span,
+.ui-dialog-content code,
+.ui-dialog-content pre code {
+    font-family: "Roboto Mono", monospace
+}
+
+.ui-dialog-content code,
+.ui-dialog-content pre code {
+    color: #303030
+}
+
+.ui-dialog-content pre code {
+    padding: 0
+}
+
+.ui-dialog-content pre {
+    background-color: #f7f7f7;
+    display: block;
+    margin: 20px 0;
+    padding: 15px;
+    position: relative;
+    overflow-x: auto
+}
+
+.ui-dialog-content h1 code,
+.ui-dialog-content h2 code,
+.ui-dialog-content h3 code,
+.ui-dialog-content h4 code,
+.ui-dialog-content h5 code,
+.ui-dialog-content h6 code {
+    font-family: inherit;
+    font-size: inherit;
+    background-color: transparent
+}
+
+.ui-dialog-content .includecode {
+    table-layout: fixed
+}
+
+.ui-dialog-content .includecode,
+.ui-dialog-content .includecode th,
+.ui-dialog-content .includecode td {
+    padding: 0 !important
+}
+
+.ui-dialog-content .includecode th {
+    text-align: right !important;
+    padding: 10px !important
+}
+
+.ui-dialog-content .includecode th a,
+.ui-dialog-content .includecode th a code {
+    color: white !important;
+    background-color: transparent !important
+}
+
+.ui-dialog-content .includecode pre {
+    margin: 0 !important
+}
+
+.ui-dialog-content ul li {
+    list-style: disc
+}
+
+.ui-dialog-content ol li {
+    list-style: decimal
+}
+
+.ui-dialog-content ul,
+.ui-dialog-content ol {
+    margin: 20px 0;
+    padding-left: 30px;
+    font-weight: 300
+}
+
+.ui-dialog-content ul ul,
+.ui-dialog-content ol ol,
+.ui-dialog-content ul ol,
+.ui-dialog-content ol ul {
+    margin: 0.75em 0
+}
+
+.ui-dialog-content li {
+    margin-bottom: 0.75em;
+    font-size: 16px;
+    line-height: 1.75em
+}
+
+.ui-dialog-content table {
+    width: 100%;
+    border: 1px solid #ccc;
+    border-spacing: 0;
+    margin-top: 30px;
+    margin-bottom: 30px
+}
+
+.ui-dialog-content thead,
+.ui-dialog-content tr:nth-child(even) {
+    background-color: #f7f7f7
+}
+
+.ui-dialog-content thead {
+    background-color: #555;
+    color: white
+}
+
+.ui-dialog-content th,
+.ui-dialog-content td {
+    padding: 8px;
+    text-align: left;
+    margin: 0
+}
+
+.ui-dialog-content th {
+    font-weight: normal
+}
+
+.ui-dialog-content td {
+    font-size: 0.85em
+}
+
+.ui-dialog-content #editPageButton {
+    position: absolute;
+    top: -25px;
+    right: 5px;
+    width: 50px;
+    height: 50px;
+    line-height: 50px;
+    border-radius: 50%;
+    white-space: nowrap;
+    text-indent: 50px;
+    overflow: hidden;
+    background: #3371e3 url(../images/icon-pencil.svg) no-repeat;
+    background-position: 12px 10px;
+    background-size: 29px 29px
+}
+
+.ui-dialog-content #markdown-toc {
+    margin-bottom: 20px
+}
+
+.ui-dialog-content #markdown-toc ul,
+.ui-dialog-content #markdown-toc li {
+    list-style: disc;
+    color: #3371e3
+}
+
+.ui-dialog-content #markdown-toc ul {
+    padding: 0 15px;
+    margin: 0
+}
+
+.ui-dialog-content #markdown-toc li {
+    padding: 0;
+    line-height: 1.5em;
+    margin-bottom: 0
+}
+
+.ui-dialog-content #markdown-toc a {
+    position: relative;
+    color: #3371e3;
+    font-weight: 700
+}
+
+.ui-dialog-content img {
+    max-width: 100%
+}
+
+.ui-dialog-content a {
+    text-decoration: underline
+}
+
+.ui-dialog-content a.button {
+    border-radius: 2px;
+    text-decoration: none
+}
+
+.ui-dialog-content a.button:visited {
+    color: white
+}
+
+.ui-dialog-content a.issue {
+    margin-left: 0px
+}
+
+.ui-dialog-buttonpane {
+    background: #f7f7f7 !important
+}
+
+.ui-widget-header {
+    background: transparent !important;
+    background-color: transparent !important;
+    border: 0px !important
+}
+
+.ui-tabs ul,
+.ui-tabs ol,
+.ui-tabs li {
+    padding: 0px !important;
+    list-style: none !important;
+    margin-bottom: 0px !important;
+    margin-left: 4px !important
+}
+
+.ui-tabs-panel ul li {
+    list-style: disc !important
+}
+
+.ui-tabs-panel ol li {
+    list-style: decimal !important
+}
+
+.ui-widget-content {
+    border: 0px !important
+}
+
+.ui-widget-content p a {
+    color: #3371e3
+}
+
+.ui-widget-content table {
+    margin: 0px !important
+}
+
+.ui-tabs .ui-tabs-panel {
+    border: 1px solid #ccc !important
+}
+
+.ui-tabs-anchor {
+    text-decoration: none !important
+}
+
+#talkToUs h3,
+#talkToUs h4 {
+    text-align: center
+}
+
+#talkToUs h3 {
+    margin-bottom: 15px
+}
+
+#talkToUs h4 {
+    line-height: normal;
+    margin-bottom: 50px
+}
+
+#talkToUs h4 br {
+    display: none
+}
+
+#talkToUs #bigSocial {
+    overflow: hidden
+}
+
+#talkToUs #bigSocial div {
+    width: 100%;
+    float: left;
+    padding: 30px;
+    padding-top: 110px;
+    background-position: center top;
+    background-size: auto;
+    background-repeat: no-repeat
+}
+
+#talkToUs #bigSocial div:nth-child(1) {
+    background-image: url(../images/twitter_icon.png)
+}
+
+#talkToUs #bigSocial div:nth-child(2) {
+    background-image: url(../images/github_icon.png)
+}
+
+#talkToUs #bigSocial div:nth-child(3) {
+    background-image: url(../images/slack_icon.png)
+}
+
+#talkToUs #bigSocial div:nth-child(4) {
+    background-image: url(../images/stackoverflow_icon.png)
+}
+
+#talkToUs #bigSocial div+div {
+    margin-top: 20px;
+    margin-left: 0
+}
+
+#talkToUs #bigSocial a {
+    display: inline-block;
+    color: #3371e3;
+    font-size: 24px;
+    font-weight: 400;
+    text-decoration: none;
+    margin-bottom: 15px
+}
+
+#talkToUs #bigSocial a,
+#talkToUs #bigSocial p {
+    text-align: center;
+    width: 100%
+}
+
+#home #talkToUs main {
+    padding: 30px 0
+}
+
+#home #talkToUs h5 {
+    font-size: 20px
+}
+
+#home #caseStudiesWrapper {
+    position: relative;
+    text-align: center;
+    margin-bottom: 30px
+}
+
+#home #caseStudiesWrapper img {
+    padding-bottom: 1rem
+}
+
+#home #caseStudiesWrapper div {
+    position: relative;
+    display: inline-block;
+    vertical-align: top;
+    width: 100%;
+    min-height: 230px;
+    margin-bottom: 60px;
+    padding-right: 1rem;
+    background-position: top center
+}
+
+#home #caseStudiesWrapper p {
+    font-size: 20px
+}
+
+#home #caseStudiesWrapper a {
+    position: absolute;
+    bottom: -30px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: #3371e3;
+    font-weight: 400
+}
+
+.cse .gsc-control-cse,
+.gsc-control-cse {
+    padding: 0
+}
+
+.gsc-control-cse table,
+.gsc-control-cse-en table {
+    margin: 0px !important
+}
+
+.gsc-above-wrapper-area {
+    border-bottom: 0
+}
+
+#bing-results-container {
+    margin-top: 30px;
+    margin-left: 20px
+}
+
+.bing-result {
+    margin-bottom: 20px
+}
+
+.bing-result-name a {
+    font-size: 16px;
+    color: #0000CC
+}
+
+.bing-result-url {
+    color: #008000;
+    font-size: 13px
+}
+
+.bing-result-snippet {
+    color: #000;
+    font-size: 11px
+}
+
+#bing-pagination-container {
+    margin: 10px;
+    margin-left: 20px
+}
+
+.bing-page-anchor {
+    text-decoration: none !important;
+    cursor: pointer;
+    color: #0000CC;
+    margin-right: 8px
+}
+
+.page {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh
+}
+
+.page .page-content {
+    flex: 1
+}
+
+.container-404 {
+    text-align: center;
+    margin: 3.5rem 0
+}
+
+.container-404 ul li a {
+    font-size: 1.5rem
+}
+
+#pre-footer {
+    margin-top: 2rem
+}
+
+#pre-footer .button {
+    font-size: 1.1rem
+}
+
+#pre-footer .button:first-of-type {
+    margin-right: .75rem
+}
+
+#pre-footer .lastedit {
+    margin-top: 1rem;
+    font-size: 1rem
+}
+
+@media screen and (min-width: 750px) {
+    h1 {
+        font-size: 32px;
+        line-height: 40px
+    }
+    h2 {
+        font-size: 28px;
+        line-height: 60px
+    }
+    h3 {
+        font-size: 24px;
+        line-height: 32px
+    }
+    h4 {
+        font-size: 20px;
+        line-height: 40px
+    }
+    h5 {
+        font-size: 16px;
+        line-height: 36px
+    }
+    p {
+        font-size: 14px;
+        line-height: 22px
+    }
+    section,
+    header,
+    #vendorStrip {
+        padding-left: 20px;
+        padding-right: 20px
+    }
+    section main,
+    header main,
+    #vendorStrip main {
+        width: 100%;
+        max-width: 100%
+    }
+    header {
+        height: 80px
+    }
+    .nav-buttons {
+        height: 80px;
+        line-height: 80px
+    }
+    .nav-buttons .button+* {
+        margin-left: 30px
+    }
+    #hamburger {
+        width: 50px;
+        height: 50px
+    }
+    #mainNav {
+        padding: 140px 0 30px
+    }
+    #mainNav h5 {
+        margin-bottom: 1em
+    }
+    #mainNav h3 {
+        margin-bottom: .6em
+    }
+    #mainNav .nav-box {
+        width: 20%
+    }
+    #mainNav .nav-box+.nav-box {
+        margin-left: calc(20% / 3)
+    }
+    #mainNav main+main {
+        margin-top: 60px
+    }
+    #mainNav .left .button {
+        height: 50px;
+        line-height: 50px;
+        font-size: 18px
+    }
+    .open-nav #tryKubernetes,
+    .y-enough #tryKubernetes {
+        margin-left: 30px
+    }
+    #hero {
+        padding-top: 80px
+    }
+    #docs #hero h1,
+    #docs #hero h5 {
+        padding-left: 20px;
+        padding-right: 20px
+    }
+    #vendorStrip {
+        height: 88px;
+        line-height: 88px;
+        font-size: 16px
+    }
+    p {
+        font-size: 16px;
+        line-height: 24px;
+        letter-spacing: 0.1px
+    }
+    h1 {
+        font-size: 36px;
+        line-height: 44px
+    }
+    h3 {
+        font-size: 28px;
+        line-height: 36px
+    }
+    h4 {
+        font-size: 24px;
+        line-height: 40px
+    }
+    #home #viewDocs,
+    #home #tryKubernetes {
+        display: inline-block
+    }
+    #vendorStrip {
+        display: block;
+        text-align: center
+    }
+    #vendorStrip img {
+        max-height: 24px;
+        vertical-align: middle;
+        margin: 0 30px
+    }
+    #docs #vendorStrip li a {
+        font-size: 1em;
+        font-weight: normal
+    }
+    #docs #vendorStrip li li+li {
+        margin-left: 60px
+    }
+    #oceanNodes h3 {
+        text-align: left;
+        margin-bottom: 18px
+    }
+    #oceanNodes main {
+        position: relative;
+        clear: both;
+        display: table;
+        height: 160px
+    }
+    #oceanNodes main .content {
+        display: table-cell;
+        position: relative;
+        vertical-align: middle
+    }
+    #oceanNodes main .image-wrapper {
+        position: absolute;
+        top: 50%;
+        max-width: 25%;
+        max-height: 100%;
+        transform: translateY(-50%)
+    }
+    #oceanNodes main:nth-child(odd) {
+        padding-right: 210px
+    }
+    #oceanNodes main:nth-child(odd) .image-wrapper {
+        right: 0
+    }
+    #oceanNodes main:nth-child(even) {
+        padding-left: 210px
+    }
+    #oceanNodes main:nth-child(even) .image-wrapper {
+        left: 0
+    }
+    #oceanNodes main:nth-child(1) {
+        padding-right: 0
+    }
+    #oceanNodes main:nth-child(1) h3,
+    #oceanNodes main:nth-child(1) p {
+        text-align: center
+    }
+    #oceanNodes main:nth-child(1) .image-wrapper {
+        position: relative;
+        display: block;
+        float: none;
+        max-width: 100%;
+        transform: none
+    }
+    #oceanNodes main:nth-child(1) .content {
+        display: block
+    }
+    #oceanNodes main img {
+        width: 100%
+    }
+    #video {
+        height: 400px;
+        display: block
+    }
+    #video>.light-text {
+        display: block
+    }
+    #mobileShowVideoButton {
+        display: none
+    }
+    #features {
+        padding-bottom: 60px
+    }
+    #features .feature-box {
+        margin-bottom: 30px
+    }
+    #features .feature-box:last-child {
+        margin-bottom: 0
+    }
+    #features h3 {
+        margin-bottom: 40px
+    }
+    #features .feature-box>div {
+        width: 45%;
+        margin-bottom: 0
+    }
+    #talkToUs #bigSocial div {
+        width: calc(50% - 15px)
+    }
+    #talkToUs #bigSocial div+div {
+        margin-top: 0
+    }
+    #talkToUs #bigSocial div:nth-child(2) {
+        margin-left: 20px
+    }
+    #talkToUs #bigSocial div:nth-child(4) {
+        margin-left: 20px
+    }
+    #talkToUs #bigSocial a {
+        display: inline-block;
+        color: #3371e3;
+        font-weight: 400;
+        text-decoration: none
+    }
+    footer nav {
+        text-align: center
+    }
+    footer nav a {
+        width: 30%;
+        padding: 0 20px
+    }
+    footer .social {
+        text-align: center
+    }
+    footer .social div {
+        display: inline-block
+    }
+    footer .social div:last-child {
+        display: block;
+        margin: 0
+    }
+    footer .social span {
+        display: inline-block;
+        margin-right: 10px
+    }
+    footer .social input {
+        text-align: left
+    }
+    #home #caseStudiesWrapper div {
+        width: 48%
+    }
+}
+
+@media screen and (min-width: 1025px) {
+    #hamburger {
+        display: none
+    }
+    ul.global-nav {
+        display: inline-block
+    }
+    #docs #vendorStrip #searchBox:before {
+        top: 15px
+    }
+    #vendorStrip {
+        height: 44px;
+        line-height: 44px
+    }
+    #vendorStrip li a.YAH:after {
+        content: "";
+        display: block;
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        height: 4px;
+        background-color: #3371e3
+    }
+    #vendorStrip #searchBox {
+        float: right
+    }
+    #home #hero #vendorStrip {
+        display: block
+    }
+    #docs #hero h1,
+    #docs #hero h5 {
+        text-align: left
+    }
+    #docs #hero #vendorStrip ul {
+        float: left
+    }
+    #docs #hero #vendorStrip #searchBox {
+        float: right;
+        width: 250px
+    }
+    #docs #hero #vendorStrip #search {
+        vertical-align: middle
+    }
+    #docs .flyout-button {
+        display: none
+    }
+    #docs .logo {
+        position: relative;
+        float: left;
+        display: block;
+        width: 180px;
+        height: 88px;
+        top: 0;
+        left: 0;
+        transform: none;
+        background-image: url(../images/nav_logo.svg)
+    }
+    #docs.flip-nav .logo,
+    #docs.open-nav .logo {
+        background-image: url(../images/nav_logo2.svg)
+    }
+    #encyclopedia {
+        padding: 50px 50px 100px 100px;
+        clear: both
+    }
+    #docsToc {
+        position: relative;
+        float: left;
+        padding: 0 20px;
+        left: 0;
+        width: 350px;
+        z-index: auto
+    }
+    #docsToc .push-menu-close-button {
+        display: none
+    }
+    #docsContent {
+        width: calc(100% - 400px)
+    }
+    #docsContent #editPageButton {
+        right: -25px
+    }
+    section main,
+    header main,
+    footer main {
+        max-width: 1200px
+    }
+    header,
+    #vendorStrip,
+    #encyclopedia,
+    #hero h1,
+    #hero h5,
+    #docs #hero h1,
+    #docs #hero h5,
+    #community #hero h1,
+    .gridPage #hero h1,
+    #community #hero h5,
+    .gridPage #hero h5 {
+        padding-left: 100px;
+        padding-right: 100px
+    }
+    #vendorStrip {
+        padding-right: 10px
+    }
+    #home section main,
+    #home header main,
+    #home footer main {
+        max-width: 1000px
+    }
+    #oceanNodes main {
+        position: relative;
+        max-width: 830px
+    }
+    #oceanNodes main:nth-child(1) {
+        max-width: 1000px;
+        padding-right: 475px
+    }
+    #oceanNodes main:nth-child(1) h3,
+    #oceanNodes main:nth-child(1) p {
+        text-align: left
+    }
+    #oceanNodes main:nth-child(1) .image-wrapper {
+        position: absolute;
+        max-width: 48%;
+        transform: translateY(-50%)
+    }
+    #oceanNodes main:nth-child(1) .image-wrapper img {
+        max-width: 425px
+    }
+    #video {
+        height: 550px;
+        position: relative;
+        background-position: center center;
+        background-size: cover
+    }
+    #talkToUs h4 br {
+        display: block
+    }
+    #talkToUs #bigSocial div {
+        width: calc(25% - 18px)
+    }
+    #talkToUs #bigSocial div+div {
+        margin-left: 20px
+    }
+    footer {
+        width: 100%;
+        background-image: url(../images/texture.png);
+        background-color: #303030
+    }
+    footer main {
+        padding: 20px 0
+    }
+    footer nav {
+        overflow: hidden;
+        margin-bottom: 20px
+    }
+    footer nav a {
+        width: 16.65%;
+        float: left;
+        font-size: 24px;
+        font-weight: 300;
+        white-space: nowrap
+    }
+    footer .social {
+        padding: 0 30px;
+        max-width: 1200px
+    }
+    footer .social div {
+        float: left
+    }
+    footer .social div:last-child {
+        float: right
+    }
+    #search,
+    #wishField {
+        background-color: transparent;
+        padding: 10px;
+        font-size: 16px;
+        font-weight: 100;
+        color: white;
+        border: 1px solid white;
+        transition: 0.3s
+    }
+    #search:focus,
+    #wishField:focus {
+        background-color: #f7f7f7;
+        color: #303030
+    }
+    .social a {
+        display: inline-block;
+        background-image: url(../images/social_sprite.png);
+        background-repeat: no-repeat;
+        background-size: auto;
+        width: 50px;
+        height: 50px;
+        border-radius: 5px;
+        margin-right: 10px
+    }
+    .social a:hover {
+        background-color: #fff
+    }
+    .social a span {
+        position: absolute;
+        display: block;
+        height: 0;
+        overflow: hidden
+    }
+    a.twitter {
+        background-position: 0 0
+    }
+    a.twitter:hover {
+        background-position: 0 100%
+    }
+    a.stack-overflow {
+        background-position: -50px 0
+    }
+    a.stack-overflow:hover {
+        background-position: -50px 100%
+    }
+    a.slack {
+        background-position: -100px 0
+    }
+    a.slack:hover {
+        background-position: -100px 100%
+    }
+    a.github {
+        background-position: -150px 0
+    }
+    a.github:hover {
+        background-position: -150px 100%
+    }
+    a.mailing-list {
+        background-position: -200px 0
+    }
+    a.mailing-list:hover {
+        background-position: -200px 100%
+    }
+    a.calendar {
+        background-position: -250px 0
+    }
+    a.calendar:hover {
+        background-position: -250px 100%
+    }
+    #community #hero,
+    .gridPage #hero {
+        text-align: left
+    }
+    #community #hero h1,
+    .gridPage #hero h1 {
+        padding: 20px 100px
+    }
+    #community #tryKubernetes,
+    .gridPage #tryKubernetes {
+        width: auto;
+        background-color: #3371e3;
+        padding: 0 20px
+    }
+    #bigSocial div {
+        width: calc(25% - 18px)
+    }
+    #home #caseStudiesWrapper div {
+        width: 24%;
+        min-height: 260px
+    }
+}
+
+@media screen and (min-width: 1300px) {
+    #vendorStrip {
+        padding-right: 100px
+    }
+}
+
+@media screen and (min-width: 456px) {
+    #vendorStrip li+li {
+        margin-left: 20px
+    }
+}

--- a/xsl/css/toc.css
+++ b/xsl/css/toc.css
@@ -1,0 +1,33 @@
+div.toc > div.toc {
+    display: block;
+}
+
+div.toc > div.toc .title {
+    color: #303030;
+    position: relative;
+    padding: 7.5px 10px 7.5px 18px;
+    cursor: pointer;
+    transition: 0.3s
+}
+
+
+div.toc > div.toc .title:hover {
+    color: #3371e3
+}
+
+div#tocContent {
+    display: none;
+}
+
+@media screen and (min-width: 1300px) {
+    div.chapter div.toc > div.toc {
+        display: none;
+    }
+    
+    div#tocContent {
+        display: block;
+        flex: 0 0 100px;
+        margin-left: 20px;
+    }    
+
+}


### PR DESCRIPTION
This PR adds a backend to gen-apidocs, to output the documentation in the DocBook format, then transorms the DocBook source in PDF and HTML.

To create the doc in DocBook format:
```
$ make dbapi
```

To create the PDF (US letter) from DocBook format:
```
$ make dbapi-pdf-letter
```

To create the PDF (A4) from DocBook format:
```
$ make dbapi-pdf-a4
```

An overview of HTML and PDF outtputs are available here;

http://k8s-v1-16-api.surge.sh/index.html

http://k8s-v1-16-api.surge.sh/index-a4.pdf (6.5 MB, 1932 pages)
http://k8s-v1-16-api.surge.sh/index-letter.pdf (6.4 MB, 2026 pages)
