### PR TITLE
Fix generator for 1.17 API reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 WEBROOT=~/src/github.com/kubernetes/website
 K8SROOT=~/k8s/src/k8s.io/kubernetes
-MINOR_VERSION=16
+MINOR_VERSION=17
 
 APISRC=gen-apidocs/generators
 APIDST=$(WEBROOT)/static/docs/reference/generated/kubernetes-api/v1.$(MINOR_VERSION)

--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -224,6 +224,10 @@ func (d *Definition) GetOperationGroupName() string {
 	if strings.ToLower(d.Group.String()) == "rbac" {
 		return "RbacAuthorization"
 	}
+	if strings.ToLower(d.Group.String()) == "flowcontrol" {
+		return "FlowcontrolApiserver"
+	}
+
 	return strings.Title(d.Group.String())
 }
 

--- a/gen-apidocs/generators/api/open_api.go
+++ b/gen-apidocs/generators/api/open_api.go
@@ -63,6 +63,7 @@ func buildGroupMap(specs []*loads.Document) map[string]string {
 	mapping["apiregistration"] = "apiregistration.k8s.io"
 	mapping["apiextensions"] = "apiextensions.k8s.io"
 	mapping["certificates"] = "certificates.k8s.io"
+	mapping["flowcontrol"] = "flowcontrol.apiserver.k8s.io"
 	mapping["meta"] = "meta"
 	mapping["core"] = "core"
 	mapping["extensions"] = "extensions"

--- a/gen-apidocs/generators/config.yaml
+++ b/gen-apidocs/generators/config.yaml
@@ -64,7 +64,7 @@ resource_categories:
       version: v1
       group: core
     - name: EndpointSlice
-      version: v1alpha1
+      version: v1beta1
       group: discovery
     - name: Ingress
       version: v1beta1
@@ -82,7 +82,7 @@ resource_categories:
       version: v1beta1
       group: storage
     - name: CSINode
-      version: v1beta1
+      version: v1
       group: storage
     - name: Secret
       version: v1
@@ -164,6 +164,9 @@ resource_categories:
     - name: ComponentStatus
       version: v1
       group: core
+    - name: FlowSchema
+      version: v1alpha1
+      group: flowcontrol
     - name: Lease
       version: v1
       group: coordination
@@ -180,6 +183,9 @@ resource_categories:
       version: v1
       group: core
       description_note: "These are assigned to <a href=\"#pod-v1-core\">Pods</a> using <a href=\"#persistentvolumeclaim-v1-core\">PersistentVolumeClaims</a>."
+    - name: PriorityLevelConfiguration
+      version: v1alpha1
+      group: flowcontrol
     - name: ResourceQuota
       version: v1
       group: core


### PR DESCRIPTION
Adapt API reference generator to changes made to the upstream OpenAPI definitions, i.e.

- New API group `flowcontrol.apiserver.k8s.io` has been added and the group name is not following the `<group>.k8s.io` convention. Sigh...
- New resources `FlowSchema`, `PriorityLevelConfiguration` have been added to the above group;
- Resource `EndpointSlice` has been promoted to `v1beta1` from `v1alpha1`;
- Resource `CSINode` has been promoted to `v1` (GA) from `v1beta1`.

Since a `release-1.16` branch has been created before this PR. This change is targeting master branch, for 1.17+ versions. The Makefile and the swagger.json file have been updated accordingly. 

Closes: #100