### PR TITLE
Fix HTML display for API reference

### DIFF
--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -550,6 +550,7 @@ func (h *HTMLWriter) generateHTML(navContent string) {
 	fmt.Fprintf(html, "<LINK rel=\"stylesheet\" href=\"css/font-awesome.min.css\" type=\"text/css\">\n")
 	fmt.Fprintf(html, "<LINK rel=\"stylesheet\" href=\"css/stylesheet.css\" type=\"text/css\">\n")
 	fmt.Fprintf(html, "</HEAD>\n<BODY>\n")
+	fmt.Fprintf(html, "<DIV id=\"wrapper\">\n")
 	fmt.Fprintf(html, "<DIV id=\"sidebar-wrapper\" class=\"side-nav side-bar-nav\">\n")
 
 	// html buffer
@@ -612,8 +613,7 @@ func (h *HTMLWriter) generateHTML(navContent string) {
 	navData.js is dynamically generated - see generateNavJS()
 	*/
 	fmt.Fprintf(html, "%s</DIV>\n", navContent)
-	fmt.Fprintf(html, "<DIV id=\"wrapper\">\n")
-	fmt.Fprintf(html, "<DIV id=\"page-content-wrapper\" class=\"body-content container-fluid\">\n")
+	fmt.Fprintf(html, "<DIV id=\"page-content-wrapper\" class=\"body-content container\">\n")
 	fmt.Fprintf(html, "%s", string(buf))
 	fmt.Fprintf(html, "</DIV>\n</DIV>\n")
 	fmt.Fprintf(html, "<SCRIPT src=\"/js/jquery-3.2.1.min.js\"></SCRIPT>\n")

--- a/gen-apidocs/static/css/stylesheet.css
+++ b/gen-apidocs/static/css/stylesheet.css
@@ -83,7 +83,7 @@ body > #wrapper {
     left: 0;
     background-color: whitesmoke;
     border-right: 2px solid slategrey;
-    overflow-x: hidden;
+    overflow-x: auto;
     padding-top: 60px;
 }
 


### PR DESCRIPTION
The main content of the generated HTML is somehow "too wide" to show in
the main screen area. The left navigation bar cannot accomodate long
lines. These two issues are fixed in this PR.

Closes: #105