### PR TITLE
create version dir targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ cleancli:
 	sudo rm -rf $(shell pwd)/gen-kubectldocs/generators/build
 	sudo rm -rf $(shell pwd)/gen-kubectldocs/generators/manifest.json
 
-cli: createkubectldir cleancli
-	go run gen-kubectldocs/main.go --kubernetes-version v1_$(MINOR_VERSION)
+cli: cleancli
+	go run gen-kubectldocs/main.go --kubernetes-version v$(shell cat "release.tmp")
 	docker run -v $(shell pwd)/gen-kubectldocs/generators/includes:/source -v $(shell pwd)/gen-kubectldocs/generators/build:/build -v $(shell pwd)/gen-kubectldocs/generators/:/manifest pwittrock/brodocs
 
 copycli: cli
@@ -69,9 +69,12 @@ comp: cleancomp
 # Build api docs
 updateapispec: createversiondirs
 	@echo "Updating swagger.json for release version $(K8SRELEASE)"
-	cp $(K8SROOT)/api/openapi-spec/swagger.json $(APISRC)/config/v$(shell cat "release.tmp")/swagger.json
+	if ! [ -f $(APISRC)/config/v$(shell cat "release.tmp")/swagger.json ]; then
+		cp $(K8SROOT)/api/openapi-spec/swagger.json $(APISRC)/config/v$(shell cat "release.tmp")/swagger.json
+	fi
 	cp $(APISRC)/config/v$(shell cat "release.tmp")/swagger.json gen-apidocs/config/swagger.json
-	rm release.tmp
+	# add this back
+	#rm release.tmp
 
 api: cleanapi
 	go run gen-apidocs/main.go --work-dir=gen-apidocs --munge-groups=false

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
-WEBROOT=~/src/github.com/kubernetes/website
-K8SROOT=~/k8s/src/k8s.io/kubernetes
-MINOR_VERSION=17
+# To generate docs with Makefile targets
+# from this repo base directory,
+# set the following environment variables
+# to match your environment and release version
+#
+# WEBROOT=~/src/github.com/kubernetes/website
+# K8SROOT=~/k8s/src/k8s.io/kubernetes
+# K8S_RELEASE=1.17
+
+WEBROOT=${K8S_WEBROOT}
+K8SROOT=${K8S_ROOT}
+K8SRELEASE=${K8S_RELEASE}
 
 APISRC=gen-apidocs
-APIDST=$(WEBROOT)/static/docs/reference/generated/kubernetes-api/v1.$(MINOR_VERSION)
+APIDST=$(WEBROOT)/static/docs/reference/generated/kubernetes-api/v$(K8SRELEASE)
 
 CLISRC=gen-kubectldocs/generators/build
 CLIDST=$(WEBROOT)/static/docs/reference/generated/kubectl
@@ -11,7 +20,13 @@ CLISRCFONT=$(CLISRC)/node_modules/font-awesome
 CLIDSTFONT=$(CLIDST)/node_modules/font-awesome
 
 default:
-	@echo "Support commands:\ncli api comp copycli copyapi copycomp updateapispec"
+	@echo "Support commands:\ncli api comp copycli copyapi updateapispec"
+
+# create directories for new release
+createversiondirs:
+	@echo "Calling set_version_dirs.sh"
+	./set_version_dirs.sh
+	@echo "$(K8SRELEASE)" | sed "s/\./_/g" > "release.tmp"
 
 # Build kubectl docs
 cleancli:
@@ -20,7 +35,7 @@ cleancli:
 	sudo rm -rf $(shell pwd)/gen-kubectldocs/generators/build
 	sudo rm -rf $(shell pwd)/gen-kubectldocs/generators/manifest.json
 
-cli: cleancli
+cli: createkubectldir cleancli
 	go run gen-kubectldocs/main.go --kubernetes-version v1_$(MINOR_VERSION)
 	docker run -v $(shell pwd)/gen-kubectldocs/generators/includes:/source -v $(shell pwd)/gen-kubectldocs/generators/build:/build -v $(shell pwd)/gen-kubectldocs/generators/:/manifest pwittrock/brodocs
 
@@ -36,7 +51,7 @@ copycli: cli
 	cp $(CLISRC)/node_modules/jquery/dist/jquery.min.js $(CLIDST)/node_modules/jquery/dist/jquery.min.js
 	cp $(CLISRCFONT)/css/font-awesome.min.css $(CLIDSTFONT)/css/font-awesome.min.css
 
-# Build kube component docs
+# Build kube component,tool docs
 cleancomp:
 	rm -rf $(shell pwd)/gen-compdocs/build
 
@@ -51,12 +66,12 @@ comp: cleancomp
 	go run gen-compdocs/main.go gen-compdocs/build kubeadm
 	go run gen-compdocs/main.go gen-compdocs/build kubectl
 
-copycomp:
-	cp $(shell pwd)/gen-compdocs/build/* $(WEBROOT)/docs/reference/generated/
-
 # Build api docs
-updateapispec:
-	cp $(K8SROOT)/api/openapi-spec/swagger.json gen-apidocs/config/swagger.json
+updateapispec: createversiondirs
+	@echo "Updating swagger.json for release version $(K8SRELEASE)"
+	cp $(K8SROOT)/api/openapi-spec/swagger.json $(APISRC)/config/v$(shell cat "release.tmp")/swagger.json
+	cp $(APISRC)/config/v$(shell cat "release.tmp")/swagger.json gen-apidocs/config/swagger.json
+	rm release.tmp
 
 api: cleanapi
 	go run gen-apidocs/main.go --work-dir=gen-apidocs --munge-groups=false
@@ -64,7 +79,7 @@ api: cleanapi
 cleanapi:
 	rm -rf $(shell pwd)/gen-apidocs/build
 
-copyapi:
+copyapi: api
 	mkdir -p $(APIDST)
 	cp $(APISRC)/build/index.html $(APIDST)/index.html
 	# copy scroll.js, jquery.scrollTo.min.js and the new navData.js

--- a/gen-apidocs/config/v1_17/config.yaml
+++ b/gen-apidocs/config/v1_17/config.yaml
@@ -1,0 +1,277 @@
+example_location: "examples"
+api_groups:
+  - "AdmissionRegistration"
+  - "ApiExtensions"
+  - "ApiRegistration"
+  - "Apps"
+  - "AuditRegistration"
+  - "Authentication"
+  - "Authorization"
+  - "Autoscaling"
+  - "Batch"
+  - "Certificates"
+  - "Coordination"
+  - "Core"
+  - "Discovery"
+  - "Extensions"
+  - "Meta"
+  - "Networking"
+  - "Node"
+  - "Policy"
+  - "Rbac"
+  - "Scheduling"
+  - "Settings"
+  - "Storage"
+resource_categories:
+  - name: "Workloads APIs"
+    include: "workloads"
+    resources:
+    - name: Container
+      version: v1
+      group: core
+      description_warning: "Containers are only ever created within the context of a <a href=\"#pod-v1-core\">Pod</a>.  This is usually done using a Controller.  See Controllers: <a href=\"#deployment-v1-apps\">Deployment</a>, <a href=\"#job-v1-batch\">Job</a>, or <a href=\"#statefulset-v1-apps\">StatefulSet</a>"
+    - name: CronJob
+      version: v1beta1
+      group: batch
+    - name: DaemonSet
+      version: v1
+      group: apps
+    - name: Deployment
+      version: v1
+      group: apps
+    - name: Job
+      version: v1
+      group: batch
+    - name: Pod
+      version: v1
+      group: core
+      description_warning: "It is recommended that users create Pods only through a Controller, and not directly.  See Controllers: <a href=\"#deployment-v1-apps\">Deployment</a>, <a href=\"#job-v1-batch\">Job</a>, or <a href=\"#statefulset-v1-apps\">StatefulSet</a>."
+    - name: ReplicaSet
+      version: v1
+      group: apps
+      description_warning: "In many cases it is recommended to create a <a href=\"#deployment-v1-apps\">Deployment</a> instead of ReplicaSet."
+    - name: ReplicationController
+      version: v1
+      group: core
+      description_warning: "In many cases it is recommended to create a <a href=\"#deployment-v1-apps\">Deployment</a> instead of a ReplicationController."
+    - name: StatefulSet
+      version: v1
+      group: apps
+  - name: "Service APIs"
+    include: "servicediscovery"
+    resources:
+    - name: Endpoints
+      version: v1
+      group: core
+    - name: EndpointSlice
+      version: v1beta1
+      group: discovery
+    - name: Ingress
+      version: v1beta1
+      group: networking
+    - name: Service
+      version: v1
+      group: core
+  - name: "Config and Storage APIs"
+    include: "config"
+    resources:
+    - name: ConfigMap
+      version: v1
+      group: core
+    - name: CSIDriver
+      version: v1beta1
+      group: storage
+    - name: CSINode
+      version: v1
+      group: storage
+    - name: Secret
+      version: v1
+      group: core
+    - name: PersistentVolumeClaim
+      version: v1
+      group: core
+      description_note: "A <a href=\"#persistentvolume-v1-core\">PersistentVolume</a> must be allocated in the cluster to use this."
+    - name: StorageClass
+      version: v1
+      group: storage
+    - name: Volume
+      version: v1
+      group: core
+    - name: VolumeAttachment
+      version: v1
+      group: storage
+  - name: "Metadata APIs"
+    include: "meta"
+    resources:
+    - name: ControllerRevision
+      version: v1
+      group: apps
+    - name: CustomResourceDefinition
+      version: v1
+      group: apiextensions
+    - name: Event
+      version: v1
+      group: core
+    - name: LimitRange
+      version: v1
+      group: core
+    - name: HorizontalPodAutoscaler
+      version: v1
+      group: autoscaling
+    - name: MutatingWebhookConfiguration
+      version: v1
+      group: admissionregistration
+    - name: ValidatingWebhookConfiguration
+      version: v1
+      group: admissionregistration
+    - name: PodTemplate
+      version: v1
+      group: core
+    - name: PodDisruptionBudget
+      version: v1beta1
+      group: policy
+    - name: PriorityClass
+      version: v1
+      group: scheduling
+    - name: PodPreset
+      version: v1alpha1
+      group: settings
+      description_warning: "Alpha objects should not be used in production and may not be compatible with future versions of the resource type."
+    - name: PodSecurityPolicy
+      version: v1beta1
+      group: policy
+  - name: "Cluster APIs"
+    include: "cluster"
+    resources:
+    - name: APIService
+      version: v1
+      group: apiregistration
+    - name: AuditSink
+      version: v1alpha1
+      group: auditregistration
+    - name: Binding
+      version: v1
+      group: core
+    - name: CertificateSigningRequest
+      version: v1beta1
+      group: certificates
+    - name: ClusterRole
+      version: v1
+      group: rbac
+    - name: ClusterRoleBinding
+      version: v1
+      group: rbac
+    - name: ComponentStatus
+      version: v1
+      group: core
+    - name: FlowSchema
+      version: v1alpha1
+      group: flowcontrol
+    - name: Lease
+      version: v1
+      group: coordination
+    - name: LocalSubjectAccessReview
+      version: v1
+      group: authorization
+    - name: Namespace
+      version: v1
+      group: core
+    - name: Node
+      version: v1
+      group: core
+    - name: PersistentVolume
+      version: v1
+      group: core
+      description_note: "These are assigned to <a href=\"#pod-v1-core\">Pods</a> using <a href=\"#persistentvolumeclaim-v1-core\">PersistentVolumeClaims</a>."
+    - name: PriorityLevelConfiguration
+      version: v1alpha1
+      group: flowcontrol
+    - name: ResourceQuota
+      version: v1
+      group: core
+    - name: Role
+      version: v1
+      group: rbac
+    - name: RoleBinding
+      version: v1
+      group: rbac
+    - name: RuntimeClass
+      version: v1beta1
+      group: node
+    - name: SelfSubjectAccessReview
+      version: v1
+      group: authorization
+    - name: SelfSubjectRulesReview
+      version: v1
+      group: authorization
+    - name: ServiceAccount
+      version: v1
+      group: core
+    - name: SubjectAccessReview
+      version: v1
+      group: authorization
+    - name: TokenRequest
+      version: v1
+      group: authentication
+    - name: TokenReview
+      version: v1
+      group: authentication
+    - name: NetworkPolicy
+      version: v1
+      group: networking
+operation_categories:
+  - name: "Proxy Operations"
+    operation_types:
+    - name: Create Connect Portforward
+      match: connect${group}${version}Post(Namespaced)?${resource}Portforward
+    - name: Create Connect Proxy
+      match: connect${group}${version}Post(Namespaced)?${resource}Proxy
+    - name: Create Connect Proxy Path
+      match: connect${group}${version}Post(Namespaced)?${resource}ProxyWithPath
+    - name: Create Proxy
+      match: proxy${group}${version}POST(Namespaced)?${resource}
+    - name: Create Proxy Path
+      match: proxy${group}${version}POST(Namespaced)?${resource}WithPath
+    - name: Delete Connect Proxy
+      match: connect${group}${version}Delete(Namespaced)?${resource}Proxy
+    - name: Delete Connect Proxy Path
+      match: connect${group}${version}Delete(Namespaced)?${resource}ProxyWithPath
+    - name: Delete Proxy
+      match: proxy${group}${version}DELETE(Namespaced)?${resource}
+    - name: Delete Proxy Path
+      match: proxy${group}${version}DELETE(Namespaced)?${resource}WithPath
+    - name: Get Connect Portforward
+      match: connect${group}${version}Get(Namespaced)?${resource}Portforward
+    - name: Get Connect Proxy
+      match: connect${group}${version}Get(Namespaced)?${resource}Proxy
+    - name: Get Connect Proxy Path
+      match: connect${group}${version}Get(Namespaced)?${resource}ProxyWithPath
+    - name: Get Proxy
+      match: proxy${group}${version}GET(Namespaced)?${resource}
+    - name: Get Proxy Path
+      match: proxy${group}${version}GET(Namespaced)?${resource}WithPath
+    - name: Head Connect Proxy
+      match: connect${group}${version}Head(Namespaced)?${resource}Proxy
+    - name: Head Connect Proxy Path
+      match: connect${group}${version}Head(Namespaced)?${resource}ProxyWithPath
+    - name: Replace Connect Proxy
+      match: connect${group}${version}Put(Namespaced)?${resource}Proxy
+    - name: Replace Connect Proxy Path
+      match: connect${group}${version}Put(Namespaced)?${resource}ProxyWithPath
+    - name: Replace Proxy
+      match: proxy${group}${version}PUT(Namespaced)?${resource}
+    - name: Replace Proxy Path
+      match: proxy${group}${version}PUT(Namespaced)?${resource}WithPath
+  - name: "Misc Operations"
+    default: true
+    operation_types:
+    - name: Read Scale
+      match: read${group}${version}(Namespaced)?${resource}Scale
+    - name: Replace Scale
+      match: replace${group}${version}(Namespaced)?${resource}Scale
+    - name: Patch Scale
+      match: patch${group}${version}(Namespaced)?${resource}Scale
+    - name: Rollback
+      match: create${group}${version}(Namespaced)?${resource}Rollback
+    - name: Read Log
+      match: read${group}${version}(Namespaced)?${resource}Log

--- a/gen-kubectldocs/generators/v1_13/static_includes/_app_management.md
+++ b/gen-kubectldocs/generators/v1_13/static_includes/_app_management.md
@@ -1,0 +1,4 @@
+# <strong>APP MANAGEMENT</strong>
+
+This section contains commands for creating, updating, deleting, and
+viewing your workloads in a Kubernetes cluster.

--- a/gen-kubectldocs/generators/v1_13/static_includes/_getting_started.md
+++ b/gen-kubectldocs/generators/v1_13/static_includes/_getting_started.md
@@ -1,0 +1,11 @@
+# <strong>GETTING STARTED</strong>
+
+This section contains the most basic commands for getting a workload
+running on your cluster.
+
+- `run` will start running 1 or more instances of a container image on your cluster.
+- `expose` will load balance traffic across the running instances, and can create a HA proxy for accessing the containers from outside the cluster.
+
+Once your workloads are running, you can use the commands in the
+[WORKING WITH APPS](#-strong-working-with-apps-strong-) section to
+inspect them.

--- a/gen-kubectldocs/generators/v1_13/static_includes/_working_with_apps.md
+++ b/gen-kubectldocs/generators/v1_13/static_includes/_working_with_apps.md
@@ -1,0 +1,8 @@
+# <strong>WORKING WITH APPS</strong>
+
+This section contains commands for inspecting and debugging your
+applications.
+
+- `logs` will print the logs from the specified pod + container.
+- `exec` can be used to get an interactive shell on a pod + container.
+- `describe` will print debug information about the given resource.

--- a/gen-kubectldocs/generators/v1_13/toc.yaml
+++ b/gen-kubectldocs/generators/v1_13/toc.yaml
@@ -1,0 +1,59 @@
+categories:
+- name: GETTING STARTED
+  include: _getting_started.md
+  commands:
+  - create
+  - get
+  - run
+  - expose
+  - delete
+- name: APP MANAGEMENT
+  include: _app_management.md
+  commands:
+  - apply
+  - annotate
+  - autoscale
+  - convert
+  - edit
+  - label
+  - patch
+  - replace
+  - rollout
+  - scale
+  - set
+  - wait
+- name: WORKING WITH APPS
+  include: _working_with_apps.md
+  commands:
+  - attach
+  - auth
+  - cp
+  - describe
+  - exec
+  - logs
+  - port-forward
+  - proxy
+  - top
+- name: CLUSTER MANAGEMENT
+  commands:
+  - api-versions
+  - certificate
+  - cluster-info
+  - cordon
+  - drain
+  - taint
+  - uncordon
+- name: KUBECTL SETTINGS AND USAGE
+  commands:
+  - alpha
+  - api-resources
+  - completion
+  - config
+  - explain
+  - options
+  - plugin
+  - version
+- name: DEPRECATED COMMANDS
+  commands:
+  - rolling-update
+  - run-container

--- a/gen-kubectldocs/generators/v1_14/toc.yaml
+++ b/gen-kubectldocs/generators/v1_14/toc.yaml
@@ -16,6 +16,7 @@ categories:
   - convert
   - diff
   - edit
+  - kustomize
   - label
   - patch
   - replace
@@ -51,7 +52,6 @@ categories:
   - completion
   - config
   - explain
-  - kustomize
   - options
   - plugin
   - version

--- a/gen-kubectldocs/generators/v1_15/toc.yaml
+++ b/gen-kubectldocs/generators/v1_15/toc.yaml
@@ -16,6 +16,7 @@ categories:
   - convert
   - diff
   - edit
+  - kustomize
   - label
   - patch
   - replace
@@ -51,7 +52,6 @@ categories:
   - completion
   - config
   - explain
-  - kustomize
   - options
   - plugin
   - version

--- a/gen-kubectldocs/generators/v1_16/static_includes/_app_management.md
+++ b/gen-kubectldocs/generators/v1_16/static_includes/_app_management.md
@@ -1,0 +1,4 @@
+# <strong>APP MANAGEMENT</strong>
+
+This section contains commands for creating, updating, deleting, and
+viewing your workloads in a Kubernetes cluster.

--- a/gen-kubectldocs/generators/v1_16/static_includes/_getting_started.md
+++ b/gen-kubectldocs/generators/v1_16/static_includes/_getting_started.md
@@ -1,0 +1,11 @@
+# <strong>GETTING STARTED</strong>
+
+This section contains the most basic commands for getting a workload
+running on your cluster.
+
+- `run` will start running 1 or more instances of a container image on your cluster.
+- `expose` will load balance traffic across the running instances, and can create a HA proxy for accessing the containers from outside the cluster.
+
+Once your workloads are running, you can use the commands in the
+[WORKING WITH APPS](#-strong-working-with-apps-strong-) section to
+inspect them.

--- a/gen-kubectldocs/generators/v1_16/static_includes/_working_with_apps.md
+++ b/gen-kubectldocs/generators/v1_16/static_includes/_working_with_apps.md
@@ -1,0 +1,8 @@
+# <strong>WORKING WITH APPS</strong>
+
+This section contains commands for inspecting and debugging your
+applications.
+
+- `logs` will print the logs from the specified pod + container.
+- `exec` can be used to get an interactive shell on a pod + container.
+- `describe` will print debug information about the given resource.

--- a/gen-kubectldocs/generators/v1_16/toc.yaml
+++ b/gen-kubectldocs/generators/v1_16/toc.yaml
@@ -1,0 +1,60 @@
+categories:
+- name: GETTING STARTED
+  include: _getting_started.md
+  commands:
+  - create
+  - get
+  - run
+  - expose
+  - delete
+- name: APP MANAGEMENT
+  include: _app_management.md
+  commands:
+  - apply
+  - annotate
+  - autoscale
+  - convert
+  - diff
+  - edit
+  - kustomize
+  - label
+  - patch
+  - replace
+  - rollout
+  - scale
+  - set
+  - wait
+- name: WORKING WITH APPS
+  include: _working_with_apps.md
+  commands:
+  - attach
+  - auth
+  - cp
+  - describe
+  - exec
+  - logs
+  - port-forward
+  - proxy
+  - top
+- name: CLUSTER MANAGEMENT
+  commands:
+  - api-versions
+  - certificate
+  - cluster-info
+  - cordon
+  - drain
+  - taint
+  - uncordon
+- name: KUBECTL SETTINGS AND USAGE
+  commands:
+  - alpha
+  - api-resources
+  - completion
+  - config
+  - explain
+  - options
+  - plugin
+  - version
+- name: DEPRECATED COMMANDS
+  commands:
+  - rolling-update

--- a/gen-kubectldocs/generators/v1_17/static_includes/_app_management.md
+++ b/gen-kubectldocs/generators/v1_17/static_includes/_app_management.md
@@ -1,0 +1,4 @@
+# <strong>APP MANAGEMENT</strong>
+
+This section contains commands for creating, updating, deleting, and
+viewing your workloads in a Kubernetes cluster.

--- a/gen-kubectldocs/generators/v1_17/static_includes/_getting_started.md
+++ b/gen-kubectldocs/generators/v1_17/static_includes/_getting_started.md
@@ -1,0 +1,11 @@
+# <strong>GETTING STARTED</strong>
+
+This section contains the most basic commands for getting a workload
+running on your cluster.
+
+- `run` will start running 1 or more instances of a container image on your cluster.
+- `expose` will load balance traffic across the running instances, and can create a HA proxy for accessing the containers from outside the cluster.
+
+Once your workloads are running, you can use the commands in the
+[WORKING WITH APPS](#-strong-working-with-apps-strong-) section to
+inspect them.

--- a/gen-kubectldocs/generators/v1_17/static_includes/_working_with_apps.md
+++ b/gen-kubectldocs/generators/v1_17/static_includes/_working_with_apps.md
@@ -1,0 +1,8 @@
+# <strong>WORKING WITH APPS</strong>
+
+This section contains commands for inspecting and debugging your
+applications.
+
+- `logs` will print the logs from the specified pod + container.
+- `exec` can be used to get an interactive shell on a pod + container.
+- `describe` will print debug information about the given resource.

--- a/gen-kubectldocs/generators/v1_17/toc.yaml
+++ b/gen-kubectldocs/generators/v1_17/toc.yaml
@@ -1,0 +1,60 @@
+categories:
+- name: GETTING STARTED
+  include: _getting_started.md
+  commands:
+  - create
+  - get
+  - run
+  - expose
+  - delete
+- name: APP MANAGEMENT
+  include: _app_management.md
+  commands:
+  - apply
+  - annotate
+  - autoscale
+  - convert
+  - diff
+  - edit
+  - kustomize
+  - label
+  - patch
+  - replace
+  - rollout
+  - scale
+  - set
+  - wait
+- name: WORKING WITH APPS
+  include: _working_with_apps.md
+  commands:
+  - attach
+  - auth
+  - cp
+  - describe
+  - exec
+  - logs
+  - port-forward
+  - proxy
+  - top
+- name: CLUSTER MANAGEMENT
+  commands:
+  - api-versions
+  - certificate
+  - cluster-info
+  - cordon
+  - drain
+  - taint
+  - uncordon
+- name: KUBECTL SETTINGS AND USAGE
+  commands:
+  - alpha
+  - api-resources
+  - completion
+  - config
+  - explain
+  - options
+  - plugin
+  - version
+- name: DEPRECATED COMMANDS
+  commands:
+  - rolling-update

--- a/set_version_dirs.sh
+++ b/set_version_dirs.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# K8S_RELEASE must be set in your environment, for example:1.17
+if [ -n "${K8S_RELEASE}" ]; then
+	echo "Setting up reference directories for ${K8S_RELEASE} release."
+else
+	echo "You must set K8S_RELEASE to a release version, such as 1.17"
+	exit 1
+fi
+
+ROOTDIR=$(pwd)
+echo base dir ${ROOTDIR}
+
+# change <major>.<minor> to <major>_<minor>
+echo "${K8S_RELEASE}" | sed "s/\./_/g" > k.tmp
+
+# example: 1_17
+VERSION_DIR="$( cat k.tmp )"
+echo version ${VERSION_DIR}
+
+echo ${VERSION_DIR} | sed "s/[0-9]_//g" > minor.tmp
+echo ${VERSION_DIR} | sed "s/_[0-9]*//g" > major.tmp
+
+MINOR_VERSION="$( cat minor.tmp )"
+MAJOR_VERSION="$( cat major.tmp )"
+
+ONE=1
+PREV_VERSION_DIR="v""${MAJOR_VERSION}_""$((${MINOR_VERSION} - ${ONE}))"
+echo previous version ${PREV_VERSION_DIR}
+VERSION_DIR="v${VERSION_DIR}"
+echo version ${VERSION_DIR}
+
+# Set up versioned directories for new release
+
+# kubectl-command static-includes, toc.yaml
+mkdir -p ./gen-kubectldocs/generators/${VERSION_DIR}
+
+if ! [ -f "${ROOTDIR}/gen-kubectldocs/generators/${VERSION_DIR}/config.yaml" ]; then
+		cp -r ${ROOTDIR}/gen-kubectldocs/generators/${PREV_VERSION_DIR}/* ${ROOTDIR}/gen-kubectldocs/generators/${VERSION_DIR}/
+fi
+
+# api reference config.yaml, swagger.json
+mkdir -p ${ROOTDIR}/gen-apidocs/config/${VERSION_DIR}
+
+# config.yaml
+if ! [ -f "${ROOTDIR}/gen-apidocs/config/${VERSION_DIR}/config.yaml" ]; then
+	if [ -f "${ROOTDIR}/gen-apidocs/config/${PREV_MINOR_VERSION}/config.yaml" ]; then
+			cp ${ROOTDIR}/gen-apidocs/config/${PREV_MINOR_VERSION}/config.yaml ${ROOTDIR}/gen-apidocs/config/${VERSION_DIR}/config.yaml
+			echo "Using config file: ${ROOTDIR}/gen-apidocs/config/${PREV_MINOR_VERSION}/config.yaml"
+	else
+			cp ${ROOTDIR}/gen-apidocs/config/config.yaml ${ROOTDIR}/gen-apidocs/config/${VERSION_DIR}/config.yaml
+	fi
+fi
+
+# copy versioned files to the base config dir
+cp ${ROOTDIR}/gen-apidocs/config/${VERSION_DIR}/config.yaml ${ROOTDIR}/gen-apidocs/config/config.yaml
+
+# swagger.json
+# copy swagger file using makefile target
+
+# clean up
+rm k.tmp; rm minor.tmp; rm major.tmp


### PR DESCRIPTION
- create make targets for kubectl-command and api-ref to generate versioned directories and files. I expect the kubectl related targets will change when the kubectl-command gen process changes.
- tested kubectl directory generation and updated the versioned files in this repo.
- See issues #108, #109.