### PR TITLE
    Make sure responses from operations are sorted

### DIFF
--- a/gen-apidocs/generators/examples/daemonset/create.yaml
+++ b/gen-apidocs/generators/examples/daemonset/create.yaml
@@ -1,7 +1,7 @@
 name: daemonset-example
 namespace: default
 request: |
-  apiVersion: extensions/v1beta1
+  apiVersion: apps/v1
   kind: DaemonSet
   metadata:
     name: daemonset-example
@@ -26,11 +26,11 @@ request: |
 response: |
   {
     "kind": "DaemonSet",
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "metadata": {
       "name": "daemonset-example",
       "namespace": "default",
-      "selfLink": "/apis/extensions/v1beta1/namespaces/default/daemonsets/daemonset-example",
+      "selfLink": "/apis/apps/v1/namespaces/default/daemonsets/daemonset-example",
       "uid": "65552ced-b0e2-11e6-aef0-42010af00229",
       "resourceVersion": "3558",
       "generation": 1,

--- a/gen-apidocs/generators/examples/daemonset/daemonset.yaml
+++ b/gen-apidocs/generators/examples/daemonset/daemonset.yaml
@@ -1,6 +1,6 @@
 note: DaemonSet Config to print the `hostname` on each Node in the cluster every 10 seconds.
 sample: |
-  apiVersion: extensions/v1beta1
+  apiVersion: apps/v1
   kind: DaemonSet
   metadata:
     # Unique key of the DaemonSet instance

--- a/gen-apidocs/generators/examples/deployment/create.yaml
+++ b/gen-apidocs/generators/examples/deployment/create.yaml
@@ -8,6 +8,9 @@ request: |
   spec:
     replicas: 3
     revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: nginx
     template:
       metadata:
         labels:

--- a/gen-apidocs/generators/examples/deployment/deployment.yaml
+++ b/gen-apidocs/generators/examples/deployment/deployment.yaml
@@ -8,6 +8,9 @@ sample: |
   spec:
     # 3 Pods should exist at all times.
     replicas: 3
+    selector:
+      matchLabels:
+        app: nginx
     template:
       metadata:
         labels:

--- a/gen-apidocs/generators/examples/deployment/replace.yaml
+++ b/gen-apidocs/generators/examples/deployment/replace.yaml
@@ -8,6 +8,9 @@ request: |
   spec:
     replicas: 3
     revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: nginx
     template:
       metadata:
         labels:

--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -292,7 +293,11 @@ func (h *HTMLWriter) writeResponseParams(w io.Writer, o *api.Operation) {
 
 	fmt.Fprintf(w, "<H3>Response</H3>\n")
 	fmt.Fprintf(w, "<TABLE>\n<THEAD><TR><TH>Code</TH><TH>Description</TH></TR></THEAD>\n<TBODY>\n")
-	for _, p := range o.HttpResponses {
+	responses := o.HttpResponses
+	sort.Slice(responses, func(i, j int) bool {
+		return strings.Compare(responses[i].Name, responses[j].Name) < 0
+	})
+	for _, p := range responses {
 		fmt.Fprintf(w, "<TR><TD>%s", p.Name)
 		if p.Field.Link() != "" {
 			fmt.Fprintf(w, "<br /><I>%s</I>", p.Field.FullLink())

--- a/gen-apidocs/generators/static/stylesheet.css
+++ b/gen-apidocs/generators/static/stylesheet.css
@@ -83,7 +83,7 @@ body > #wrapper {
     left: 0;
     background-color: whitesmoke;
     border-right: 2px solid slategrey;
-    overflow-x: hidden;
+    overflow-x: auto;
     padding-top: 60px;
 }
 

--- a/gen-apidocs/generators/static_includes/_config.html
+++ b/gen-apidocs/generators/static_includes/_config.html
@@ -4,7 +4,7 @@
 
 <P>Common resource types:</P>
 <UL>
-<LI><A href="#configmap-v1-core">ConfigMaps]</A>for providing text key value pairs injected into the application through environment variables, command line arguments, or files</LI>
+<LI><A href="#configmap-v1-core">ConfigMaps</A>for providing text key value pairs injected into the application through environment variables, command line arguments, or files</LI>
 <LI><A href="#secret-v1-core">Secrets</A> for providing binary data injected into the application through files</LI>
 <LI><A href="#volume-v1-core">Volumes</A> for providing a filesystem external to the Container.  Maybe shared across Containers within the same Pod and have a lifetime persisting beyond a Container or Pod.</LI>
 </UL>


### PR DESCRIPTION
One observation from committing API reference changes to website repo is that there are many fake changes in the responses section. The response code is not sorted. This behavior is undesired. It makes the output unpredictable thus the changes are unclear from a PR commit.

We can sort the responses by their code easily, actually.