### PR TITLE
Update to use latest brodocs and fixed unescaped < and > in generated docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # set the following environment variables
 # to match your environment and release version
 #
-# WEBROOT=~/src/github.com/kubernetes/website
-# K8SROOT=~/k8s/src/k8s.io/kubernetes
+# K8S_WEBROOT=~/src/github.com/kubernetes/website
+# K8S_ROOT=~/k8s/src/k8s.io/kubernetes
 # K8S_RELEASE=1.17
 
 WEBROOT=${K8S_WEBROOT}
@@ -40,7 +40,7 @@ cleancli:
 
 cli: cleancli
 	go run gen-kubectldocs/main.go --kubernetes-version v$(K8SRELEASEDIR)
-	docker run -v $(shell pwd)/gen-kubectldocs/generators/includes:/source -v $(shell pwd)/gen-kubectldocs/generators/build:/build -v $(shell pwd)/gen-kubectldocs/generators/:/manifest pwittrock/brodocs
+	docker run -v $(shell pwd)/gen-kubectldocs/generators/includes:/source -v $(shell pwd)/gen-kubectldocs/generators/build:/build -v $(shell pwd)/gen-kubectldocs/generators/:/manifest brianpursley/brodocs:latest
 
 copycli: cli
 	cp gen-kubectldocs/generators/build/index.html $(WEBROOT)/static/docs/reference/generated/kubectl/kubectl-commands.html
@@ -53,6 +53,7 @@ copycli: cli
 	cp $(CLISRC)/node_modules/jquery.scrollto/jquery.scrollTo.min.js $(CLIDST)/node_modules/jquery.scrollto/jquery.scrollTo.min.js
 	cp $(CLISRC)/node_modules/jquery/dist/jquery.min.js $(CLIDST)/node_modules/jquery/dist/jquery.min.js
 	cp $(CLISRCFONT)/css/font-awesome.min.css $(CLIDSTFONT)/css/font-awesome.min.css
+	cp -r $(CLISRCFONT)/fonts $(CLIDSTFONT)
 
 # Build kube component,tool docs
 cleancomp:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Tools to build reference documentation for Kubernetes APIs and CLIs.
 
+See [Generating Reference Documentation for kubectl Commands](https://kubernetes.io/docs/contribute/generate-ref-docs/kubectl/) for information on how to generate kubectl reference docs.
+
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).

--- a/gen-kubectldocs/generators/gen.go
+++ b/gen-kubectldocs/generators/gen.go
@@ -65,7 +65,7 @@ func GenerateFiles() {
 
 	manifest := &Manifest{}
 	manifest.Title = "Kubectl Reference Docs"
-	manifest.Copyright = "<a href=\"https://github.com/kubernetes/kubernetes\">Copyright 2019 The Kubernetes Authors.</a>"
+	manifest.Copyright = "<a href=\"https://github.com/kubernetes/kubernetes\">Copyright 2020 The Kubernetes Authors.</a>"
 
 	NormalizeSpec(&spec)
 
@@ -246,13 +246,19 @@ func WriteCategoryFile(c Category) {
 }
 
 func WriteCommandFile(manifest *Manifest, t *template.Template, params TopLevelCommand) {
-	params.MainCommand.Description = strings.Replace(params.MainCommand.Description, "|", "&#124;", -1)
+	replacer := strings.NewReplacer(
+		"|", "&#124;",
+		"<", "&lt;",
+		">", "&gt;",
+		)
+
+	params.MainCommand.Description = replacer.Replace(params.MainCommand.Description)
 	for _, o := range params.MainCommand.Options {
-		o.Usage = strings.Replace(o.Usage, "|", "&#124;", -1)
+		o.Usage = replacer.Replace(o.Usage)
 	}
 	for _, sc := range params.SubCommands {
 		for _, o := range sc.Options {
-			o.Usage = strings.Replace(o.Usage, "|", "&#124;", -1)
+			o.Usage = replacer.Replace(o.Usage)
 		}
 	}
 	f, err := os.Create(*GenKubectlDir + "/includes/_generated_" + strings.ToLower(params.MainCommand.Name) + ".md")

--- a/runbrodocs.sh
+++ b/runbrodocs.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-rm -rf ./documents/*
-cp /manifest/manifest.json ./manifest.json
-cp /source/* ./documents/
-node brodoc.js
-cp -r ./* /build/


### PR DESCRIPTION
I'm working on [updating the kubectl reference to improve mobile display](https://github.com/kubernetes/website/pull/19540), and as part of that have [already made upstream changes to brodocs repo](https://github.com/Birdrock/brodocs/pull/9), and would like to update reference-docs to use the latest brodocs.

While working on this I also discovered and fixed a couple bugs, included in this PR:
* < and > were not being escaped as `&lt;` and `&gt;` in the generated output.
* font awesome font files were not being included in the generated output, which caused 404s when you visited the resulting page (although it seems font awesome may not actually be used currently, but I didn't try to figure that out).

---

### Generated Output Comparison:

Current kubectl reference:
https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands

Preview rendered using this version of reference-docs:
https://deploy-preview-19540--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubectl/kubectl-commands

