### PR TITLE
Fix usage and hyperlinks in kubectl reference

### DIFF
--- a/gen-kubectldocs/generators/gen.go
+++ b/gen-kubectldocs/generators/gen.go
@@ -250,7 +250,9 @@ func WriteCommandFile(manifest *Manifest, t *template.Template, params TopLevelC
 		"|", "&#124;",
 		"<", "&lt;",
 		">", "&gt;",
-		)
+		"[", "<span>[</span>",
+		"]", "<span>]</span>",
+	)
 
 	params.MainCommand.Description = replacer.Replace(params.MainCommand.Description)
 	for _, o := range params.MainCommand.Options {

--- a/gen-kubectldocs/generators/templates.go
+++ b/gen-kubectldocs/generators/templates.go
@@ -31,7 +31,7 @@ var CommandTemplate = `
 
 ### Usage
 
-` + "`" + `$ {{.MainCommand.Usage}}` + "`" + `
+` + "`" + `$ kubectl {{.MainCommand.Usage}}` + "`" + `
 
 {{if .MainCommand.Options}}
 
@@ -41,6 +41,7 @@ Name | Shorthand | Default | Usage
 ---- | --------- | ------- | ----- {{range $option := .MainCommand.Options}}
 {{$option.Name}} | {{$option.Shorthand}} | {{$option.DefaultValue}} | {{$option.Usage}} {{end}}
 {{end}}
+{{$mainCommandName := .MainCommand.Name}}
 {{range $sub := .SubCommands}}
 ------------
 
@@ -52,7 +53,7 @@ Name | Shorthand | Default | Usage
 
 ### Usage
 
-` + "`" + `$ {{$sub.Usage}}` + "`" + `
+` + "`" + `$ kubectl {{$mainCommandName}} {{$sub.Usage}}` + "`" + `
 
 {{if $sub.Options}}
 


### PR DESCRIPTION
Fixes command usage missing `kubectl`
Fixes subcommand usage missing `kubectl <maincommand>`
Fixes problem with hyperlinks surrounded by [ ] not displaying correctly...
Fixes https://github.com/kubernetes/website/issues/18444
