### PR TITLE
Update nginx to modern versions

### DIFF
--- a/gen-apidocs/config/examples/container/container.yaml
+++ b/gen-apidocs/config/examples/container/container.yaml
@@ -1,5 +1,5 @@
 note: Container Config to run nginx (must be embedded in a PodSpec to run).
 sample: |
   name: nginx
-  # Run the nginx:1.10 image
-  image: nginx:1.10
+  # Run the nginx:1.14 image
+  image: nginx:1.14

--- a/gen-apidocs/config/examples/deployment/create.yaml
+++ b/gen-apidocs/config/examples/deployment/create.yaml
@@ -18,7 +18,7 @@ request: |
       spec:
         containers:
         - name: nginx
-          image: nginx:1.10
+          image: nginx:1.14
           ports:
           - containerPort: 80
 response: |
@@ -55,7 +55,7 @@ response: |
           "containers": [
             {
               "name": "nginx",
-              "image": "nginx:1.10",
+              "image": "nginx:1.14",
               "ports": [
                 {
                   "containerPort": 80,

--- a/gen-apidocs/config/examples/deployment/deployment.yaml
+++ b/gen-apidocs/config/examples/deployment/deployment.yaml
@@ -21,4 +21,4 @@ sample: |
         containers:
         - name: nginx
           # Run this image
-          image: nginx:1.10
+          image: nginx:1.14

--- a/gen-apidocs/config/examples/deployment/list.yaml
+++ b/gen-apidocs/config/examples/deployment/list.yaml
@@ -111,7 +111,7 @@ response: |
               "containers": [
                 {
                   "name": "nginx",
-                  "image": "nginx:1.10",
+                  "image": "nginx:1.14",
                   "ports": [
                     {
                       "containerPort": 80,

--- a/gen-apidocs/config/examples/deployment/patch.yaml
+++ b/gen-apidocs/config/examples/deployment/patch.yaml
@@ -1,6 +1,6 @@
 name: deployment-example
 namespace: default
-request: '{"spec":{"template":{"spec":{"containers":[{"name":"nginx","image":"nginx:1.11"}]}}}}'
+request: '{"spec":{"template":{"spec":{"containers":[{"name":"nginx","image":"nginx:1.16"}]}}}}'
 response: |
   {
     "kind": "Deployment",
@@ -38,7 +38,7 @@ response: |
           "containers": [
             {
               "name": "nginx",
-              "image": "nginx:1.11",
+              "image": "nginx:1.16",
               "ports": [
                 {
                   "containerPort": 80,

--- a/gen-apidocs/config/examples/deployment/read.yaml
+++ b/gen-apidocs/config/examples/deployment/read.yaml
@@ -37,7 +37,7 @@ response: |
           "containers": [
             {
               "name": "nginx",
-              "image": "nginx:1.10",
+              "image": "nginx:1.14",
               "ports": [
                 {
                   "containerPort": 80,

--- a/gen-apidocs/config/examples/deployment/replace.yaml
+++ b/gen-apidocs/config/examples/deployment/replace.yaml
@@ -18,7 +18,7 @@ request: |
       spec:
         containers:
         - name: nginx
-          image: nginx:1.11
+          image: nginx:1.16
           ports:
           - containerPort: 80
 response: |
@@ -55,7 +55,7 @@ response: |
           "containers": [
             {
               "name": "nginx",
-              "image": "nginx:1.11",
+              "image": "nginx:1.16",
               "ports": [
                 {
                   "containerPort": 80,

--- a/gen-apidocs/config/examples/deployment/watch.yaml
+++ b/gen-apidocs/config/examples/deployment/watch.yaml
@@ -39,7 +39,7 @@ response: |
   					"containers": [
   						{
   							"name": "nginx",
-  							"image": "nginx:1.10",
+  							"image": "nginx:1.14",
   							"ports": [
   								{
   									"containerPort": 80,

--- a/gen-apidocs/config/examples/replicaset/replicaset.yaml
+++ b/gen-apidocs/config/examples/replicaset/replicaset.yaml
@@ -19,4 +19,4 @@ sample: |
         containers:
         # Run the nginx image
         - name: nginx
-          image: nginx:1.10
+          image: nginx:1.14

--- a/gen-apidocs/config/examples/replicationcontroller/replicationcontroller.yaml
+++ b/gen-apidocs/config/examples/replicationcontroller/replicationcontroller.yaml
@@ -16,4 +16,4 @@ sample: |
         containers:
         # Run the nginx image
         - name: nginx
-          image: nginx:1.10
+          image: nginx:1.14


### PR DESCRIPTION
Fixes #144 

- Update `nginx:1.10` to `nginx:1.14`
- Update `nginx:1.11` to `nginx:1.16`