### PR TITLE
Fix example for type definitions

### DIFF
--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -292,7 +292,7 @@ func (d *Definition) initExample(config *Config) {
 
 func (d *Definition) GetSamples() []ExampleText {
 	r := []ExampleText{}
-	for _, p := range GetExampleProviders() {
+	for _, p := range EmptyExampleProviders {
 		r = append(r, ExampleText{
 			Tab:  p.GetTab(),
 			Type: p.GetSampleType(),

--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -192,7 +192,7 @@ func (h *HTMLWriter) writeSample(w io.Writer, d *api.Definition) {
 		linkID := sType + "-" + d.LinkID()
 		fmt.Fprintf(w, "<BUTTON class=\"btn btn-info\" type=\"button\" data-toggle=\"collapse\"\n")
 		fmt.Fprintf(w, "  data-target=\"#%s\" aria-controls=\"%s\"\n", linkID, linkID)
-		fmt.Fprintf(w, "  aria-expanded=\"false\">%s example</BUTTON>\n", sType)
+		fmt.Fprintf(w, "  aria-expanded=\"false\">%s</BUTTON>\n", sType)
 	}
 
 	for _, s := range d.GetSamples() {


### PR DESCRIPTION
We are generating two buttons under the resource type definitions, for
'curl' and 'kubectl' respectively. However, for resource type
definitions, this logic is wrong. One examples for operations have
different types. This fix the problem.