### PR TITLE
Fix page grid

### DIFF
--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -292,7 +292,7 @@ func (d *Definition) initExample(config *Config) {
 
 func (d *Definition) GetSamples() []ExampleText {
 	r := []ExampleText{}
-	for _, p := range GetExampleProviders() {
+	for _, p := range EmptyExampleProviders {
 		r = append(r, ExampleText{
 			Tab:  p.GetTab(),
 			Type: p.GetSampleType(),

--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -555,8 +555,9 @@ func (h *HTMLWriter) generateHTML(navContent string) {
 	fmt.Fprintf(html, "<LINK rel=\"stylesheet\" href=\"css/font-awesome.min.css\" type=\"text/css\">\n")
 	fmt.Fprintf(html, "<LINK rel=\"stylesheet\" href=\"css/stylesheet.css\" type=\"text/css\">\n")
 	fmt.Fprintf(html, "</HEAD>\n<BODY>\n")
-	fmt.Fprintf(html, "<DIV id=\"wrapper\">\n")
-	fmt.Fprintf(html, "<DIV id=\"sidebar-wrapper\" class=\"side-nav side-bar-nav\">\n")
+	fmt.Fprintf(html, "<DIV id=\"wrapper\" class=\"container-fluid\">\n")
+	fmt.Fprintf(html, "<DIV class=\"row\">\n")
+	fmt.Fprintf(html, "<DIV id=\"sidebar-wrapper\" class=\"col-xs-4 col-sm-3 col-md-2 side-nav side-bar-nav\">\n")
 
 	// html buffer
 	buf := "<DIV class=\"row\">\n  <DIV class=\"col-md-6 copyright\">\n " + h.TOC.Copyright + "\n  </DIV>\n"
@@ -618,9 +619,9 @@ func (h *HTMLWriter) generateHTML(navContent string) {
 	navData.js is dynamically generated - see generateNavJS()
 	*/
 	fmt.Fprintf(html, "%s</DIV>\n", navContent)
-	fmt.Fprintf(html, "<DIV id=\"page-content-wrapper\" class=\"body-content container\">\n")
+	fmt.Fprintf(html, "<DIV id=\"page-content-wrapper\" class=\"col-xs-8 offset-xs-4 col-sm-9 offset-sm-3 col-md-10 offset-md-2 body-content\">\n")
 	fmt.Fprintf(html, "%s", string(buf))
-	fmt.Fprintf(html, "</DIV>\n</DIV>\n")
+	fmt.Fprintf(html, "\n</DIV>\n</DIV>\n</DIV>\n")
 	fmt.Fprintf(html, "<SCRIPT src=\"/js/jquery-3.2.1.min.js\"></SCRIPT>\n")
 	fmt.Fprintf(html, "<SCRIPT src=\"js/jquery.scrollTo.min.js\"></SCRIPT>\n")
 	fmt.Fprintf(html, "<SCRIPT src=\"/js/bootstrap-4.3.1.min.js\"></SCRIPT>\n")

--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -192,7 +192,7 @@ func (h *HTMLWriter) writeSample(w io.Writer, d *api.Definition) {
 		linkID := sType + "-" + d.LinkID()
 		fmt.Fprintf(w, "<BUTTON class=\"btn btn-info\" type=\"button\" data-toggle=\"collapse\"\n")
 		fmt.Fprintf(w, "  data-target=\"#%s\" aria-controls=\"%s\"\n", linkID, linkID)
-		fmt.Fprintf(w, "  aria-expanded=\"false\">%s example</BUTTON>\n", sType)
+		fmt.Fprintf(w, "  aria-expanded=\"false\">%s</BUTTON>\n", sType)
 	}
 
 	for _, s := range d.GetSamples() {

--- a/gen-apidocs/static/css/stylesheet.css
+++ b/gen-apidocs/static/css/stylesheet.css
@@ -21,7 +21,6 @@ light grey - rgb(161, 160, 158)
 
 .body-content table {
     margin-bottom: 1em;
-    width: 100%;
     overflow: auto;
 }
 
@@ -76,7 +75,6 @@ body > #wrapper {
 #sidebar-wrapper {
     display: block;
     height: 100%;
-    width: 20%;
     position: fixed;
     z-index: 1;
     top: 0;
@@ -124,7 +122,6 @@ body > #wrapper {
 }
 
 #page-content-wrapper {
-    margin-left: 20%;
     padding-top: 60px;
 }
 


### PR DESCRIPTION
Closes: #136 

We are currently employing both custom sytlesheet and Bootstrap classes.
This is hurting the stability of the page layout. This PR proposes to
use the bootstrap grid system so that we don't need to customize the
20%/80% division manually. Hopefully this can yield a better layout that
works across different browsers.
