### PR TITLE
modify comp docs table indentation

### DIFF
--- a/set_version_dirs.sh
+++ b/set_version_dirs.sh
@@ -34,7 +34,7 @@ echo version dir ${VERSION_DIR}
 # kubectl-command static-includes, toc.yaml
 mkdir -p ./gen-kubectldocs/generators/${VERSION_DIR}
 
-if ! [ -f "${ROOTDIR}/gen-kubectldocs/generators/${VERSION_DIR}/config.yaml" ]; then
+if ! [ -f "${ROOTDIR}/gen-kubectldocs/generators/${VERSION_DIR}/toc.yaml" ]; then
 		cp -r ${ROOTDIR}/gen-kubectldocs/generators/${PREV_VERSION_DIR}/* ${ROOTDIR}/gen-kubectldocs/generators/${VERSION_DIR}/
 fi
 


### PR DESCRIPTION
- Fixed issue #141. The script incorrectly checked for `config.yaml` instead of `toc.yaml`.
- Added a solution for #99. This replaces the output of `$HOME` with the variable name "$HOME" for the value of the flag, `cache-dir`. Possibly moved into a post-processing function.
- Updated the `Options` HTML table block (`gen-compdocs/generators/doc.go`) indentation so that the inline HTML table renders. For information, see issue #148.
- The sample output can be found in pull request, https://github.com/kubernetes/website/pull/20245 .