### PR TITLE
Add "latest" version of API docs to provide more stable external link targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,4 @@ copyapi: api
 	# copy fonts data
 	mkdir -p $(APIDST)/fonts
 	cp $(APISRC)/static/fonts/* $(APIDST)/fonts/
+	ln -sf $$(ls -d $(APIDST)/../v[0-9]* | xargs basename -a | sort -V -r | head -1) $(APIDST)/../latest


### PR DESCRIPTION
Currently, links to API docs include the version in the URL. Additionally, the website only includes the current version. That means that any external links to the API docs break each time we update to a new version.

This PR adds a `latest` symlink so that external links can refer to (for example) `.../kubernetes-api/latest/#pod-v1-core` instead of `.../kubernetes-api/v1.18/#pod-v1-core` and then as long as the reference target `#pod-v1-core` lives on from version to version, the link would continue to work.  