### PR TITLE
Fix API generation for v1.20 (rc.0)

### DIFF
--- a/gen-apidocs/config/v1_20/config.yaml
+++ b/gen-apidocs/config/v1_20/config.yaml
@@ -2,6 +2,7 @@ example_location: "examples"
 api_groups:
   - "AdmissionRegistration"
   - "ApiExtensions"
+  - "InternalApiserver"
   - "ApiRegistration"
   - "Apps"
   - "AuditRegistration"
@@ -14,6 +15,7 @@ api_groups:
   - "Core"
   - "Discovery"
   - "Extensions"
+  - "FlowControl"
   - "Meta"
   - "Networking"
   - "Node"
@@ -203,6 +205,9 @@ resource_categories:
     - name: ServiceAccount
       version: v1
       group: core
+    - name: StorageVersion
+      version: v1alpha1
+      group: apiserverinternal
     - name: SubjectAccessReview
       version: v1
       group: authorization

--- a/gen-apidocs/generators/api/config.go
+++ b/gen-apidocs/generators/api/config.go
@@ -306,7 +306,7 @@ func LoadConfigFromYAML() *Config {
 	contents, err := ioutil.ReadFile(f)
 	if err != nil {
 		if !*UseTags {
-			fmt.Printf("Failed to read yaml file %s: %v", f, err)
+			fmt.Printf("\033[31mFailed to read yaml file %s: %v\033[0m", f, err)
 			os.Exit(2)
 		}
 	} else {
@@ -584,12 +584,12 @@ func (c *Config) visitResourcesInToc() {
 				d.initExample(c)
 				r.Definition = d
 			} else {
-				fmt.Printf("Could not find definition for resource in TOC: %s %s %s.\n", r.Group, r.Version, r.Name)
+				fmt.Printf("\033[31mCould not find definition for resource in TOC: %s %s %s.\033[0m\n", r.Group, r.Version, r.Name)
 				missing = true
 			}
 		}
 	}
 	if missing {
-		fmt.Printf("All known definitions: %v\n", c.Definitions.All)
+		fmt.Printf("\033[36mAll known definitions: %v\033[0m\n", c.Definitions.All)
 	}
 }

--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -222,11 +222,16 @@ func (d *Definition) GroupDisplayName() string {
 }
 
 func (d *Definition) GetOperationGroupName() string {
+	// TODO(Qiming): Expose this to config.yaml so that we don't need to
+	// change the Go source next time.
 	if strings.ToLower(d.Group.String()) == "rbac" {
 		return "RbacAuthorization"
 	}
 	if strings.ToLower(d.Group.String()) == "flowcontrol" {
 		return "FlowcontrolApiserver"
+	}
+	if strings.ToLower(d.Group.String()) == "apiserverinternal" {
+		return "InternalApiserver"
 	}
 
 	return strings.Title(d.Group.String())

--- a/gen-apidocs/generators/api/open_api.go
+++ b/gen-apidocs/generators/api/open_api.go
@@ -58,11 +58,14 @@ func LoadOpenApiSpec() []*loads.Document {
 
 // return the map from short group name to full group name
 func buildGroupMap(specs []*loads.Document) map[string]string {
+	// TODO(Qiming): Expose this map to the config.yaml so that we don't need
+	// to revise the source code next time.
 	mapping := map[string]string{}
 	mapping["apiregistration"] = "apiregistration.k8s.io"
 	mapping["apiextensions"] = "apiextensions.k8s.io"
 	mapping["certificates"] = "certificates.k8s.io"
 	mapping["flowcontrol"] = "flowcontrol.apiserver.k8s.io"
+	mapping["apiserverinternal"] = "internal.apiserver.k8s.io"
 	mapping["meta"] = "meta"
 	mapping["core"] = "core"
 	mapping["extensions"] = "extensions"

--- a/gen-apidocs/generators/api/operation.go
+++ b/gen-apidocs/generators/api/operation.go
@@ -122,6 +122,8 @@ func (o *Operation) GetDisplayHttp() string {
 }
 
 func (o *Operation) VerifyBlackListed() {
+	// TODO(Qiming): Expose this to the config.yaml file so that we don't need
+	// to change the source code next time.
 	switch {
 	case strings.Contains(o.ID, "connectCoreV1Patch"):
 	case strings.Contains(o.ID, "createCoreV1NamespacedPodBinding"):
@@ -134,8 +136,10 @@ func (o *Operation) VerifyBlackListed() {
 	case strings.Contains(o.ID, "V1beta1CertificateSigningRequestApproval"):
 	case strings.Contains(o.ID, "V1CertificateSigningRequestApproval"):
 	case strings.Contains(o.ID, "V1beta1NamespacedReplicationControllerDummyScale"):
+	case strings.Contains(o.ID, "getServiceAccountIssuerOpenIDConfiguration"):
+	case strings.Contains(o.ID, "getServiceAccountIssuerOpenIDKeyset"):
 	default:
-		fmt.Printf("No Definition found for %s [%s].  \n", o.ID, o.Path)
+		fmt.Printf("\033[31mNo Definition found for %s [%s].\033[0m\n", o.ID, o.Path)
 	}
 }
 


### PR DESCRIPTION
This PR fixes two problems in the API reference generator:

1. The `StorageVersion` resource introduced in 1.20 is not a good citizen:

- resource API version named: `internal.apiserver.k8s.io`
- definition path in Swagger: `io.k8s.api.apiserverinternal`
- operation ID defined as: `createInternalApiserver...`

Note that the two key words ("internal" and "apiserver") are in different orders; sometimes they split, other times they are merged.

2. The following APIs are not RESTful APIs because they are not associated with any REST resources. These two APIs have to be skipped.

- `getServiceAccountIssuerOpenIDConfiguration` exposed at `/.well-known/openid-configuration/`;
- `getServiceAccountIssuerOpenIDKeyset` exposed at `/openid/v1/jwks`.


closes: #178