### PR TITLE
Expose group mapping into config file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ updateapispec: createversiondirs
 	cd $(K8SROOT) && git show "v$(K8SRELEASE):api/openapi-spec/swagger.json" > $(CURDIR)/$(APISRC)/config/v$(K8SRELEASEDIR)/swagger.json
 
 api: cleanapi
-	go run gen-apidocs/main.go --kubernetes-release=$(K8SRELEASE_PREFIX) --work-dir=gen-apidocs --munge-groups=false
+	go run gen-apidocs/main.go --kubernetes-release=$(K8SRELEASE_PREFIX) --work-dir=gen-apidocs
 
 cleanapi:
 	rm -rf $(shell pwd)/gen-apidocs/build

--- a/gen-apidocs/config/v1_20/config.yaml
+++ b/gen-apidocs/config/v1_20/config.yaml
@@ -321,3 +321,9 @@ group_full_names:
   scheduling: scheduling.k8s.io
   storage: storage.k8s.io
 
+# The map from the group as the resource sees it to the group as the operation
+# sees it.
+operation_group_map:
+  rbac: RbacAuthorization
+  flowcontrol: FlowcontrolApiserver
+  apiserverinternal: InternalApiserver

--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -221,22 +221,6 @@ func (d *Definition) GroupDisplayName() string {
 	return string(d.Group)
 }
 
-func (d *Definition) GetOperationGroupName() string {
-	// TODO(Qiming): Expose this to config.yaml so that we don't need to
-	// change the Go source next time.
-	if strings.ToLower(d.Group.String()) == "rbac" {
-		return "RbacAuthorization"
-	}
-	if strings.ToLower(d.Group.String()) == "flowcontrol" {
-		return "FlowcontrolApiserver"
-	}
-	if strings.ToLower(d.Group.String()) == "apiserverinternal" {
-		return "InternalApiserver"
-	}
-
-	return strings.Title(d.Group.String())
-}
-
 func (d *Definition) Key() string {
 	return fmt.Sprintf("%s.%s.%s", d.Group, d.Version, d.Kind)
 }

--- a/gen-apidocs/generators/api/types.go
+++ b/gen-apidocs/generators/api/types.go
@@ -211,7 +211,7 @@ type Config struct {
 	ExcludedOperations  []string            `yaml:"excluded_operations,omitempty"`
 
 	// Used to map the group as the resource sees it to the group as the operation sees it
-	GroupMap map[string]string
+	OperationGroupMap map[string]string `yaml:"operation_group_map,omitempty"`
 
 	GroupFullNames map[string]string `yaml:"group_full_names,omitempty"`
 


### PR DESCRIPTION
The group names used in operation IDs are sometimes different from the group names seen by the corresponding resource. This PR expose such mappings for customization when bad citizens show up in the API spec.

/hold

Holding until #181 is in.