### PR TITLE
Allow customization of the full names for groups

### DIFF
--- a/gen-apidocs/config/v1_20/config.yaml
+++ b/gen-apidocs/config/v1_20/config.yaml
@@ -293,3 +293,31 @@ excluded_operations:
   - V1beta1NamespacedReplicationControllerDummyScale
   - getServiceAccountIssuerOpenIDConfiguration
   - getServiceAccountIssuerOpenIDKeyset
+
+# Map from group name to its full name
+group_full_names:
+  admission: admission
+  admissionregistration: admissionregistration.k8s.io
+  apiextensions: apiextensions.k8s.io
+  apiregistration: apiregistration.k8s.io
+  apiserverinternal: internal.apiserver.k8s.io
+  apps: apps
+  authentication: authentication.k8s.io
+  authorization: authorization.k8s.io
+  autoscaling: autoscaling
+  batch: batch
+  certificates: certificates.k8s.io
+  coordination: coordination.k8s.io
+  core: core
+  discovery: discovery.k8s.io
+  events: events.k8s.io
+  extensions: extensions
+  flowcontrol: flowcontrol.apiserver.k8s.io
+  meta: meta
+  networking: networking.k8s.io
+  node: node.k8s.io
+  policy: policy
+  rbac: rbac.authorization.k8s.io
+  scheduling: scheduling.k8s.io
+  storage: storage.k8s.io
+

--- a/gen-apidocs/generators/api/config.go
+++ b/gen-apidocs/generators/api/config.go
@@ -76,7 +76,7 @@ func NewConfig() *Config {
 	config.SpecVersion = fmt.Sprintf("%s%s.%s", versionChar, *KubernetesRelease, "0")
 
 	// Initialize all of the operations
-	config.Definitions = NewDefinitions(specs)
+	config.Definitions = NewDefinitions(config, specs)
 
 	if *UseTags {
 		// Initialize the config and ToC from the tags on definitions
@@ -119,7 +119,6 @@ func NewConfig() *Config {
 func (c *Config) genConfigFromTags(specs []*loads.Document) {
 	log.Printf("Using OpenAPI extension tags to configure.")
 
-	c.ExampleLocation = "examples"
 	// build the apis from the observed groups
 	groupsMap := map[ApiGroup]DefinitionList{}
 	for _, d := range c.Definitions.All {

--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -45,14 +45,14 @@ var _INLINE_DEFINITIONS = []inlineDefinition{
 	{Name: "EventSource", Match: "${resource}EventSource"},
 }
 
-func NewDefinitions(specs []*loads.Document) Definitions {
+func NewDefinitions(config *Config, specs []*loads.Document) Definitions {
 	s := Definitions{
 		All:           map[string]*Definition{},
 		ByKind:        map[string]SortDefinitionsByVersion{},
 		GroupVersions: map[string]ApiVersions{},
 	}
 
-	LoadDefinitions(specs, &s)
+	LoadDefinitions(config, specs, &s)
 	s.initialize()
 	return s
 }

--- a/gen-apidocs/generators/api/types.go
+++ b/gen-apidocs/generators/api/types.go
@@ -213,6 +213,8 @@ type Config struct {
 	// Used to map the group as the resource sees it to the group as the operation sees it
 	GroupMap map[string]string
 
+	GroupFullNames map[string]string `yaml:"group_full_names,omitempty"`
+
 	Definitions Definitions
 	Operations  Operations
 	SpecTitle   string

--- a/gen-apidocs/generators/api/util.go
+++ b/gen-apidocs/generators/api/util.go
@@ -49,8 +49,10 @@ func GetDefinitionVersionKind(s spec.Schema) (string, string, string) {
 			version = name[len(name)-2]
 			kind = name[len(name)-1]
 		} else if name[len(name)-3] == "util" || name[len(name)-3] == "pkg" {
-			// e.g. io.k8s.apimachinery.pkg.util.intstr.IntOrString
-			// e.g. io.k8s.apimachinery.pkg.runtime.RawExtension
+			// This is for:
+			// - io.k8s.apimachinery.pkg.util.intstr.IntOrString
+			// - io.k8s.apimachinery.pkg.version.Info
+			// - io.k8s.apimachinery.pkg.runtime.RawExtension
 			return "", "", ""
 		} else {
 			panic(errors.New(fmt.Sprintf("Could not locate group for %s", name)))


### PR DESCRIPTION
Groups have different schemes for naming its full group names. This is bad but we have to live with it. This PR avoids hardcoding this conversion or guessing by exposing the full names for users to adapt.
