### PR TITLE
add mkdir for catalina docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ cleancli:
 
 cli: cleancli
 	go run gen-kubectldocs/main.go --kubernetes-version v$(K8SRELEASEDIR)
+	mkdir -p $(CLISRC)
 	docker run -v $(shell pwd)/gen-kubectldocs/generators/includes:/source -v $(shell pwd)/gen-kubectldocs/generators/build:/build -v $(shell pwd)/gen-kubectldocs/generators/:/manifest brianpursley/brodocs:latest
 
 copycli: cli


### PR DESCRIPTION
Add mkdir before docker build. When running on macOS catalina, build directory is not created.