### PR TITLE
resourcedocs: Add Anchors to inlined definitions

### DIFF
--- a/gen-resourcesdocs/pkg/config/output.go
+++ b/gen-resourcesdocs/pkg/config/output.go
@@ -212,7 +212,7 @@ func (o *TOC) OutputProperties(defname string, definition spec.Schema, outputSec
 						return err
 					}
 
-					err = outputSection.AddTypeDefinition(target.Description)
+					err = outputSection.AddTypeDefinition(property.TypeKey.ResourceName(), target.Description)
 					if err != nil {
 						return err
 					}

--- a/gen-resourcesdocs/pkg/config/output_test.go
+++ b/gen-resourcesdocs/pkg/config/output_test.go
@@ -32,9 +32,9 @@ func (o FakeChapter) Write() error { return nil }
 
 type FakeSection struct{}
 
-func (o FakeSection) AddContent(s string) error          { return nil }
-func (o FakeSection) AddTypeDefinition(s string) error   { return nil }
-func (o FakeSection) AddFieldCategory(name string) error { return nil }
+func (o FakeSection) AddContent(s string) error                              { return nil }
+func (o FakeSection) AddTypeDefinition(typ string, description string) error { return nil }
+func (o FakeSection) AddFieldCategory(name string) error                     { return nil }
 
 func (o FakeSection) AddProperty(name string, property *kubernetes.Property, linkend []string, indent bool, defname string, shortName string) error {
 	return nil

--- a/gen-resourcesdocs/pkg/outputs/interface.go
+++ b/gen-resourcesdocs/pkg/outputs/interface.go
@@ -28,7 +28,7 @@ type Chapter interface {
 // Section is an interface to a section of an output
 type Section interface {
 	AddContent(s string) error
-	AddTypeDefinition(s string) error
+	AddTypeDefinition(typ string, description string) error
 	StartPropertyList() error
 	AddFieldCategory(name string) error
 	AddProperty(name string, property *kubernetes.Property, linkend []string, indent bool, defname string, shortName string) error

--- a/gen-resourcesdocs/pkg/outputs/kwebsite/chapter.go
+++ b/gen-resourcesdocs/pkg/outputs/kwebsite/chapter.go
@@ -51,6 +51,7 @@ type FieldData struct {
 	Name           string
 	Value          string
 	Description    string
+	Type           string
 	TypeDefinition string
 	Indent         int
 }

--- a/gen-resourcesdocs/pkg/outputs/kwebsite/files.go
+++ b/gen-resourcesdocs/pkg/outputs/kwebsite/files.go
@@ -63,7 +63,6 @@ func escapeName(parts ...string) string {
 
 // headingID returns the ID built by hugo for a given header
 func headingID(s string) string {
-	result := strings.ToLower(s)
-	result = strings.ReplaceAll(result, " ", "-")
+	result := strings.ReplaceAll(s, " ", "-")
 	return result
 }

--- a/gen-resourcesdocs/pkg/outputs/kwebsite/section.go
+++ b/gen-resourcesdocs/pkg/outputs/kwebsite/section.go
@@ -24,7 +24,7 @@ func (o Section) AddContent(s string) error {
 }
 
 // AddTypeDefinition adds the definition of a type to a section
-func (o Section) AddTypeDefinition(s string) error {
+func (o Section) AddTypeDefinition(typ string, description string) error {
 	i := len(o.chapter.data.Sections)
 	cats := o.chapter.data.Sections[i-1].FieldCategories
 	var fields *[]FieldData
@@ -34,7 +34,8 @@ func (o Section) AddTypeDefinition(s string) error {
 		fields = &cats[len(cats)-1].Fields
 	}
 	j := len(*fields)
-	(*fields)[j-1].TypeDefinition = "*" + s + "*"
+	(*fields)[j-1].Type = typ
+	(*fields)[j-1].TypeDefinition = "*" + description + "*"
 	return nil
 }
 

--- a/gen-resourcesdocs/templates/chapter-single-definition.tmpl
+++ b/gen-resourcesdocs/templates/chapter-single-definition.tmpl
@@ -22,6 +22,7 @@ weight: {{.Metadata.Weight}}
 {{.Description | replace "<" "\\<" | indent 2 | indent .Indent | indent .Indent}}
 {{- end}}
 {{if .TypeDefinition}}
+{{ ""  | indent .Indent | indent .Indent}}  <a name="{{.Type}}"></a>
 {{.TypeDefinition | indent 2 | indent .Indent | indent .Indent}}
 {{end}}
 {{- end}}{{/* range .Fields */}}
@@ -35,6 +36,7 @@ weight: {{.Metadata.Weight}}
 {{.Description | replace "<" "\\<" | indent 2 | indent .Indent | indent .Indent}}
 {{- end}}
 {{if .TypeDefinition}}
+{{ ""  | indent .Indent | indent .Indent}}  <a name="{{.Type}}"></a>
 {{.TypeDefinition | indent 2 | indent .Indent | indent .Indent}}
 {{end}}
 {{- end}}{{/* range .Fields */}}

--- a/gen-resourcesdocs/templates/chapter-single-definition.tmpl
+++ b/gen-resourcesdocs/templates/chapter-single-definition.tmpl
@@ -28,7 +28,7 @@ weight: {{.Metadata.Weight}}
 {{- end}}{{/* range .Fields */}}
 
 {{range .FieldCategories}}
-### {{.Name}}
+### {{.Name}} {#{{.Name}}}
 
 {{range .Fields}}
 {{ ""  | indent .Indent | indent .Indent}}- {{.Name}}{{if .Value}}: {{.Value}}{{end}}

--- a/gen-resourcesdocs/templates/chapter-single-definition.tmpl
+++ b/gen-resourcesdocs/templates/chapter-single-definition.tmpl
@@ -28,7 +28,7 @@ weight: {{.Metadata.Weight}}
 {{- end}}{{/* range .Fields */}}
 
 {{range .FieldCategories}}
-### {{.Name}} {#{{.Name}}}
+### {{.Name}} {#{{.Name}}}{{/* explicitly set fragment to keep capitalization */}}
 
 {{range .Fields}}
 {{ ""  | indent .Indent | indent .Indent}}- {{.Name}}{{if .Value}}: {{.Value}}{{end}}

--- a/gen-resourcesdocs/templates/chapter.tmpl
+++ b/gen-resourcesdocs/templates/chapter.tmpl
@@ -24,6 +24,7 @@ weight: {{.Metadata.Weight}}
 {{.Description | replace "<" "\\<" | indent 2 | indent .Indent | indent .Indent}}
 {{- end}}
 {{if .TypeDefinition}}
+{{ ""  | indent .Indent | indent .Indent}}  <a name="{{.Type}}"></a>
 {{.TypeDefinition | indent 2 | indent .Indent | indent .Indent}}
 {{end}}
 {{- end}}{{/* range .Fields */}}
@@ -37,6 +38,7 @@ weight: {{.Metadata.Weight}}
 {{.Description | replace "<" "\\<" | indent 2 | indent .Indent | indent .Indent}}
 {{- end}}
 {{if .TypeDefinition}}
+{{ ""  | indent .Indent | indent .Indent}}  <a name="{{.Type}}"></a>
 {{.TypeDefinition | indent 2 | indent .Indent | indent .Indent}}
 {{end}}
 {{- end}}{{/* range .Fields */}}

--- a/gen-resourcesdocs/templates/chapter.tmpl
+++ b/gen-resourcesdocs/templates/chapter.tmpl
@@ -14,7 +14,7 @@ weight: {{.Metadata.Weight}}
 {{if .Import}}`import "{{.Import}}"`{{end}}
 
 {{range .Sections}}
-## {{.Name}} {#{{.Name}}}
+## {{.Name}} {#{{.Name}}}{{/* explicitly set fragment to keep capitalization */}}
 
 {{.Description | replace "<" "\\<" }}
 

--- a/gen-resourcesdocs/templates/chapter.tmpl
+++ b/gen-resourcesdocs/templates/chapter.tmpl
@@ -14,7 +14,7 @@ weight: {{.Metadata.Weight}}
 {{if .Import}}`import "{{.Import}}"`{{end}}
 
 {{range .Sections}}
-## {{.Name}}
+## {{.Name}} {#{{.Name}}}
 
 {{.Description | replace "<" "\\<" }}
 


### PR DESCRIPTION
Inlined definitions into the Markdown generated by gen-resourcesdocs are not referenceable.

These changes adds anchors to the inlined definitions.

These changes also explicitly set fragment names for Resources.