### PR TITLE
API reference: Do not generate main index

### DIFF
--- a/gen-resourcesdocs/pkg/config/output.go
+++ b/gen-resourcesdocs/pkg/config/output.go
@@ -12,13 +12,8 @@ import (
 
 // OutputDocument outputs contents using output
 func (o *TOC) OutputDocument(output outputs.Output) error {
-	err := output.Prepare()
-	if err != nil {
-		return err
-	}
-
 	for p, tocPart := range o.Parts {
-		err = o.OutputPart(p, tocPart, output)
+		err := o.OutputPart(p, tocPart, output)
 		if err != nil {
 			return err
 		}
@@ -26,7 +21,7 @@ func (o *TOC) OutputDocument(output outputs.Output) error {
 
 	o.OutputCommonParameters(len(o.Parts), output)
 
-	err = output.Terminate()
+	err := output.Terminate()
 	if err != nil {
 		return err
 	}

--- a/gen-resourcesdocs/pkg/config/toc.go
+++ b/gen-resourcesdocs/pkg/config/toc.go
@@ -145,17 +145,7 @@ func GetGV(group kubernetes.APIGroup, version kubernetes.APIVersion) string {
 
 // ToKWebsite outputs documentation in Markdown format for k/website in dir directory
 func (o *TOC) ToKWebsite(outputDir string, templatesDir string) error {
-	// Test that dir is empty
-	fileinfos, err := ioutil.ReadDir(outputDir)
-	if err != nil {
-		return fmt.Errorf("Unable to open directory %s", outputDir)
-	}
-	if len(fileinfos) > 0 {
-		return fmt.Errorf("Directory %s must be empty", outputDir)
-	}
-
 	kw := kwebsite.NewKWebsite(outputDir, templatesDir)
-
 	return o.OutputDocument(kw)
 }
 

--- a/gen-resourcesdocs/pkg/outputs/interface.go
+++ b/gen-resourcesdocs/pkg/outputs/interface.go
@@ -4,7 +4,6 @@ import "github.com/kubernetes-sigs/reference-docs/gen-resourcesdocs/pkg/kubernet
 
 // Output is an interface for output formats
 type Output interface {
-	Prepare() error
 	AddPart(i int, name string) (Part, error)
 	NewPart(i int, name string) (Part, error)
 	Terminate() error

--- a/gen-resourcesdocs/pkg/outputs/kwebsite/files.go
+++ b/gen-resourcesdocs/pkg/outputs/kwebsite/files.go
@@ -9,19 +9,6 @@ import (
 	"github.com/stoewer/go-strcase"
 )
 
-func (o *KWebsite) addMainIndex() error {
-	t := template.Must(template.ParseFiles(filepath.Join(o.TemplatesDir, "main-index.tmpl")))
-
-	filename := filepath.Join(o.Directory, "_index.md")
-	f, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	return t.Execute(f, nil)
-}
-
 type PartIndex struct {
 	Title  string
 	Weight int

--- a/gen-resourcesdocs/pkg/outputs/kwebsite/kwebsite.go
+++ b/gen-resourcesdocs/pkg/outputs/kwebsite/kwebsite.go
@@ -20,15 +20,6 @@ func NewKWebsite(dir string, templatesDir string) *KWebsite {
 	return &KWebsite{Directory: dir, TemplatesDir: templatesDir}
 }
 
-// Prepare a new output
-func (o *KWebsite) Prepare() error {
-	err := o.addMainIndex()
-	if err != nil {
-		return fmt.Errorf("Error writing index file in %s: %s", o.Directory, err)
-	}
-	return nil
-}
-
 // NewPart creates a new part for the output
 func (o *KWebsite) NewPart(i int, name string) (outputs.Part, error) {
 	partname := escapeName(name)

--- a/gen-resourcesdocs/templates/main-index.tmpl
+++ b/gen-resourcesdocs/templates/main-index.tmpl
@@ -1,8 +1,0 @@
----
-title: "Kubernetes API"
-weight: 30
----
-
-<!-- overview -->
-
-{{"{{< glossary_definition prepend=\"Kubernetes' API is\" term_id=\"kubernetes-api\" length=\"all\" >}}"}}


### PR DESCRIPTION
As the main index is static, it is not generated here anymore, but let as is in the destination directory.

For this, it is not tested anymore that the destination directory is empty.

Fixes #192 

The main index file is not removed anymore in the destination directory in k/website: https://github.com/kubernetes/website/pull/23294/commits/9497ed3e29b578c2fb9ae2a0b3ab32a647cc90fa (from https://github.com/kubernetes/website/pull/23294/commits)
