### PR TITLE
Remove non alphanumeric characters from anchors

### DIFF
--- a/gen-resourcesdocs/templates/chapter-single-definition.tmpl
+++ b/gen-resourcesdocs/templates/chapter-single-definition.tmpl
@@ -29,7 +29,7 @@ weight: {{.Metadata.Weight}}
 {{- end}}{{/* range .Fields */}}
 
 {{range .FieldCategories}}
-### {{.Name}} {#{{.Name}}}{{/* explicitly set fragment to keep capitalization */}}
+### {{.Name}} {#{{"-" | regexReplaceAll "[^a-zA-Z0-9]+" .Name }}}{{/* explicitly set fragment to keep capitalization */}}
 
 {{range .Fields}}
 {{ ""  | indent .Indent | indent .Indent}}- {{.Name}}{{if .Value}}: {{.Value}}{{end}}

--- a/gen-resourcesdocs/templates/chapter.tmpl
+++ b/gen-resourcesdocs/templates/chapter.tmpl
@@ -14,7 +14,7 @@ weight: {{.Metadata.Weight}}
 {{if .Import}}`import "{{.Import}}"`{{end}}
 
 {{range .Sections}}
-## {{.Name}} {#{{.Name}}}{{/* explicitly set fragment to keep capitalization */}}
+## {{.Name}} {#{{"-" | regexReplaceAll "[^a-zA-Z0-9]+" .Name }}}{{/* explicitly set fragment to keep capitalization */}}
 
 {{.Description | replace "<" "\\<" }}
 


### PR DESCRIPTION
Fixes #203 by replacing non alphanumeric characters by hyphens in anchors
