### PR TITLE
Prepare for v1.21 + better presentation

### DIFF
--- a/gen-resourcesdocs/Makefile
+++ b/gen-resourcesdocs/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v1.20
+VERSION ?= v1.21
 
 all: kwebsite
 

--- a/gen-resourcesdocs/config/v1.21/README.md
+++ b/gen-resourcesdocs/config/v1.21/README.md
@@ -11,11 +11,17 @@
 - `CronJob` v2alpha1 removed
 - `CronJob` GA
 - `EndpointSlice` GA
-- `JobSpec`: new field `completionMode`
+- `JobSpec`: new fields `completionMode`, `suspend`
 - `JobStatus`; new field `completedIndexes`
 - `CronJobStatus`: new field `lastSuccessfulTime`
 - `PodAffinityTerm`: new field `namespaceSelector`
-- `ServiceSpec`: new field `loadBalancerClass`
+- `ServiceSpec`: new fields `loadBalancerClass`, `internalTrafficPolicy`
 - `IngressClassParametersReference` added
 - `IngressClassSpec.parameters` of type `IngressClassParametersReference` (v1 and v1beta1)
 - `PodDisruptionBudgetStatus`: new field `conditions`
+- `EphemeralVolumeSource`: remove field `readonly`
+- `Probe`: new field `terminationGracePeriodSeconds`
+- `Endpoint`: new field `hints`
+- new definition `EndpointHints`
+- new definition `ForZone`
+- `PodDisruptionBudget` GA

--- a/gen-resourcesdocs/config/v1.21/README.md
+++ b/gen-resourcesdocs/config/v1.21/README.md
@@ -1,0 +1,10 @@
+# Changes on v1.21
+
+- `RollingUpdateDaemonSet`: new field `maxSurge`
+- `EphemeralContainers`: added
+- `NetworkPolicyPort`: new field `endport`
+- `CSIStorageCapacity`: added
+- `ConfigMap.immutable` GA
+- `Secret.immutable` GA
+- `PodSecurityPolicy` deprecated
+- `ServiceSpec.topologyKeys` deprecated

--- a/gen-resourcesdocs/config/v1.21/README.md
+++ b/gen-resourcesdocs/config/v1.21/README.md
@@ -8,3 +8,4 @@
 - `Secret.immutable` GA
 - `PodSecurityPolicy` deprecated
 - `ServiceSpec.topologyKeys` deprecated
+- `CronJob` v2alpha1 removed

--- a/gen-resourcesdocs/config/v1.21/README.md
+++ b/gen-resourcesdocs/config/v1.21/README.md
@@ -9,3 +9,13 @@
 - `PodSecurityPolicy` deprecated
 - `ServiceSpec.topologyKeys` deprecated
 - `CronJob` v2alpha1 removed
+- `CronJob` GA
+- `EndpointSlice` GA
+- `JobSpec`: new field `completionMode`
+- `JobStatus`; new field `completedIndexes`
+- `CronJobStatus`: new field `lastSuccessfulTime`
+- `PodAffinityTerm`: new field `namespaceSelector`
+- `ServiceSpec`: new field `loadBalancerClass`
+- `IngressClassParametersReference` added
+- `IngressClassSpec.parameters` of type `IngressClassParametersReference` (v1 and v1beta1)
+- `PodDisruptionBudgetStatus`: new field `conditions`

--- a/gen-resourcesdocs/config/v1.21/fields.yaml
+++ b/gen-resourcesdocs/config/v1.21/fields.yaml
@@ -151,6 +151,7 @@
     - httpGet
     - tcpSocket
     - initialDelaySeconds
+    - terminationGracePeriodSeconds
     - periodSeconds
     - timeoutSeconds
     - failureThreshold
@@ -375,6 +376,7 @@
     - backoffLimit
     - activeDeadlineSeconds
     - ttlSecondsAfterFinished
+    - suspend
   - name: Selector
     fields:
     - selector
@@ -435,6 +437,7 @@
     - loadBalancerClass
     - externalName
     - externalTrafficPolicy
+    - internalTrafficPolicy
     - healthCheckNodePort
     - publishNotReadyAddresses
     - sessionAffinityConfig

--- a/gen-resourcesdocs/config/v1.21/fields.yaml
+++ b/gen-resourcesdocs/config/v1.21/fields.yaml
@@ -371,6 +371,7 @@
   - name: Lifecycle
     fields:
     - completions
+    - completionMode
     - backoffLimit
     - activeDeadlineSeconds
     - ttlSecondsAfterFinished
@@ -387,6 +388,7 @@
     - active
     - failed
     - succeeded
+    - completedIndexes
     - conditions
 
 - definition: io.k8s.api.batch.v1beta1.CronJobSpec
@@ -430,6 +432,7 @@
     - sessionAffinity
     - loadBalancerIP
     - loadBalancerSourceRanges
+    - loadBalancerClass
     - externalName
     - externalTrafficPolicy
     - healthCheckNodePort

--- a/gen-resourcesdocs/config/v1.21/fields.yaml
+++ b/gen-resourcesdocs/config/v1.21/fields.yaml
@@ -1,0 +1,693 @@
+- definition: io.k8s.api.core.v1.PodSpec
+  field_categories:
+  - name: Containers
+    fields:
+    - containers
+    - initContainers
+    - imagePullSecrets
+    - enableServiceLinks
+  - name: Volumes
+    fields:
+    - volumes
+  - name: Scheduling
+    fields:
+    - nodeSelector
+    - nodeName
+    - affinity
+    - tolerations
+    - schedulerName
+    - runtimeClassName
+    - priorityClassName
+    - priority
+  - name: Lifecycle
+    fields:
+    - restartPolicy
+    - terminationGracePeriodSeconds
+    - activeDeadlineSeconds
+    - readinessGates
+  - name: Hostname and Name resolution
+    fields:
+    - hostname
+    - setHostnameAsFQDN
+    - subdomain
+    - hostAliases
+    - dnsConfig
+    - dnsPolicy
+  - name: Hosts namespaces
+    fields:
+    - hostNetwork
+    - hostPID
+    - hostIPC
+    - shareProcessNamespace
+  - name: Service account
+    fields:
+    - serviceAccountName
+    - automountServiceAccountToken
+  - name: Security context
+    fields:
+    - securityContext
+  - name: Beta level
+    fields:
+    - overhead
+    - topologySpreadConstraints
+  - name: Alpha level
+    fields:
+    - ephemeralContainers
+    - preemptionPolicy
+  - name: Deprecated
+    fields:
+    - serviceAccount
+
+- definition: io.k8s.api.core.v1.PodSecurityContext
+  field_categories:
+  - fields:
+    - runAsUser
+    - runAsNonRoot
+    - runAsGroup
+    - supplementalGroups
+    - fsGroup
+    - fsGroupChangePolicy
+    - seccompProfile
+    - seLinuxOptions
+    - sysctls
+    - windowsOptions
+
+- definition: io.k8s.api.core.v1.Toleration
+  field_categories:
+  - fields:
+    - key
+    - operator
+    - value
+    - effect
+    - tolerationSeconds
+
+- definition: io.k8s.api.core.v1.PodStatus
+  field_categories:
+  - fields:
+    - nominatedNodeName
+    - hostIP
+    - startTime
+    - phase
+    - message
+    - reason
+    - podIP
+    - podIPs
+    - conditions
+    - qosClass
+    - initContainerStatuses
+    - containerStatuses
+    - ephemeralContainerStatuses
+
+- definition: io.k8s.api.core.v1.Container
+  field_categories:
+  - fields:
+    - name
+  - name: Image
+    fields:
+    - image
+    - imagePullPolicy
+  - name: Entrypoint
+    fields:
+    - command
+    - args
+    - workingDir
+  - name: Ports
+    fields:
+    - ports
+  - name: Environment variables
+    fields:
+    - env
+    - envFrom
+  - name: Volumes
+    fields:
+    - volumeMounts
+    - volumeDevices
+  - name: Resources
+    fields:
+    - resources
+  - name: Lifecycle
+    fields:
+    - lifecycle
+    - terminationMessagePath
+    - terminationMessagePolicy
+    - livenessProbe
+    - readinessProbe
+  - name: Security Context
+    fields:
+    - securityContext
+  - name: Debugging
+    fields:
+    - stdin
+    - stdinOnce
+    - tty
+  - name: Beta level
+    fields:
+    - startupProbe
+
+- definition: io.k8s.api.core.v1.Probe
+  field_categories:
+  - fields:
+    - exec
+    - httpGet
+    - tcpSocket
+    - initialDelaySeconds
+    - periodSeconds
+    - timeoutSeconds
+    - failureThreshold
+    - successThreshold
+
+- definition: io.k8s.api.core.v1.SecurityContext
+  field_categories:
+  - fields:
+    - runAsUser
+    - runAsNonRoot
+    - runAsGroup
+    - readOnlyRootFilesystem
+    - procMount
+    - privileged
+    - allowPrivilegeEscalation
+    - capabilities
+    - seccompProfile
+    - seLinuxOptions
+    - windowsOptions
+
+- definition: io.k8s.api.core.v1.ContainerStatus
+  field_categories:
+  - fields:
+    - name
+    - image
+    - imageID
+    - containerID
+    - state
+    - lastState
+    - ready
+    - restartCount
+    - started
+
+- definition: io.k8s.api.core.v1.ContainerStateTerminated
+  field_categories:
+  - fields:
+    - containerID
+    - exitCode
+    - startedAt
+    - finishedAt
+    - message
+    - reason
+    - signal
+
+- definition: io.k8s.api.core.v1.EphemeralContainer
+  field_categories:
+  - fields:
+    - name
+    - targetContainerName
+  - name: Image
+    fields:
+    - image
+    - imagePullPolicy
+  - name: Entrypoint
+    fields:
+    - command
+    - args
+    - workingDir
+  - name: Environment variables
+    fields:
+    - env
+    - envFrom
+  - name: Volumes
+    fields:
+    - volumeMounts
+    - volumeDevices
+  - name: Lifecycle
+    fields:
+    - terminationMessagePath
+    - terminationMessagePolicy
+  - name: Debugging
+    fields:
+    - stdin
+    - stdinOnce
+    - tty
+  - name: Not allowed
+    fields:
+    - ports
+    - resources
+    - lifecycle
+    - livenessProbe
+    - readinessProbe
+    - securityContext
+    - startupProbe
+
+- definition: io.k8s.api.core.v1.ReplicationControllerSpec
+  field_categories:
+  - fields:
+    - selector
+    - template
+    - replicas
+    - minReadySeconds
+
+- definition: io.k8s.api.core.v1.ReplicationControllerStatus
+  field_categories:
+  - fields:
+    - replicas
+    - availableReplicas
+    - readyReplicas
+    - fullyLabeledReplicas
+    - conditions
+    - observedGeneration
+
+- definition: io.k8s.api.apps.v1.ReplicaSetSpec
+  field_categories:
+  - fields:
+    - selector
+    - template
+    - replicas
+    - minReadySeconds
+
+- definition: io.k8s.api.apps.v1.ReplicaSetStatus
+  field_categories:
+  - fields:
+    - replicas
+    - availableReplicas
+    - readyReplicas
+    - fullyLabeledReplicas
+    - conditions
+    - observedGeneration
+
+- definition: io.k8s.api.apps.v1.DeploymentSpec
+  field_categories:
+  - fields:
+    - selector
+    - template
+    - replicas
+    - minReadySeconds
+    - strategy
+    - revisionHistoryLimit
+    - progressDeadlineSeconds
+    - paused
+
+- definition: io.k8s.api.apps.v1.DeploymentStatus
+  field_categories:
+  - fields:
+    - replicas
+    - availableReplicas
+    - readyReplicas
+    - unavailableReplicas
+    - updatedReplicas
+    - collisionCount
+    - conditions
+    - observedGeneration
+
+- definition: io.k8s.api.apps.v1.DeploymentStrategy
+  field_categories:
+  - fields:
+    - type
+    - rollingUpdate
+
+- definition: io.k8s.api.apps.v1.StatefulSetSpec
+  field_categories:
+  - fields:
+    - serviceName
+    - selector
+    - template
+    - replicas
+    - updateStrategy
+    - podManagementPolicy
+    - revisionHistoryLimit
+    - volumeClaimTemplates
+
+- definition: io.k8s.api.apps.v1.StatefulSetUpdateStrategy
+  field_categories:
+  - fields:
+    - type
+    - rollingUpdate
+
+- definition: io.k8s.api.apps.v1.StatefulSetStatus
+  field_categories:
+  - fields:
+    - replicas
+    - readyReplicas
+    - currentReplicas
+    - updatedReplicas
+    - collisionCount
+    - conditions
+    - currentRevision
+    - updateRevision
+    - observedGeneration
+
+- definition: io.k8s.api.apps.v1.DaemonSetSpec
+  field_categories:
+  - fields:
+    - selector
+    - template
+    - minReadySeconds
+    - updateStrategy
+    - revisionHistoryLimit
+
+- definition: io.k8s.api.apps.v1.DaemonSetUpdateStrategy
+  field_categories:
+  - fields:
+    - type
+    - rollingUpdate
+
+- definition: io.k8s.api.apps.v1.DaemonSetStatus
+  field_categories:
+  - fields:
+    - numberReady
+    - numberAvailable
+    - numberUnavailable
+    - numberMisscheduled
+    - desiredNumberScheduled
+    - currentNumberScheduled
+    - updatedNumberScheduled
+    - collisionCount
+    - conditions
+    - observedGeneration
+
+- definition: io.k8s.api.batch.v1.JobSpec
+  field_categories:
+  - name: Replicas
+    fields:
+    - template
+    - parallelism
+  - name: Lifecycle
+    fields:
+    - completions
+    - backoffLimit
+    - activeDeadlineSeconds
+    - ttlSecondsAfterFinished
+  - name: Selector
+    fields:
+    - selector
+    - manualSelector
+
+- definition: io.k8s.api.batch.v1.JobStatus
+  field_categories:
+  - fields:
+    - startTime
+    - completionTime
+    - active
+    - failed
+    - succeeded
+    - conditions
+
+- definition: io.k8s.api.batch.v1beta1.CronJobSpec
+  field_categories:
+  - fields:
+    - jobTemplate
+    - schedule
+    - concurrencyPolicy
+    - startingDeadlineSeconds
+    - suspend
+    - successfulJobsHistoryLimit
+    - failedJobsHistoryLimit
+
+- definition: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec
+  field_categories:
+  - fields:
+    - maxReplicas
+    - scaleTargetRef
+    - minReplicas
+    - behavior
+    - metrics
+
+- definition: io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy
+  field_categories:
+  - fields:
+    - type
+    - value
+    - periodSeconds
+
+- definition: io.k8s.api.core.v1.ServiceSpec
+  field_categories:
+  - fields:
+    - selector
+    - ports
+    - type
+    - ipFamilies
+    - ipFamilyPolicy
+    - clusterIP
+    - clusterIPs
+    - externalIPs
+    - sessionAffinity
+    - loadBalancerIP
+    - loadBalancerSourceRanges
+    - externalName
+    - externalTrafficPolicy
+    - healthCheckNodePort
+    - publishNotReadyAddresses
+    - sessionAffinityConfig
+    - topologyKeys
+    - allocateLoadBalancerNodePorts
+
+- definition: io.k8s.api.core.v1.ServicePort
+  field_categories:
+  - fields:
+    - port
+    - targetPort
+    - protocol
+    - name
+    - nodePort
+    - appProtocol
+
+- definition: io.k8s.api.core.v1.EndpointSubset
+  field_categories:
+  - fields:
+    - addresses
+    - notReadyAddresses
+    - ports
+
+- definition: io.k8s.api.core.v1.EndpointPort
+  field_categories:
+  - fields:
+    - port
+    - protocol
+    - name
+    - appProtocol
+
+- definition: io.k8s.api.discovery.v1beta1.EndpointPort
+  field_categories:
+  - fields:
+    - port
+    - protocol
+    - name
+    - appProtocol
+
+- definition: io.k8s.api.core.v1.Volume
+  field_categories:
+  - fields:
+    - name
+  - name: Exposed Persistent volumes
+    fields:
+    - persistentVolumeClaim
+  - name: Projections
+    fields:
+    - configMap
+    - secret
+    - downwardAPI
+    - projected
+  - name: Local / Temporary Directory
+    fields:
+    - emptyDir
+    - hostPath
+  - name: Persistent volumes
+    fields:
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - cephfs
+    - cinder
+    - fc
+    - flexVolume
+    - flocker
+    - gcePersistentDisk
+    - glusterfs
+    - iscsi
+    - nfs
+    - photonPersistentDisk
+    - portworxVolume
+    - quobyte
+    - rbd
+    - scaleIO
+    - storageos
+    - vsphereVolume
+  - name: Beta level
+    fields:
+    - csi
+  - name: Alpha level
+    fields:
+    - ephemeral
+  - name: Deprecated
+    fields:
+    - gitRepo
+
+- definition: io.k8s.api.core.v1.ConfigMapVolumeSource
+  field_categories:
+  - fields:
+    - name
+    - optional
+    - defaultMode
+    - items
+
+- definition: io.k8s.api.core.v1.SecretVolumeSource
+  field_categories:
+  - fields:
+    - secretName
+    - optional
+    - defaultMode
+    - items
+
+- definition: io.k8s.api.core.v1.ConfigMapProjection
+  field_categories:
+  - fields:
+    - name
+    - optional
+    - items
+
+- definition: io.k8s.api.core.v1.SecretProjection
+  field_categories:
+  - fields:
+    - name
+    - optional
+    - items
+
+- definition: io.k8s.api.core.v1.ProjectedVolumeSource
+  field_categories:
+  - fields:
+    - defaultMode
+    - sources
+
+- definition: io.k8s.api.core.v1.PersistentVolumeClaimSpec
+  field_categories:
+  - fields:
+    - accessModes
+    - selector
+    - resources
+    - volumeName
+    - storageClassName
+    - volumeMode
+  - name: Alpha level
+    fields:
+    - dataSource
+
+- definition: io.k8s.api.core.v1.PersistentVolumeSpec
+  field_categories:
+  - fields:
+    - accessModes
+    - capacity
+    - claimRef
+    - mountOptions
+    - nodeAffinity
+    - persistentVolumeReclaimPolicy
+    - storageClassName
+    - volumeMode
+  - name: Local
+    fields:
+    - hostPath
+    - local
+  - name: Persistent volumes
+    fields:
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - cephfs
+    - cinder
+    - fc
+    - flexVolume
+    - flocker
+    - gcePersistentDisk
+    - glusterfs
+    - iscsi
+    - nfs
+    - photonPersistentDisk
+    - portworxVolume
+    - quobyte
+    - rbd
+    - scaleIO
+    - storageos
+    - vsphereVolume
+  - name: Beta level
+    fields:
+    - csi
+
+- definition: io.k8s.api.rbac.v1.PolicyRule
+  field_categories:
+  - fields:
+    - apiGroups
+    - resources
+    - verbs
+    - resourceNames
+    - nonResourceURLs
+
+- definition: io.k8s.api.networking.v1.NetworkPolicySpec
+  field_categories:
+  - fields:
+    - podSelector
+    - policyTypes
+    - ingress
+    - egress
+
+- definition: io.k8s.api.networking.v1.NetworkPolicyEgressRule
+  field_categories:
+  - fields:
+    - to
+    - ports
+
+- definition: io.k8s.api.networking.v1.NetworkPolicyPort
+  field_categories:
+  - fields:
+    - port
+    - endPort
+    - protocol
+
+- definition: io.k8s.api.policy.v1beta1.PodSecurityPolicySpec
+  field_categories:
+  - fields:
+    - runAsUser
+    - runAsGroup
+    - fsGroup
+    - supplementalGroups
+    - seLinux
+    - readOnlyRootFilesystem
+    - privileged
+    - allowPrivilegeEscalation
+    - defaultAllowPrivilegeEscalation
+    - allowedCSIDrivers
+    - allowedCapabilities
+    - requiredDropCapabilities
+    - defaultAddCapabilities
+    - allowedFlexVolumes
+    - allowedHostPaths
+    - allowedProcMountTypes
+    - allowedUnsafeSysctls
+    - forbiddenSysctls
+    - hostIPC
+    - hostNetwork
+    - hostPID
+    - hostPorts
+    - runtimeClass
+    - volumes
+
+- definition: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+  field_categories:
+  - fields:
+    - name
+    - generateName
+    - namespace
+    - labels
+    - annotations
+  - name: System
+    fields:
+    - finalizers
+    - managedFields
+    - ownerReferences
+  - name: Read-only
+    fields:
+    - creationTimestamp
+    - deletionGracePeriodSeconds
+    - deletionTimestamp
+    - generation
+    - resourceVersion
+    - selfLink
+    - uid
+  - name: Ignored
+    fields:
+    - clusterName

--- a/gen-resourcesdocs/config/v1.21/fields.yaml
+++ b/gen-resourcesdocs/config/v1.21/fields.yaml
@@ -391,7 +391,7 @@
     - completedIndexes
     - conditions
 
-- definition: io.k8s.api.batch.v1beta1.CronJobSpec
+- definition: io.k8s.api.batch.v1.CronJobSpec
   field_categories:
   - fields:
     - jobTemplate
@@ -466,7 +466,7 @@
     - name
     - appProtocol
 
-- definition: io.k8s.api.discovery.v1beta1.EndpointPort
+- definition: io.k8s.api.discovery.v1.EndpointPort
   field_categories:
   - fields:
     - port

--- a/gen-resourcesdocs/config/v1.21/fields.yaml
+++ b/gen-resourcesdocs/config/v1.21/fields.yaml
@@ -19,6 +19,7 @@
     - runtimeClassName
     - priorityClassName
     - priority
+    - topologySpreadConstraints
   - name: Lifecycle
     fields:
     - restartPolicy
@@ -48,12 +49,11 @@
     - securityContext
   - name: Beta level
     fields:
+    - preemptionPolicy
     - overhead
-    - topologySpreadConstraints
   - name: Alpha level
     fields:
     - ephemeralContainers
-    - preemptionPolicy
   - name: Deprecated
     fields:
     - serviceAccount
@@ -132,6 +132,7 @@
     - terminationMessagePolicy
     - livenessProbe
     - readinessProbe
+    - startupProbe
   - name: Security Context
     fields:
     - securityContext
@@ -140,9 +141,6 @@
     - stdin
     - stdinOnce
     - tty
-  - name: Beta level
-    fields:
-    - startupProbe
 
 - definition: io.k8s.api.core.v1.Probe
   field_categories:
@@ -501,6 +499,7 @@
     - azureFile
     - cephfs
     - cinder
+    - csi
     - fc
     - flexVolume
     - flocker
@@ -515,9 +514,6 @@
     - scaleIO
     - storageos
     - vsphereVolume
-  - name: Beta level
-    fields:
-    - csi
   - name: Alpha level
     fields:
     - ephemeral
@@ -596,6 +592,7 @@
     - azureFile
     - cephfs
     - cinder
+    - csi
     - fc
     - flexVolume
     - flocker
@@ -610,9 +607,6 @@
     - scaleIO
     - storageos
     - vsphereVolume
-  - name: Beta level
-    fields:
-    - csi
 
 - definition: io.k8s.api.rbac.v1.PolicyRule
   field_categories:

--- a/gen-resourcesdocs/config/v1.21/toc.yaml
+++ b/gen-resourcesdocs/config/v1.21/toc.yaml
@@ -1,0 +1,274 @@
+# Copyright 2016 The Kubernetes Authors.
+# Copyright 2020 Philippe Martin
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+parts:
+- name: Workloads Resources
+  chapters:
+  - name: Pod
+    group: ""
+    version: v1
+    otherDefinitions:
+    - PodSpec
+    - Container
+    - Handler
+    - NodeAffinity
+    - PodAffinity
+    - PodAntiAffinity
+    - Probe
+    - PodStatus
+    - PodList
+  - name: EphemeralContainers
+    group: ""
+    version: v1
+    otherDefinitions:
+    - EphemeralContainer
+  - name: PodTemplate
+    group: ""
+    version: v1
+  - name: ReplicationController
+    group: ""
+    version: v1
+  - name: ReplicaSet
+    group: apps
+    version: v1
+  - name: Deployment
+    group: apps
+    version: v1
+  - name: StatefulSet
+    group: apps
+    version: v1
+  - name: ControllerRevision
+    group: apps
+    version: v1
+  - name: DaemonSet
+    group: apps
+    version: v1
+  - name: Job
+    group: batch
+    version: v1
+  - name: CronJob
+    group: batch
+    version: v1beta1
+  - name: CronJob
+    group: batch
+    version: v2alpha1
+  - name: HorizontalPodAutoscaler
+    group: autoscaling
+    version: v1
+  - name: HorizontalPodAutoscaler
+    group: autoscaling
+    version: v2beta2
+  - name: PriorityClass
+    group: scheduling.k8s.io
+    version: v1
+- name: Services Resources
+  chapters:
+  - name: Service
+    group: ""
+    version: v1
+  - name: Endpoints
+    group: ""
+    version: v1
+  - name: EndpointSlice
+    group: discovery.k8s.io
+    version: v1beta1
+  - name: Ingress
+    group: networking.k8s.io
+    version: v1
+    otherDefinitions:
+    - IngressSpec
+    - IngressBackend
+    - IngressStatus
+    - IngressList
+  - name: IngressClass
+    group: networking.k8s.io
+    version: v1
+- name: Config and Storage Resources
+  chapters:
+  - name: ConfigMap
+    group: ""
+    version: v1
+  - name: Secret
+    group: ""
+    version: v1
+  - name: Volume
+    key: io.k8s.api.core.v1.Volume
+    otherDefinitions:
+    - DownwardAPIVolumeFile
+    - KeyToPath
+  - name: PersistentVolumeClaim
+    group: ""
+    version: v1
+  - name: PersistentVolume
+    group: ""
+    version: v1
+  - name: StorageClass
+    group: storage.k8s.io
+    version: v1
+  - name: VolumeAttachment
+    group: storage.k8s.io
+    version: v1
+  - name: CSIDriver
+    group: storage.k8s.io
+    version: v1
+  - name: CSINode
+    group: storage.k8s.io
+    version: v1
+  - name: CSIStorageCapacity
+    group: storage.k8s.io
+    version: v1alpha1
+- name: Authentication Resources
+  chapters:
+  - name: ServiceAccount
+    group: ""
+    version: v1
+  - name: TokenRequest
+    group: authentication.k8s.io
+    version: v1
+  - name: TokenReview
+    group: authentication.k8s.io
+    version: v1
+  - name: CertificateSigningRequest
+    group: certificates.k8s.io
+    version: v1
+- name: Authorization Resources
+  chapters:
+  - name: LocalSubjectAccessReview
+    group: authorization.k8s.io
+    version: v1
+  - name: SelfSubjectAccessReview
+    group: authorization.k8s.io
+    version: v1
+  - name: SelfSubjectRulesReview
+    group: authorization.k8s.io
+    version: v1
+  - name: SubjectAccessReview
+    group: authorization.k8s.io
+    version: v1
+  - name: ClusterRole
+    group: rbac.authorization.k8s.io
+    version: v1
+  - name: ClusterRoleBinding
+    group: rbac.authorization.k8s.io
+    version: v1
+  - name: Role
+    group: rbac.authorization.k8s.io
+    version: v1
+  - name: RoleBinding
+    group: rbac.authorization.k8s.io
+    version: v1
+- name: Policies Resources
+  chapters:
+  - name: LimitRange
+    group: ""
+    version: v1
+  - name: ResourceQuota
+    group: ""
+    version: v1
+  - name: NetworkPolicy
+    group: networking.k8s.io
+    version: v1
+  - name: PodDisruptionBudget
+    group: policy
+    version: v1beta1
+  - name: PodSecurityPolicy
+    group: policy
+    version: v1beta1
+- name: Extend Resources
+  chapters:
+  - name: CustomResourceDefinition
+    group: apiextensions.k8s.io
+    version: v1
+    otherDefinitions:
+    - CustomResourceDefinitionSpec
+    - JSONSchemaProps
+    - CustomResourceDefinitionStatus
+    - CustomResourceDefinitionList
+  - name: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    version: v1
+  - name: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    version: v1
+- name: Cluster Resources
+  chapters:
+  - name: Node
+    group: ""
+    version: v1
+  - name: Namespace
+    group: ""
+    version: v1
+  - name: Event
+    group: events.k8s.io
+    version: v1
+  - name: APIService
+    group: apiregistration.k8s.io
+    version: v1
+  - name: Lease
+    group: coordination.k8s.io
+    version: v1
+  - name: RuntimeClass
+    group: node.k8s.io
+    version: v1
+  - name: FlowSchema
+    group: flowcontrol.apiserver.k8s.io
+    version: v1beta1
+  - name: PriorityLevelConfiguration
+    group: flowcontrol.apiserver.k8s.io
+    version: v1beta1
+  - name: Binding
+    group: ""
+    version: v1
+  - name: ComponentStatus
+    group: ""
+    version: v1
+- name: Common Definitions
+  chapters:
+  - name: DeleteOptions
+    key: io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions
+  - name: LabelSelector
+    key: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+  - name: ListMeta
+    key: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+  - name: LocalObjectReference
+    key: io.k8s.api.core.v1.LocalObjectReference
+  - name: NodeSelectorRequirement
+    key: io.k8s.api.core.v1.NodeSelectorRequirement
+  - name: ObjectFieldSelector
+    key: io.k8s.api.core.v1.ObjectFieldSelector
+  - name: ObjectMeta
+    key: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+  - name: ObjectReference
+    key: io.k8s.api.core.v1.ObjectReference
+  - name: Patch
+    key: io.k8s.apimachinery.pkg.apis.meta.v1.Patch
+  - name: Quantity
+    key: "io.k8s.apimachinery.pkg.api.resource.Quantity"
+  - name: ResourceFieldSelector
+    key: io.k8s.api.core.v1.ResourceFieldSelector
+  - name: Status
+    key: io.k8s.apimachinery.pkg.apis.meta.v1.Status
+  - name: TypedLocalObjectReference
+    key: io.k8s.api.core.v1.TypedLocalObjectReference
+skippedResources:
+- APIGroup
+- APIGroupList
+- APIResourceList
+- APIVersions
+- Eviction
+- Scale
+- Status
+- StorageVersion
+- StorageVersionList

--- a/gen-resourcesdocs/config/v1.21/toc.yaml
+++ b/gen-resourcesdocs/config/v1.21/toc.yaml
@@ -60,7 +60,7 @@ parts:
     version: v1
   - name: CronJob
     group: batch
-    version: v1beta1
+    version: v1
   - name: HorizontalPodAutoscaler
     group: autoscaling
     version: v1
@@ -80,7 +80,7 @@ parts:
     version: v1
   - name: EndpointSlice
     group: discovery.k8s.io
-    version: v1beta1
+    version: v1
   - name: Ingress
     group: networking.k8s.io
     version: v1

--- a/gen-resourcesdocs/config/v1.21/toc.yaml
+++ b/gen-resourcesdocs/config/v1.21/toc.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 parts:
-- name: Workloads Resources
+- name: Workload Resources
   chapters:
   - name: Pod
     group: ""
@@ -70,7 +70,7 @@ parts:
   - name: PriorityClass
     group: scheduling.k8s.io
     version: v1
-- name: Services Resources
+- name: Service Resources
   chapters:
   - name: Service
     group: ""
@@ -166,7 +166,7 @@ parts:
   - name: RoleBinding
     group: rbac.authorization.k8s.io
     version: v1
-- name: Policies Resources
+- name: Policy Resources
   chapters:
   - name: LimitRange
     group: ""

--- a/gen-resourcesdocs/config/v1.21/toc.yaml
+++ b/gen-resourcesdocs/config/v1.21/toc.yaml
@@ -125,7 +125,7 @@ parts:
     version: v1
   - name: CSIStorageCapacity
     group: storage.k8s.io
-    version: v1alpha1
+    version: v1beta1
 - name: Authentication Resources
   chapters:
   - name: ServiceAccount
@@ -179,7 +179,7 @@ parts:
     version: v1
   - name: PodDisruptionBudget
     group: policy
-    version: v1beta1
+    version: v1
   - name: PodSecurityPolicy
     group: policy
     version: v1beta1

--- a/gen-resourcesdocs/config/v1.21/toc.yaml
+++ b/gen-resourcesdocs/config/v1.21/toc.yaml
@@ -61,9 +61,6 @@ parts:
   - name: CronJob
     group: batch
     version: v1beta1
-  - name: CronJob
-    group: batch
-    version: v2alpha1
   - name: HorizontalPodAutoscaler
     group: autoscaling
     version: v1

--- a/gen-resourcesdocs/pkg/config/output.go
+++ b/gen-resourcesdocs/pkg/config/output.go
@@ -168,7 +168,7 @@ func (o *TOC) OutputProperties(defname string, definition spec.Schema, outputSec
 				} else if name == "kind" {
 					property = kubernetes.NewHardCodedValueProperty(name, defname)
 				}
-				err := outputSection.AddProperty(name, property, []string{}, false, defname, name)
+				err := outputSection.AddProperty(name, property, []string{}, 0, defname, name)
 				if err != nil {
 					return err
 				}
@@ -186,7 +186,7 @@ func (o *TOC) OutputProperties(defname string, definition spec.Schema, outputSec
 			}
 			completeName := prefix
 			completeName = append(completeName, name)
-			err = outputSection.AddProperty(strings.Join(completeName, "."), property, linkend, len(prefix) > 0, defname, name)
+			err = outputSection.AddProperty(strings.Join(completeName, "."), property, linkend, len(prefix), defname, name)
 			if err != nil {
 				return err
 			}

--- a/gen-resourcesdocs/pkg/outputs/interface.go
+++ b/gen-resourcesdocs/pkg/outputs/interface.go
@@ -28,7 +28,7 @@ type Section interface {
 	AddTypeDefinition(typ string, description string) error
 	StartPropertyList() error
 	AddFieldCategory(name string) error
-	AddProperty(name string, property *kubernetes.Property, linkend []string, indent bool, defname string, shortName string) error
+	AddProperty(name string, property *kubernetes.Property, linkend []string, indent int, defname string, shortName string) error
 	EndProperty() error
 	EndPropertyList() error
 	AddOperation(operation *kubernetes.ActionInfo, linkends kubernetes.LinkEnds) error

--- a/gen-resourcesdocs/pkg/outputs/kwebsite/section.go
+++ b/gen-resourcesdocs/pkg/outputs/kwebsite/section.go
@@ -53,7 +53,7 @@ func (o Section) AddFieldCategory(name string) error {
 }
 
 // AddProperty adds a property to the section
-func (o Section) AddProperty(name string, property *kubernetes.Property, linkend []string, indent bool, defname string, shortName string) error {
+func (o Section) AddProperty(name string, property *kubernetes.Property, linkend []string, indent int, defname string, shortName string) error {
 	if property.HardCodedValue != nil {
 		i := len(o.chapter.data.Sections)
 		cats := o.chapter.data.Sections[i-1].FieldCategories
@@ -71,10 +71,6 @@ func (o Section) AddProperty(name string, property *kubernetes.Property, linkend
 		return nil
 	}
 
-	indentLevel := 0
-	if indent {
-		indentLevel++
-	}
 	required := ""
 	if property.Required {
 		required = ", required"
@@ -130,8 +126,11 @@ func (o Section) AddProperty(name string, property *kubernetes.Property, linkend
 	*fields = append(*fields, FieldData{
 		Name:        title,
 		Description: description,
-		Indent:      indentLevel,
+		Indent:      indent,
 	})
+	if indent > 3 {
+		fmt.Printf("Warning: %s/%s indentation is %d\n", o.chapter.name, name, indent)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Preview at https://deploy-preview-26413--kubernetes-io-master-staging.netlify.app/docs/reference/kubernetes-api/

# Local common definitions in the same page of the resource

Add the possibility (from the toc.yaml file) to display Definitions at the same level of the Resources, instead of placing the Definitions in the Common Definitions section.

For example, the Pod page now displays Container, Handler, NodeAffinity, PodAffinity, PodAntiAffinity, Probe definitions at the same level as Pod and PodSpec definitions.

This is useful when these definitions are used in different places of definitions, but only on a single page. For example, Handler is used in lifecycle.postStart and lifecycle.preStop of the Container definition.

By default, using this in the toc.yaml file:

```
  - name: Deployment
    group: apps
    version: v1
```

will display Deployment, DeploymentSpec, DeploymentStatus and DeploymentList in the page. The sub-definitions of these definitions will be displayed inline.

If you want to personalize the definitions to display at the top level, you can use:
```
  - name: Pod
    group: ""
    version: v1
    otherDefinitions:
    - PodSpec
    - Container
    - Handler
    - NodeAffinity
    - PodAffinity
    - PodAntiAffinity
    - Probe
    - PodStatus
    - PodList
```

When a definition is displayed this way, the definition won't be displayed inline anymore.

# Deep indentation

In previous versions, the indentation of subfields if definitions were not recursive and was stopped after the first indentation, to avoid indentation hell (rememder LISP?) 

This version enables indentation of any number of levels, but a warning message is added to try to avoid too much deep indentation.
