### PR TITLE
Use consistent pluralization for API groupings in reference

### DIFF
--- a/gen-resourcesdocs/config/v1.20/toc.yaml
+++ b/gen-resourcesdocs/config/v1.20/toc.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 parts:
-- name: Workloads Resources
+- name: Workload Resources
   chapters:
   - name: Pod
     group: ""
@@ -62,7 +62,7 @@ parts:
   - name: PriorityClass
     group: scheduling.k8s.io
     version: v1
-- name: Services Resources
+- name: Service Resources
   chapters:
   - name: Service
     group: ""
@@ -147,7 +147,7 @@ parts:
   - name: RoleBinding
     group: rbac.authorization.k8s.io
     version: v1
-- name: Policies Resources
+- name: Policy Resources
   chapters:
   - name: LimitRange
     group: ""


### PR DESCRIPTION
Fixes https://github.com/kubernetes/website/issues/26361

The result can be seen at https://github.com/kubernetes/website/pull/26481