### PR TITLE
Add outputs from genref tool

### DIFF
--- a/genref/config.yaml
+++ b/genref/config.yaml
@@ -38,6 +38,8 @@ apis:
     title: Kubelet Stats (v1alpha1)
     package: k8s.io/kubelet
     path: pkg/apis/stats/v1alpha1
+    # Skip this because not referenced anywhere and it has no group name
+    skip: true
 
   - name: kube-scheduler-config
     title: kube-scheduler Configuration (v1beta1)
@@ -69,6 +71,8 @@ apis:
     title: Kubernetes Metrics (v1alpha1)
     package: k8s.io/metrics
     path: pkg/apis/metrics/v1alpha1
+    # superceded by v1beta1 version
+    skip: true
 
   - name: metrics
     title: Kubernetes Metrics (v1alpha1)
@@ -79,6 +83,8 @@ apis:
     title: Client Authentication (v1alpha1)
     package: k8s.io/client-go
     path: pkg/apis/clientauthentication/v1alpha1
+    # superceded by v1beta1
+    skip: true
 
   - name: client-authentication
     title: Client Authentication (v1beta1)

--- a/genref/markdown/members.tpl
+++ b/genref/markdown/members.tpl
@@ -4,21 +4,21 @@
   {{- range .GetMembers -}}
     {{/* . is a apiMember */}}
     {{- if not .Hidden }}
-<tr><td><samp>{{ .FieldName }}</samp>
+<tr><td><code>{{ .FieldName }}</code>
       {{- if not .IsOptional }} <B>[Required]</B>{{- end -}}
 <br/>
 {{/* Link for type reference */}}
       {{- with .GetType -}}
         {{- if .Link -}}
-<a href="{{ .Link }}"><samp>{{ .DisplayName }}</samp></a>
+<a href="{{ .Link }}"><code>{{ .DisplayName }}</code></a>
         {{- else -}}
-<samp>{{ .DisplayName }}</samp>
+<code>{{ .DisplayName }}</code>
         {{- end -}}
       {{- end }}
 </td>
 <td>
    {{- if .IsInline -}}
-(Members of <samp>{{ .FieldName }}</samp> are embedded into this type.)
+(Members of <code>{{ .FieldName }}</code> are embedded into this type.)
    {{- end }}
    {{ if .GetComment -}}
    {{ .GetComment }}
@@ -26,7 +26,7 @@
    <span class="text-muted">No description provided.</span>
    {{ end }}
    {{- if and (eq (.GetType.Name.Name) "ObjectMeta") -}}
-Refer to the Kubernetes API documentation for the fields of the <samp>metadata</samp> field.
+Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.
    {{- end -}}
 </td>
 </tr>

--- a/genref/markdown/pkg.tpl
+++ b/genref/markdown/pkg.tpl
@@ -1,24 +1,25 @@
 {{ define "packages" -}}
 
+{{ $grpname := "" -}}
 {{- range $idx, $val := .packages -}}
-{{/* Only display package that has a group name */}}
-{{- if and (ne .GroupName "") (eq $idx 0) -}}
+{{- if and (ne .GroupName "") (eq $grpname "") -}}
 ---
 title: {{ .Title }}
 content_type: tool-reference
 package: {{ .DisplayName }}
 auto_generated: true
 ---
-{{ .GetComment }}
+{{ .GetComment -}}
+{{ $grpname = .GroupName }}
 {{- end -}}
 {{- end }}
 
 ## Resource Types 
 
-{{ range .packages }}
-  {{ if ne .GroupName "" -}}
+{{ range .packages -}}
+  {{- if ne .GroupName "" -}}
     {{- range .VisibleTypes -}}
-      {{ if .IsExported }}
+      {{- if .IsExported }}
 - [{{ .DisplayName }}]({{ .Link }})
       {{- end -}}
     {{- end -}}

--- a/genref/markdown/type.tpl
+++ b/genref/markdown/type.tpl
@@ -24,8 +24,8 @@
     {{/* . is a apiType */}}
     {{- if .IsExported -}}
 {{/* Add apiVersion and kind rows if deemed necessary */}}
-<tr><td><samp>apiVersion</samp><br/>string</td><td><samp>{{- .APIGroup -}}</samp></td></tr>
-<tr><td><samp>kind</samp><br/>string</td><td><samp>{{- .Name.Name -}}</samp></td></tr>
+<tr><td><code>apiVersion</code><br/>string</td><td><code>{{- .APIGroup -}}</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>{{- .Name.Name -}}</code></td></tr>
     {{ end -}}
 
 {{/* The actual list of members is in the following template */}}

--- a/genref/output/html/apiserver-audit.v1.html
+++ b/genref/output/html/apiserver-audit.v1.html
@@ -1,0 +1,1594 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="audit-k8s-io-v1">Package: <span style="font-family: monospace">audit.k8s.io/v1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#audit-k8s-io-v1-Event">Event</a>
+                  </li><li>
+                    <a href="#audit-k8s-io-v1-EventList">EventList</a>
+                  </li><li>
+                    <a href="#audit-k8s-io-v1-Policy">Policy</a>
+                  </li><li>
+                    <a href="#audit-k8s-io-v1-PolicyList">PolicyList</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="audit-k8s-io-v1-Event">Event
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#audit-k8s-io-v1-EventList">EventList</a>)
+    </p>
+  
+
+  <p>Event captures all the information that can be included in an API audit log.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>audit.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>Event</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>level</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-Level">
+                <span style="font-family: monospace">Level</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          AuditLevel at which event was generated
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>auditID</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/types#UID">
+                <span style="font-family: monospace">k8s.io/apimachinery/pkg/types.UID</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Unique audit ID, generated for each request.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>stage</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-Stage">
+                <span style="font-family: monospace">Stage</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Stage of the request handling when this event instance was generated.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>requestURI</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          RequestURI is the request URI as sent by the client to a server.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>verb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb is the kubernetes verb associated with the request.
+For non-resource requests, this is the lower-cased HTTP method.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>user</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#userinfo-v1-authentication">
+                <span style="font-family: monospace">authentication/v1.UserInfo</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Authenticated user information.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>impersonatedUser</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#userinfo-v1-authentication">
+                <span style="font-family: monospace">authentication/v1.UserInfo</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Impersonated user information.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>sourceIPs</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Source IPs, from where the request originated and intermediate proxies.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>userAgent</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          UserAgent records the user agent string reported by the client.
+Note that the UserAgent is provided by the client, and must not be trusted.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>objectRef</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-ObjectReference">
+                <span style="font-family: monospace">ObjectReference</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Object reference this request is targeted at.
+Does not apply for List-type requests, or non-resource requests.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>responseStatus</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#status-v1-meta">
+                <span style="font-family: monospace">meta/v1.Status</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The response status, populated even when the ResponseObject is not a Status type.
+For successful responses, this will only include the Code and StatusSuccess.
+For non-status type error responses, this will be auto-populated with the error Message.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>requestObject</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown">
+                <span style="font-family: monospace">k8s.io/apimachinery/pkg/runtime.Unknown</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          API object from the request, in JSON format. The RequestObject is recorded as-is in the request
+(possibly re-encoded as JSON), prior to version conversion, defaulting, admission or
+merging. It is an external versioned object type, and may not be a valid object on its own.
+Omitted for non-resource requests.  Only logged at Request Level and higher.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>responseObject</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown">
+                <span style="font-family: monospace">k8s.io/apimachinery/pkg/runtime.Unknown</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          API object returned in the response, in JSON. The ResponseObject is recorded after conversion
+to the external type, and serialized as JSON.  Omitted for non-resource requests.  Only logged
+at Response Level.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>requestReceivedTimestamp</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#microtime-v1-meta">
+                <span style="font-family: monospace">meta/v1.MicroTime</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Time the request reached the apiserver.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>stageTimestamp</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#microtime-v1-meta">
+                <span style="font-family: monospace">meta/v1.MicroTime</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Time the request reached current audit stage.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>annotations</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Annotations is an unstructured key value map stored with an audit event that may be set by
+plugins invoked in the request serving chain, including authentication, authorization and
+admission plugins. Note that these annotations are for the audit event, and do not correspond
+to the metadata.annotations of the submitted object. Keys should uniquely identify the informing
+component to avoid name collisions (e.g. podsecuritypolicy.admission.k8s.io/policy). Values
+should be short. Annotations are included in the Metadata level.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="audit-k8s-io-v1-EventList">EventList
+    </H3>
+
+  
+
+  <p>EventList is a list of audit Events.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>audit.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>EventList</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>metadata</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta">
+                <span style="font-family: monospace">meta/v1.ListMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>items</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-Event">
+                <span style="font-family: monospace">[]Event</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="audit-k8s-io-v1-Policy">Policy
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#audit-k8s-io-v1-PolicyList">PolicyList</a>)
+    </p>
+  
+
+  <p>Policy defines the configuration of audit logging, and the rules for how different request
+categories are logged.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>audit.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>Policy</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>metadata</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+                <span style="font-family: monospace">meta/v1.ObjectMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ObjectMeta is included for interoperability with API infrastructure.
+
+          
+            Refer to the Kubernetes API documentation for the fields of the
+            <code>metadata</code> field.
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>rules</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-PolicyRule">
+                <span style="font-family: monospace">[]PolicyRule</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Rules specify the audit Level a request should be recorded at.
+A request may match multiple rules, in which case the FIRST matching rule is used.
+The default audit level is None, but can be overridden by a catch-all rule at the end of the list.
+PolicyRules are strictly ordered.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>omitStages</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-Stage">
+                <span style="font-family: monospace">[]Stage</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          OmitStages is a list of stages for which no events are created. Note that this can also
+be specified per rule in which case the union of both are omitted.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="audit-k8s-io-v1-PolicyList">PolicyList
+    </H3>
+
+  
+
+  <p>PolicyList is a list of audit Policies.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>audit.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>PolicyList</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>metadata</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta">
+                <span style="font-family: monospace">meta/v1.ListMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>items</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-Policy">
+                <span style="font-family: monospace">[]Policy</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="audit-k8s-io-v1-GroupResources">GroupResources
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#audit-k8s-io-v1-PolicyRule">PolicyRule</a>)
+    </p>
+  
+
+  <p>GroupResources represents resource kinds in an API group.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>group</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Group is the name of the API group that contains the resources.
+The empty string represents the core API group.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Resources is a list of resources this rule applies to.
+
+For example:
+'pods' matches pods.
+'pods/log' matches the log subresource of pods.
+'&lowast;' matches all resources and their subresources.
+'pods/&lowast;' matches all subresources of pods.
+'&lowast;/scale' matches all scale subresources.
+
+If wildcard is present, the validation rule will ensure resources do not
+overlap with each other.
+
+An empty list implies all resources and subresources in this API groups apply.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resourceNames</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ResourceNames is a list of resource instance names that the policy matches.
+Using this field requires Resources to be specified.
+An empty list implies that every instance of the resource is matched.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="audit-k8s-io-v1-Level">Level
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#audit-k8s-io-v1-Event">Event</a>, 
+        <a href="#audit-k8s-io-v1-PolicyRule">PolicyRule</a>)
+    </p>
+  
+
+  <p>Level defines the amount of information logged during auditing</p>
+
+  
+
+            
+              
+  <H3 id="audit-k8s-io-v1-ObjectReference">ObjectReference
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#audit-k8s-io-v1-Event">Event</a>)
+    </p>
+  
+
+  <p>ObjectReference contains enough information to let you inspect or modify the referred object.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>resource</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>namespace</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>uid</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/types#UID">
+                <span style="font-family: monospace">k8s.io/apimachinery/pkg/types.UID</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>apiGroup</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          APIGroup is the name of the API group that contains the referred object.
+The empty string represents the core API group.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>apiVersion</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          APIVersion is the version of the API group that contains the referred object.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resourceVersion</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>subresource</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="audit-k8s-io-v1-PolicyRule">PolicyRule
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#audit-k8s-io-v1-Policy">Policy</a>)
+    </p>
+  
+
+  <p>PolicyRule maps requests based off metadata to an audit Level.
+Requests must match the rules of every field (an intersection of rules).</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>level</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-Level">
+                <span style="font-family: monospace">Level</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The Level that requests matching this rule are recorded at.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>users</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The users (by authenticated user name) this rule applies to.
+An empty list implies every user.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>userGroups</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The user groups this rule applies to. A user is considered matching
+if it is a member of any of the UserGroups.
+An empty list implies every user group.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>verbs</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The verbs that match this rule.
+An empty list implies every verb.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-GroupResources">
+                <span style="font-family: monospace">[]GroupResources</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Resources that this rule matches. An empty list implies all kinds in all API groups.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>namespaces</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Namespaces that this rule matches.
+The empty string "" matches non-namespaced resources.
+An empty list implies every namespace.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nonResourceURLs</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          NonResourceURLs is a set of URL paths that should be audited.
+&lowast;s are allowed, but only as the full, final step in the path.
+Examples:
+ "/metrics" - Log requests for apiserver metrics
+ "/healthz&lowast;" - Log all health checks
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>omitStages</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#audit-k8s-io-v1-Stage">
+                <span style="font-family: monospace">[]Stage</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          OmitStages is a list of stages for which no events are created. Note that this can also
+be specified policy wide in which case the union of both are omitted.
+An empty list means no restrictions will apply.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="audit-k8s-io-v1-Stage">Stage
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#audit-k8s-io-v1-Event">Event</a>, 
+        <a href="#audit-k8s-io-v1-Policy">Policy</a>, 
+        <a href="#audit-k8s-io-v1-PolicyRule">PolicyRule</a>)
+    </p>
+  
+
+  <p>Stage defines the stages in request handling that audit events may be generated.</p>
+
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/apiserver-config.v1.html
+++ b/genref/output/html/apiserver-config.v1.html
@@ -1,0 +1,239 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="apiserver-config-k8s-io-v1">Package: <span style="font-family: monospace">apiserver.config.k8s.io/v1</span></H2>
+            <p>Package v1 is the v1 version of the API.</p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#apiserver-config-k8s-io-v1-AdmissionConfiguration">AdmissionConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-AdmissionConfiguration">AdmissionConfiguration
+    </H3>
+
+  
+
+  <p>AdmissionConfiguration provides versioned configuration for admission controllers.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>apiserver.config.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>AdmissionConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>plugins</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-AdmissionPluginConfiguration">
+                <span style="font-family: monospace">[]AdmissionPluginConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Plugins allows specifying a configuration per admission control plugin.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-AdmissionPluginConfiguration">AdmissionPluginConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-AdmissionConfiguration">AdmissionConfiguration</a>)
+    </p>
+  
+
+  <p>AdmissionPluginConfiguration provides the configuration for a single plug-in.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name is the name of the admission controller.
+It must match the registered admission plugin name.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>path</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Path is the path to a configuration file that contains the plugin's
+configuration
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>configuration</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown">
+                <span style="font-family: monospace">k8s.io/apimachinery/pkg/runtime.Unknown</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Configuration is an embedded configuration object to be used as the plugin's
+configuration. If present, it will be used instead of the path to the configuration file.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/apiserver-config.v1beta1.html
+++ b/genref/output/html/apiserver-config.v1beta1.html
@@ -1,0 +1,706 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="apiserver-k8s-io-v1beta1">Package: <span style="font-family: monospace">apiserver.k8s.io/v1beta1</span></H2>
+            <p>Package v1beta1 is the v1beta1 version of the API.</p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration">EgressSelectorConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="apiserver-k8s-io-v1beta1-EgressSelectorConfiguration">EgressSelectorConfiguration
+    </H3>
+
+  
+
+  <p>EgressSelectorConfiguration provides versioned configuration for egress selector clients.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>apiserver.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>EgressSelectorConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>egressSelections</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-k8s-io-v1beta1-EgressSelection">
+                <span style="font-family: monospace">[]EgressSelection</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          connectionServices contains a list of egress selection client configurations
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-k8s-io-v1beta1-Connection">Connection
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-k8s-io-v1beta1-EgressSelection">EgressSelection</a>)
+    </p>
+  
+
+  <p>Connection provides the configuration for a single egress selection client.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>proxyProtocol</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-k8s-io-v1beta1-ProtocolType">
+                <span style="font-family: monospace">ProtocolType</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Protocol is the protocol used to connect from client to the konnectivity server.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>transport</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-k8s-io-v1beta1-Transport">
+                <span style="font-family: monospace">Transport</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Transport defines the transport configurations we use to dial to the konnectivity server.
+This is required if ProxyProtocol is HTTPConnect or GRPC.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-k8s-io-v1beta1-EgressSelection">EgressSelection
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration">EgressSelectorConfiguration</a>)
+    </p>
+  
+
+  <p>EgressSelection provides the configuration for a single egress selection client.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          name is the name of the egress selection.
+Currently supported values are "controlplane", "master", "etcd" and "cluster"
+The "master" egress selector is deprecated in favor of "controlplane"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>connection</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-k8s-io-v1beta1-Connection">
+                <span style="font-family: monospace">Connection</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          connection is the exact information used to configure the egress selection
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-k8s-io-v1beta1-ProtocolType">ProtocolType
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-k8s-io-v1beta1-Connection">Connection</a>)
+    </p>
+  
+
+  <p>ProtocolType is a set of valid values for Connection.ProtocolType</p>
+
+  
+
+            
+              
+  <H3 id="apiserver-k8s-io-v1beta1-TCPTransport">TCPTransport
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-k8s-io-v1beta1-Transport">Transport</a>)
+    </p>
+  
+
+  <p>TCPTransport provides the information to connect to konnectivity server via TCP</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>url</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          URL is the location of the konnectivity server to connect to.
+As an example it might be "https://127.0.0.1:8131"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsConfig</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-k8s-io-v1beta1-TLSConfig">
+                <span style="font-family: monospace">TLSConfig</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          TLSConfig is the config needed to use TLS when connecting to konnectivity server
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-k8s-io-v1beta1-TLSConfig">TLSConfig
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-k8s-io-v1beta1-TCPTransport">TCPTransport</a>)
+    </p>
+  
+
+  <p>TLSConfig provides the authentication information to connect to konnectivity server
+Only used with TCPTransport</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>caBundle</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          caBundle is the file location of the CA to be used to determine trust with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+If absent while TCPTransport.URL is prefixed with https://, default to system trust roots.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clientKey</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clientKey is the file location of the client key to be used in mtls handshakes with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+Must be configured if TCPTransport.URL is prefixed with https://
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clientCert</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clientCert is the file location of the client certificate to be used in mtls handshakes with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+Must be configured if TCPTransport.URL is prefixed with https://
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-k8s-io-v1beta1-Transport">Transport
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-k8s-io-v1beta1-Connection">Connection</a>)
+    </p>
+  
+
+  <p>Transport defines the transport configurations we use to dial to the konnectivity server</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>tcp</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-k8s-io-v1beta1-TCPTransport">
+                <span style="font-family: monospace">TCPTransport</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          TCP is the TCP configuration for communicating with the konnectivity server via TCP
+ProxyProtocol of GRPC is not supported with TCP transport at the moment
+Requires at least one of TCP or UDS to be set
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>uds</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-k8s-io-v1beta1-UDSTransport">
+                <span style="font-family: monospace">UDSTransport</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          UDS is the UDS configuration for communicating with the konnectivity server via UDS
+Requires at least one of TCP or UDS to be set
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-k8s-io-v1beta1-UDSTransport">UDSTransport
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-k8s-io-v1beta1-Transport">Transport</a>)
+    </p>
+  
+
+  <p>UDSTransport provides the information to connect to konnectivity server via UDS</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>udsName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          UDSName is the name of the unix domain socket to connect to konnectivity server
+This does not use a unix:// prefix. (Eg: /etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket)
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/apiserver-encryption.v1.html
+++ b/genref/output/html/apiserver-encryption.v1.html
@@ -1,0 +1,796 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="apiserver-config-k8s-io-v1">Package: <span style="font-family: monospace">apiserver.config.k8s.io/v1</span></H2>
+            <p>Package v1 is the v1 version of the API.</p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#apiserver-config-k8s-io-v1-EncryptionConfiguration">EncryptionConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-EncryptionConfiguration">EncryptionConfiguration
+    </H3>
+
+  
+
+  <p>EncryptionConfiguration stores the complete configuration for encryption providers.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>apiserver.config.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>EncryptionConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-ResourceConfiguration">
+                <span style="font-family: monospace">[]ResourceConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          resources is a list containing resources, and their corresponding encryption providers.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-AESConfiguration">AESConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-ProviderConfiguration">ProviderConfiguration</a>)
+    </p>
+  
+
+  <p>AESConfiguration contains the API configuration for an AES transformer.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>keys</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-Key">
+                <span style="font-family: monospace">[]Key</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          keys is a list of keys to be used for creating the AES transformer.
+Each key has to be 32 bytes long for AES-CBC and 16, 24 or 32 bytes for AES-GCM.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-IdentityConfiguration">IdentityConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-ProviderConfiguration">ProviderConfiguration</a>)
+    </p>
+  
+
+  <p>IdentityConfiguration is an empty struct to allow identity transformer in provider configuration.</p>
+
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-KMSConfiguration">KMSConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-ProviderConfiguration">ProviderConfiguration</a>)
+    </p>
+  
+
+  <p>KMSConfiguration contains the name, cache size and path to configuration file for a KMS based envelope transformer.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          name is the name of the KMS plugin to be used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cachesize</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          cachesize is the maximum number of secrets which are cached in memory. The default value is 1000.
+Set to a negative value to disable caching.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>endpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          endpoint is the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>timeout</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-Key">Key
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-AESConfiguration">AESConfiguration</a>, 
+        <a href="#apiserver-config-k8s-io-v1-SecretboxConfiguration">SecretboxConfiguration</a>)
+    </p>
+  
+
+  <p>Key contains name and secret of the provided key for a transformer.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          name is the name of the key to be used while storing data to disk.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>secret</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          secret is the actual key, encoded in base64.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-ProviderConfiguration">ProviderConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-ResourceConfiguration">ResourceConfiguration</a>)
+    </p>
+  
+
+  <p>ProviderConfiguration stores the provided configuration for an encryption provider.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>aesgcm</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-AESConfiguration">
+                <span style="font-family: monospace">AESConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          aesgcm is the configuration for the AES-GCM transformer.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>aescbc</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-AESConfiguration">
+                <span style="font-family: monospace">AESConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          aescbc is the configuration for the AES-CBC transformer.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>secretbox</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-SecretboxConfiguration">
+                <span style="font-family: monospace">SecretboxConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          secretbox is the configuration for the Secretbox based transformer.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>identity</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-IdentityConfiguration">
+                <span style="font-family: monospace">IdentityConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          identity is the (empty) configuration for the identity transformer.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kms</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-KMSConfiguration">
+                <span style="font-family: monospace">KMSConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          kms contains the name, cache size and path to configuration file for a KMS based envelope transformer.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-ResourceConfiguration">ResourceConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-EncryptionConfiguration">EncryptionConfiguration</a>)
+    </p>
+  
+
+  <p>ResourceConfiguration stores per resource configuration.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          resources is a list of kubernetes resources which have to be encrypted.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>providers</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-ProviderConfiguration">
+                <span style="font-family: monospace">[]ProviderConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          providers is a list of transformers to be used for reading and writing the resources to disk.
+eg: aesgcm, aescbc, secretbox, identity.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-SecretboxConfiguration">SecretboxConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-ProviderConfiguration">ProviderConfiguration</a>)
+    </p>
+  
+
+  <p>SecretboxConfiguration contains the API configuration for an Secretbox transformer.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>keys</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-Key">
+                <span style="font-family: monospace">[]Key</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          keys is a list of keys to be used for creating the Secretbox transformer.
+Each key has to be 32 bytes long.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/apiserver-resourcequota.v1.html
+++ b/genref/output/html/apiserver-resourcequota.v1.html
@@ -1,0 +1,283 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="apiserver-config-k8s-io-v1">Package: <span style="font-family: monospace">apiserver.config.k8s.io/v1</span></H2>
+            <p>Package v1 is the v1 version of the API.</p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#apiserver-config-k8s-io-v1-Configuration">Configuration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-Configuration">Configuration
+    </H3>
+
+  
+
+  <p>Configuration provides configuration for the ResourceQuota admission controller.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>apiserver.config.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>Configuration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>limitedResources</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#apiserver-config-k8s-io-v1-LimitedResource">
+                <span style="font-family: monospace">[]LimitedResource</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          LimitedResources whose consumption is limited by default.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-LimitedResource">LimitedResource
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#apiserver-config-k8s-io-v1-Configuration">Configuration</a>)
+    </p>
+  
+
+  <p>LimitedResource matches a resource whose consumption is limited by default.
+To consume the resource, there must exist an associated quota that limits
+its consumption.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>apiGroup</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          APIGroup is the name of the APIGroup that contains the limited resource.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resource</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Resource is the name of the resource this rule applies to.
+For example, if the administrator wants to limit consumption
+of a storage resource associated with persistent volume claims,
+the value would be "persistentvolumeclaims".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>matchContains</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          For each intercepted request, the quota system will evaluate
+its resource usage.  It will iterate through each resource consumed
+and if the resource contains any substring in this listing, the
+quota system will ensure that there is a covering quota.  In the
+absence of a covering quota, the quota system will deny the request.
+For example, if an administrator wants to globally enforce that
+that a quota must exist to consume persistent volume claims associated
+with any storage class, the list would include
+".storageclass.storage.k8s.io/requests.storage"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>matchScopes</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#scopedresourceselectorrequirement-v1-core">
+                <span style="font-family: monospace">[]core/v1.ScopedResourceSelectorRequirement</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          For each intercepted request, the quota system will figure out if the input object
+satisfies a scope which is present in this listing, then
+quota system will ensure that there is a covering quota.  In the
+absence of a covering quota, the quota system will deny the request.
+For example, if an administrator wants to globally enforce that
+a quota must exist to create a pod with "cluster-services" priorityclass
+the list would include "scopeName=PriorityClass, Operator=In, Value=cluster-services"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/apiserver-webhookadmission.v1.html
+++ b/genref/output/html/apiserver-webhookadmission.v1.html
@@ -1,0 +1,117 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="apiserver-config-k8s-io-v1">Package: <span style="font-family: monospace">apiserver.config.k8s.io/v1</span></H2>
+            <p>Package v1 is the v1 version of the API.</p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#apiserver-config-k8s-io-v1-WebhookAdmission">WebhookAdmission</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="apiserver-config-k8s-io-v1-WebhookAdmission">WebhookAdmission
+    </H3>
+
+  
+
+  <p>WebhookAdmission provides configuration for the webhook admission controller.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>apiserver.config.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>WebhookAdmission</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>kubeConfigFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          KubeConfigFile is the path to the kubeconfig file.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/client-authentication.v1beta1.html
+++ b/genref/output/html/client-authentication.v1beta1.html
@@ -1,0 +1,640 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="client-authentication-k8s-io-v1beta1">Package: <span style="font-family: monospace">client.authentication.k8s.io/v1beta1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#client-authentication-k8s-io-v1beta1-ExecCredential">ExecCredential</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="client-authentication-k8s-io-v1beta1-ExecCredential">ExecCredential
+    </H3>
+
+  
+
+  <p>ExecCredential is used by exec-based plugins to communicate credentials to
+HTTP transports.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>client.authentication.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>ExecCredential</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>spec</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#client-authentication-k8s-io-v1beta1-ExecCredentialSpec">
+                <span style="font-family: monospace">ExecCredentialSpec</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Spec holds information passed to the plugin by the transport.
+
+          
+
+          
+            <br/>
+            <br/>
+            <table>
+              
+
+  
+  
+    
+    
+      <tr>
+        <td><code>cluster</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#client-authentication-k8s-io-v1beta1-Cluster">
+                <span style="font-family: monospace">Cluster</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Cluster contains information to allow an exec plugin to communicate with the
+kubernetes cluster being authenticated to. Note that Cluster is non-nil only
+when provideClusterInfo is set to true in the exec provider config (i.e.,
+ExecConfig.ProvideClusterInfo).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+            </table>
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>status</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#client-authentication-k8s-io-v1beta1-ExecCredentialStatus">
+                <span style="font-family: monospace">ExecCredentialStatus</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Status is filled in by the plugin and holds the credentials that the transport
+should use to contact the API.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="client-authentication-k8s-io-v1beta1-Cluster">Cluster
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#client-authentication-k8s-io-v1beta1-ExecCredentialSpec">ExecCredentialSpec</a>)
+    </p>
+  
+
+  <p>Cluster contains information to allow an exec plugin to communicate
+with the kubernetes cluster being authenticated to.
+
+To ensure that this struct contains everything someone would need to communicate
+with a kubernetes cluster (just like they would via a kubeconfig), the fields
+should shadow "k8s.io/client-go/tools/clientcmd/api/v1".Cluster, with the exception
+of CertificateAuthority, since CA data will always be passed to the plugin as bytes.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>server</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Server is the address of the kubernetes cluster (https://hostname:port).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tls-server-name</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          TLSServerName is passed to the server for SNI and is used in the client to
+check server certificates against. If ServerName is empty, the hostname
+used to contact the server is used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>insecure-skip-tls-verify</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          InsecureSkipTLSVerify skips the validity check for the server's certificate.
+This will make your HTTPS connections insecure.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certificate-authority-data</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]byte</span>
+            
+          
+        </td>
+        <td>
+          
+
+          CAData contains PEM-encoded certificate authority certificates.
+If empty, system roots should be used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>proxy-url</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ProxyURL is the URL to the proxy to be used for all requests to this
+cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>config</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension">
+                <span style="font-family: monospace">k8s.io/apimachinery/pkg/runtime.RawExtension</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Config holds additional config data that is specific to the exec
+plugin with regards to the cluster being authenticated to.
+
+This data is sourced from the clientcmd Cluster object's
+extensions[client.authentication.k8s.io/exec] field:
+
+clusters:
+- name: my-cluster
+  cluster:
+    ...
+    extensions:
+    - name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config
+      extension:
+        audience: 06e3fbd18de8  # arbitrary config
+
+In some environments, the user config may be exactly the same across many clusters
+(i.e. call this exec plugin) minus some details that are specific to each cluster
+such as the audience.  This field allows the per cluster config to be directly
+specified with the cluster info.  Using this field to store secret data is not
+recommended as one of the prime benefits of exec plugins is that no secrets need
+to be stored directly in the kubeconfig.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="client-authentication-k8s-io-v1beta1-ExecCredentialSpec">ExecCredentialSpec
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#client-authentication-k8s-io-v1beta1-ExecCredential">ExecCredential</a>)
+    </p>
+  
+
+  <p>ExecCredentialSpec holds request and runtime specific information provided by
+the transport.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>cluster</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#client-authentication-k8s-io-v1beta1-Cluster">
+                <span style="font-family: monospace">Cluster</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Cluster contains information to allow an exec plugin to communicate with the
+kubernetes cluster being authenticated to. Note that Cluster is non-nil only
+when provideClusterInfo is set to true in the exec provider config (i.e.,
+ExecConfig.ProvideClusterInfo).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="client-authentication-k8s-io-v1beta1-ExecCredentialStatus">ExecCredentialStatus
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#client-authentication-k8s-io-v1beta1-ExecCredential">ExecCredential</a>)
+    </p>
+  
+
+  <p>ExecCredentialStatus holds credentials for the transport to use.
+
+Token and ClientKeyData are sensitive fields. This data should only be
+transmitted in-memory between client and exec plugin process. Exec plugin
+itself should at least be protected via file permissions.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>expirationTimestamp</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+                <span style="font-family: monospace">meta/v1.Time</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ExpirationTimestamp indicates a time when the provided credentials expire.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>token</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Token is a bearer token used by the client for request authentication.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clientCertificateData</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          PEM-encoded client TLS certificates (including intermediates, if any).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clientKeyData</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          PEM-encoded private key for the above certificate.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/cloud-provider-config.v1alpha1.html
+++ b/genref/output/html/cloud-provider-config.v1alpha1.html
@@ -1,0 +1,1282 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="cloudcontrollermanager-config-k8s-io-v1alpha1">Package: <span style="font-family: monospace">cloudcontrollermanager.config.k8s.io/v1alpha1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration
+    </H3>
+
+  
+
+  <p></p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>cloudcontrollermanager.config.k8s.io/v1alpha1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>CloudControllerManagerConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>Generic</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration">
+                <span style="font-family: monospace">GenericControllerManagerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Generic holds configuration for a generic controller-manager
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>KubeCloudShared</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration">
+                <span style="font-family: monospace">KubeCloudSharedConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ServiceController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#ServiceControllerConfiguration">
+                <span style="font-family: monospace">ServiceControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ServiceControllerConfiguration holds configuration for ServiceController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeStatusUpdateFrequency</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration">CloudProviderConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration">KubeCloudSharedConfiguration</a>)
+    </p>
+  
+
+  <p>CloudProviderConfiguration contains basically elements about cloud provider.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>Name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name is the provider for cloud services.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>CloudConfigFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          cloudConfigFile is the path to the cloud provider configuration file.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration">KubeCloudSharedConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>, 
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
+and cloud-controller manager, but not genericconfig.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>CloudProvider</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration">
+                <span style="font-family: monospace">CloudProviderConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          CloudProviderConfiguration holds configuration for CloudProvider related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ExternalCloudVolumePlugin</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          externalCloudVolumePlugin specifies the plugin to use when cloudProvider is "external".
+It is currently used by the in repo cloud providers to handle node and volume control in the KCM.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>UseServiceAccountCredentials</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          useServiceAccountCredentials indicates whether controllers should be run with
+individual service account credentials.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>AllowUntaggedCloud</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          run with untagged cloud instances
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>RouteReconciliationPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeMonitorPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ClusterName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterName is the instance prefix for the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ClusterCIDR</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterCIDR is CIDR Range for Pods in cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>AllocateNodeCIDRs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+ConfigureCloudRoutes is true, to be set on the cloud provider.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>CIDRAllocatorType</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          CIDRAllocatorType determines what kind of pod CIDR allocator will be used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ConfigureCloudRoutes</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
+to be configured on the cloud provider.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
+periods will result in fewer calls to cloud provider, but may delay addition
+of new nodes to cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+          
+          
+            <H2 id="controllermanager-config-k8s-io-v1alpha1">Package: <span style="font-family: monospace">controllermanager.config.k8s.io/v1alpha1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul></ul>
+
+            
+            
+              
+  <H3 id="controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration">ControllerLeaderConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration">LeaderMigrationConfiguration</a>)
+    </p>
+  
+
+  <p>ControllerLeaderConfiguration provides the configuration for a migrating leader lock.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name is the name of the controller being migrated
+E.g. service-controller, route-controller, cloud-node-controller, etc
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>component</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Component is the name of the component in which the controller should be running.
+E.g. kube-controller-manager, cloud-controller-manager, etc
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration">GenericControllerManagerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>, 
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>GenericControllerManagerConfiguration holds configuration for a generic controller-manager.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>Port</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          port is the port that the controller-manager's http service runs on.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>Address</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>MinResyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          minResyncPeriod is the resync period in reflectors; will be random between
+minResyncPeriod and 2&lowast;minResyncPeriod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ClientConnection</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#ClientConnectionConfiguration">
+                <span style="font-family: monospace">ClientConnectionConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ControllerStartInterval</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          How long to wait between starting controller managers
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>LeaderElection</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#LeaderElectionConfiguration">
+                <span style="font-family: monospace">LeaderElectionConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          leaderElection defines the configuration of leader election client.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>Controllers</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Controllers is the list of controllers to enable or disable
+'&lowast;' means "all enabled by default controllers"
+'foo' means "enable 'foo'"
+'-foo' means "disable 'foo'"
+first item for a particular name wins
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>Debugging</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#DebuggingConfiguration">
+                <span style="font-family: monospace">DebuggingConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          DebuggingConfiguration holds configuration for Debugging related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration">LeaderMigrationConfiguration
+    </H3>
+
+  
+
+  <p>LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>leaderName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          LeaderName is the name of the leader election resource that protects the migration
+E.g. 1-20-KCM-to-1-21-CCM
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resourceLock</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ResourceLock indicates the resource object type that will be used to lock
+Should be "leases" or "endpoints"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>controllerLeaders</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration">
+                <span style="font-family: monospace">[]ControllerLeaderConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ControllerLeaders contains a list of migrating leader lock configurations
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+          
+          
+            
+            
+              
+                
+  <H3 id="ServiceControllerConfiguration">ServiceControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>, 
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>ServiceControllerConfiguration contains elements describing ServiceController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentServiceSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+              
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/cloud-provider-service.v1alpha1.html
+++ b/genref/output/html/cloud-provider-service.v1alpha1.html
@@ -1,0 +1,105 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            
+            
+              
+                
+  <H3 id="ServiceControllerConfiguration">ServiceControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>, 
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>ServiceControllerConfiguration contains elements describing ServiceController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentServiceSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+              
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/kube-controller-manager-config.v1alpha1.html
+++ b/genref/output/html/kube-controller-manager-config.v1alpha1.html
@@ -1,0 +1,5533 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="kubecontrollermanager-config-k8s-io-v1alpha1">Package: <span style="font-family: monospace">kubecontrollermanager.config.k8s.io/v1alpha1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration
+    </H3>
+
+  
+
+  <p>KubeControllerManagerConfiguration contains elements describing kube-controller manager.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubecontrollermanager.config.k8s.io/v1alpha1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>KubeControllerManagerConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>Generic</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration">
+                <span style="font-family: monospace">GenericControllerManagerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Generic holds configuration for a generic controller-manager
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>KubeCloudShared</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration">
+                <span style="font-family: monospace">KubeCloudSharedConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>AttachDetachController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-AttachDetachControllerConfiguration">
+                <span style="font-family: monospace">AttachDetachControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          AttachDetachControllerConfiguration holds configuration for
+AttachDetachController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>CSRSigningController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration">
+                <span style="font-family: monospace">CSRSigningControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          CSRSigningControllerConfiguration holds configuration for
+CSRSigningController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>DaemonSetController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DaemonSetControllerConfiguration">
+                <span style="font-family: monospace">DaemonSetControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          DaemonSetControllerConfiguration holds configuration for DaemonSetController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>DeploymentController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DeploymentControllerConfiguration">
+                <span style="font-family: monospace">DeploymentControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          DeploymentControllerConfiguration holds configuration for
+DeploymentController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>StatefulSetController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-StatefulSetControllerConfiguration">
+                <span style="font-family: monospace">StatefulSetControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          StatefulSetControllerConfiguration holds configuration for
+StatefulSetController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>DeprecatedController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DeprecatedControllerConfiguration">
+                <span style="font-family: monospace">DeprecatedControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          DeprecatedControllerConfiguration holds configuration for some deprecated
+features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>EndpointController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointControllerConfiguration">
+                <span style="font-family: monospace">EndpointControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          EndpointControllerConfiguration holds configuration for EndpointController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>EndpointSliceController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceControllerConfiguration">
+                <span style="font-family: monospace">EndpointSliceControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          EndpointSliceControllerConfiguration holds configuration for
+EndpointSliceController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>EndpointSliceMirroringController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceMirroringControllerConfiguration">
+                <span style="font-family: monospace">EndpointSliceMirroringControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          EndpointSliceMirroringControllerConfiguration holds configuration for
+EndpointSliceMirroringController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>GarbageCollectorController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration">
+                <span style="font-family: monospace">GarbageCollectorControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          GarbageCollectorControllerConfiguration holds configuration for
+GarbageCollectorController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>HPAController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-HPAControllerConfiguration">
+                <span style="font-family: monospace">HPAControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HPAControllerConfiguration holds configuration for HPAController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>JobController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-JobControllerConfiguration">
+                <span style="font-family: monospace">JobControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          JobControllerConfiguration holds configuration for JobController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>CronJobController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CronJobControllerConfiguration">
+                <span style="font-family: monospace">CronJobControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          CronJobControllerConfiguration holds configuration for CronJobController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NamespaceController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NamespaceControllerConfiguration">
+                <span style="font-family: monospace">NamespaceControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          NamespaceControllerConfiguration holds configuration for NamespaceController
+related features.
+NamespaceControllerConfiguration holds configuration for NamespaceController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeIPAMController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NodeIPAMControllerConfiguration">
+                <span style="font-family: monospace">NodeIPAMControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeIPAMControllerConfiguration holds configuration for NodeIPAMController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeLifecycleController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NodeLifecycleControllerConfiguration">
+                <span style="font-family: monospace">NodeLifecycleControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeLifecycleControllerConfiguration holds configuration for
+NodeLifecycleController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>PersistentVolumeBinderController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration">
+                <span style="font-family: monospace">PersistentVolumeBinderControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          PersistentVolumeBinderControllerConfiguration holds configuration for
+PersistentVolumeBinderController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>PodGCController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PodGCControllerConfiguration">
+                <span style="font-family: monospace">PodGCControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          PodGCControllerConfiguration holds configuration for PodGCController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ReplicaSetController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicaSetControllerConfiguration">
+                <span style="font-family: monospace">ReplicaSetControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ReplicaSetControllerConfiguration holds configuration for ReplicaSet related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ReplicationController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicationControllerConfiguration">
+                <span style="font-family: monospace">ReplicationControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ReplicationControllerConfiguration holds configuration for
+ReplicationController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ResourceQuotaController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceQuotaControllerConfiguration">
+                <span style="font-family: monospace">ResourceQuotaControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ResourceQuotaControllerConfiguration holds configuration for
+ResourceQuotaController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>SAController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-SAControllerConfiguration">
+                <span style="font-family: monospace">SAControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          SAControllerConfiguration holds configuration for ServiceAccountController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ServiceController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#ServiceControllerConfiguration">
+                <span style="font-family: monospace">ServiceControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ServiceControllerConfiguration holds configuration for ServiceController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>TTLAfterFinishedController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-TTLAfterFinishedControllerConfiguration">
+                <span style="font-family: monospace">TTLAfterFinishedControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          TTLAfterFinishedControllerConfiguration holds configuration for
+TTLAfterFinishedController related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-AttachDetachControllerConfiguration">AttachDetachControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>AttachDetachControllerConfiguration contains elements describing AttachDetachController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>DisableAttachDetachReconcilerSync</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Reconciler runs a periodic loop to reconcile the desired state of the with
+the actual state of the world by triggering attach detach operations.
+This flag enables or disables reconcile.  Is false by default, and thus enabled.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ReconcilerSyncLoopPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
+wait between successive executions. Is set to 5 sec by default.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration">CSRSigningConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration">CSRSigningControllerConfiguration</a>)
+    </p>
+  
+
+  <p>CSRSigningConfiguration holds information about a particular CSR signer</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>CertFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          certFile is the filename containing a PEM-encoded
+X509 CA certificate used to issue certificates
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>KeyFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          keyFile is the filename containing a PEM-encoded
+RSA or ECDSA private key used to issue certificates
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration">CSRSigningControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>CSRSigningControllerConfiguration contains elements describing CSRSigningController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ClusterSigningCertFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterSigningCertFile is the filename containing a PEM-encoded
+X509 CA certificate used to issue cluster-scoped certificates
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ClusterSigningKeyFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterSigningCertFile is the filename containing a PEM-encoded
+RSA or ECDSA private key used to issue cluster-scoped certificates
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>KubeletServingSignerConfiguration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration">
+                <span style="font-family: monospace">CSRSigningConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          kubeletServingSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kubelet-serving signer
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>KubeletClientSignerConfiguration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration">
+                <span style="font-family: monospace">CSRSigningConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          kubeletClientSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kube-apiserver-client-kubelet
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>KubeAPIServerClientSignerConfiguration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration">
+                <span style="font-family: monospace">CSRSigningConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          kubeAPIServerClientSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kube-apiserver-client
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>LegacyUnknownSignerConfiguration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration">
+                <span style="font-family: monospace">CSRSigningConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          legacyUnknownSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/legacy-unknown
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ClusterSigningDuration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterSigningDuration is the length of duration signed certificates
+will be given.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-CronJobControllerConfiguration">CronJobControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>CronJobControllerConfiguration contains elements describing CrongJob2Controller.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentCronJobSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentCronJobSyncs is the number of job objects that are
+allowed to sync concurrently. Larger number = more responsive jobs,
+but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-DaemonSetControllerConfiguration">DaemonSetControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>DaemonSetControllerConfiguration contains elements describing DaemonSetController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentDaemonSetSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentDaemonSetSyncs is the number of daemonset objects that are
+allowed to sync concurrently. Larger number = more responsive daemonset,
+but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-DeploymentControllerConfiguration">DeploymentControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>DeploymentControllerConfiguration contains elements describing DeploymentController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentDeploymentSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentDeploymentSyncs is the number of deployment objects that are
+allowed to sync concurrently. Larger number = more responsive deployments,
+but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>DeploymentControllerSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          deploymentControllerSyncPeriod is the period for syncing the deployments.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-DeprecatedControllerConfiguration">DeprecatedControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>DeprecatedControllerConfiguration contains elements be deprecated.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>DeletingPodsQPS</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">float32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          DEPRECATED: deletingPodsQps is the number of nodes per second on which pods are deleted in
+case of node failure.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>DeletingPodsBurst</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          DEPRECATED: deletingPodsBurst is the number of nodes on which pods are bursty deleted in
+case of node failure. For more details look into RateLimiter.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>RegisterRetryCount</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          registerRetryCount is the number of retries for initial node registration.
+Retry interval equals node-sync-period.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-EndpointControllerConfiguration">EndpointControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>EndpointControllerConfiguration contains elements describing EndpointController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentEndpointSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentEndpointSyncs is the number of endpoint syncing operations
+that will be done concurrently. Larger number = faster endpoint updating,
+but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>EndpointUpdatesBatchPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          EndpointUpdatesBatchPeriod describes the length of endpoint updates batching period.
+Processing of pod changes will be delayed by this duration to join them with potential
+upcoming updates and reduce the overall number of endpoints updates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceControllerConfiguration">EndpointSliceControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>EndpointSliceControllerConfiguration contains elements describing
+EndpointSliceController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentServiceEndpointSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentServiceEndpointSyncs is the number of service endpoint syncing
+operations that will be done concurrently. Larger number = faster
+endpoint slice updating, but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>MaxEndpointsPerSlice</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          maxEndpointsPerSlice is the maximum number of endpoints that will be
+added to an EndpointSlice. More endpoints per slice will result in fewer
+and larger endpoint slices, but larger resources.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>EndpointUpdatesBatchPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          EndpointUpdatesBatchPeriod describes the length of endpoint updates batching period.
+Processing of pod changes will be delayed by this duration to join them with potential
+upcoming updates and reduce the overall number of endpoints updates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceMirroringControllerConfiguration">EndpointSliceMirroringControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>EndpointSliceMirroringControllerConfiguration contains elements describing
+EndpointSliceMirroringController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>MirroringConcurrentServiceEndpointSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          mirroringConcurrentServiceEndpointSyncs is the number of service endpoint
+syncing operations that will be done concurrently. Larger number = faster
+endpoint slice updating, but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>MirroringMaxEndpointsPerSubset</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          mirroringMaxEndpointsPerSubset is the maximum number of endpoints that
+will be mirrored to an EndpointSlice for an EndpointSubset.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>MirroringEndpointUpdatesBatchPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          mirroringEndpointUpdatesBatchPeriod can be used to batch EndpointSlice
+updates. All updates triggered by EndpointSlice changes will be delayed
+by up to 'mirroringEndpointUpdatesBatchPeriod'. If other addresses in the
+same Endpoints resource change in that period, they will be batched to a
+single EndpointSlice update. Default 0 value means that each Endpoints
+update triggers an EndpointSlice update.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration">GarbageCollectorControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>GarbageCollectorControllerConfiguration contains elements describing GarbageCollectorController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>EnableGarbageCollector</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enables the generic garbage collector. MUST be synced with the
+corresponding flag of the kube-apiserver. WARNING: the generic garbage
+collector is an alpha feature.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentGCSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentGCSyncs is the number of garbage collector workers that are
+allowed to sync concurrently.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>GCIgnoredResources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GroupResource">
+                <span style="font-family: monospace">[]GroupResource</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          gcIgnoredResources is the list of GroupResources that garbage collection should ignore.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-GroupResource">GroupResource
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration">GarbageCollectorControllerConfiguration</a>)
+    </p>
+  
+
+  <p>GroupResource describes an group resource.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>Group</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          group is the group portion of the GroupResource.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>Resource</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          resource is the resource portion of the GroupResource.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-HPAControllerConfiguration">HPAControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>HPAControllerConfiguration contains elements describing HPAController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>HorizontalPodAutoscalerSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HorizontalPodAutoscalerSyncPeriod is the period for syncing the number of
+pods in horizontal pod autoscaler.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>HorizontalPodAutoscalerUpscaleForbiddenWindow</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HorizontalPodAutoscalerUpscaleForbiddenWindow is a period after which next upscale allowed.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>HorizontalPodAutoscalerDownscaleStabilizationWindow</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HorizontalPodAutoscalerDowncaleStabilizationWindow is a period for which autoscaler will look
+backwards and not scale down below any recommendation it made during that period.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>HorizontalPodAutoscalerDownscaleForbiddenWindow</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HorizontalPodAutoscalerDownscaleForbiddenWindow is a period after which next downscale allowed.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>HorizontalPodAutoscalerTolerance</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">float64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          HorizontalPodAutoscalerTolerance is the tolerance for when
+resource usage suggests upscaling/downscaling
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>HorizontalPodAutoscalerUseRESTClients</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          HorizontalPodAutoscalerUseRESTClients causes the HPA controller to use REST clients
+through the kube-aggregator when enabled, instead of using the legacy metrics client
+through the API server proxy.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>HorizontalPodAutoscalerCPUInitializationPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HorizontalPodAutoscalerCPUInitializationPeriod is the period after pod start when CPU samples
+might be skipped.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>HorizontalPodAutoscalerInitialReadinessDelay</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HorizontalPodAutoscalerInitialReadinessDelay is period after pod start during which readiness
+changes are treated as readiness being set for the first time. The only effect of this is that
+HPA will disregard CPU samples from unready pods that had last readiness change during that
+period.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-JobControllerConfiguration">JobControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>JobControllerConfiguration contains elements describing JobController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentJobSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentJobSyncs is the number of job objects that are
+allowed to sync concurrently. Larger number = more responsive jobs,
+but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-NamespaceControllerConfiguration">NamespaceControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>NamespaceControllerConfiguration contains elements describing NamespaceController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>NamespaceSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          namespaceSyncPeriod is the period for syncing namespace life-cycle
+updates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentNamespaceSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentNamespaceSyncs is the number of namespace objects that are
+allowed to sync concurrently.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-NodeIPAMControllerConfiguration">NodeIPAMControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>NodeIPAMControllerConfiguration contains elements describing NodeIpamController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ServiceCIDR</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          serviceCIDR is CIDR Range for Services in cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>SecondaryServiceCIDR</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          secondaryServiceCIDR is CIDR Range for Services in cluster. This is used in dual stack clusters. SecondaryServiceCIDR must be of different IP family than ServiceCIDR
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeCIDRMaskSize</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeCIDRMaskSize is the mask size for node cidr in cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeCIDRMaskSizeIPv4</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeCIDRMaskSizeIPv4 is the mask size for node cidr in dual-stack cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeCIDRMaskSizeIPv6</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeCIDRMaskSizeIPv6 is the mask size for node cidr in dual-stack cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-NodeLifecycleControllerConfiguration">NodeLifecycleControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>NodeLifecycleControllerConfiguration contains elements describing NodeLifecycleController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>EnableTaintManager</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          If set to true enables NoExecute Taints and will evict all not-tolerating
+Pod running on Nodes tainted with this kind of Taints.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeEvictionRate</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">float32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is healthy
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>SecondaryNodeEvictionRate</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">float32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          secondaryNodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is unhealthy
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeStartupGracePeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeStartupGracePeriod is the amount of time which we allow starting a node to
+be unresponsive before marking it unhealthy.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeMonitorGracePeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeMontiorGracePeriod is the amount of time which we allow a running node to be
+unresponsive before marking it unhealthy. Must be N times more than kubelet's
+nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet
+to post node status.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>PodEvictionTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          podEvictionTimeout is the grace period for deleting pods on failed nodes.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>LargeClusterSizeThreshold</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          secondaryNodeEvictionRate is implicitly overridden to 0 for clusters smaller than or equal to largeClusterSizeThreshold
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>UnhealthyZoneThreshold</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">float32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Zone is treated as unhealthy in nodeEvictionRate and secondaryNodeEvictionRate when at least
+unhealthyZoneThreshold (no less than 3) of Nodes in the zone are NotReady
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration">PersistentVolumeBinderControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>PersistentVolumeBinderControllerConfiguration contains elements describing
+PersistentVolumeBinderController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>PVClaimBinderSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          pvClaimBinderSyncPeriod is the period for syncing persistent volumes
+and persistent volume claims.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>VolumeConfiguration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration">
+                <span style="font-family: monospace">VolumeConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          volumeConfiguration holds configuration for volume related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>VolumeHostCIDRDenylist</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          VolumeHostCIDRDenylist is a list of CIDRs that should not be reachable by the
+controller from plugins.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>VolumeHostAllowLocalLoopback</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          VolumeHostAllowLocalLoopback indicates if local loopback hosts (127.0.0.1, etc)
+should be allowed from plugins.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeRecyclerConfiguration">PersistentVolumeRecyclerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration">VolumeConfiguration</a>)
+    </p>
+  
+
+  <p>PersistentVolumeRecyclerConfiguration contains elements describing persistent volume plugins.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>MaximumRetry</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          maximumRetry is number of retries the PV recycler will execute on failure to recycle
+PV.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>MinimumTimeoutNFS</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          minimumTimeoutNFS is the minimum ActiveDeadlineSeconds to use for an NFS Recycler
+pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>PodTemplateFilePathNFS</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          podTemplateFilePathNFS is the file path to a pod definition used as a template for
+NFS persistent volume recycling
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>IncrementTimeoutNFS</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          incrementTimeoutNFS is the increment of time added per Gi to ActiveDeadlineSeconds
+for an NFS scrubber pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>PodTemplateFilePathHostPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          podTemplateFilePathHostPath is the file path to a pod definition used as a template for
+HostPath persistent volume recycling. This is for development and testing only and
+will not work in a multi-node cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>MinimumTimeoutHostPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          minimumTimeoutHostPath is the minimum ActiveDeadlineSeconds to use for a HostPath
+Recycler pod.  This is for development and testing only and will not work in a multi-node
+cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>IncrementTimeoutHostPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          incrementTimeoutHostPath is the increment of time added per Gi to ActiveDeadlineSeconds
+for a HostPath scrubber pod.  This is for development and testing only and will not work
+in a multi-node cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-PodGCControllerConfiguration">PodGCControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>PodGCControllerConfiguration contains elements describing PodGCController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>TerminatedPodGCThreshold</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          terminatedPodGCThreshold is the number of terminated pods that can exist
+before the terminated pod garbage collector starts deleting terminated pods.
+If <= 0, the terminated pod garbage collector is disabled.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-ReplicaSetControllerConfiguration">ReplicaSetControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>ReplicaSetControllerConfiguration contains elements describing ReplicaSetController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentRSSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentRSSyncs is the number of replica sets that are  allowed to sync
+concurrently. Larger number = more responsive replica  management, but more
+CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-ReplicationControllerConfiguration">ReplicationControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>ReplicationControllerConfiguration contains elements describing ReplicationController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentRCSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentRCSyncs is the number of replication controllers that are
+allowed to sync concurrently. Larger number = more responsive replica
+management, but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-ResourceQuotaControllerConfiguration">ResourceQuotaControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>ResourceQuotaControllerConfiguration contains elements describing ResourceQuotaController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ResourceQuotaSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          resourceQuotaSyncPeriod is the period for syncing quota usage status
+in the system.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentResourceQuotaSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentResourceQuotaSyncs is the number of resource quotas that are
+allowed to sync concurrently. Larger number = more responsive quota
+management, but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-SAControllerConfiguration">SAControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>SAControllerConfiguration contains elements describing ServiceAccountController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ServiceAccountKeyFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
+used to sign service account tokens.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentSATokenSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentSATokenSyncs is the number of service account token syncing operations
+that will be done concurrently.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>RootCAFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          rootCAFile is the root certificate authority will be included in service
+account's token secret. This must be a valid PEM-encoded CA bundle.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-StatefulSetControllerConfiguration">StatefulSetControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>StatefulSetControllerConfiguration contains elements describing StatefulSetController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentStatefulSetSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentStatefulSetSyncs is the number of statefulset objects that are
+allowed to sync concurrently. Larger number = more responsive statefulsets,
+but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-TTLAfterFinishedControllerConfiguration">TTLAfterFinishedControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>TTLAfterFinishedControllerConfiguration contains elements describing TTLAfterFinishedController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentTTLSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentTTLSyncs is the number of TTL-after-finished collector workers that are
+allowed to sync concurrently.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration">VolumeConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration">PersistentVolumeBinderControllerConfiguration</a>)
+    </p>
+  
+
+  <p>VolumeConfiguration contains &lowast;all&lowast; enumerated flags meant to configure all volume
+plugins. From this config, the controller-manager binary will create many instances of
+volume.VolumeConfig, each containing only the configuration needed for that plugin which
+are then passed to the appropriate plugin. The ControllerManager binary is the only part
+of the code which knows what plugins are supported and which flags correspond to each plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>EnableHostPathProvisioning</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableHostPathProvisioning enables HostPath PV provisioning when running without a
+cloud provider. This allows testing and development of provisioning features. HostPath
+provisioning is not supported in any way, won't work in a multi-node cluster, and
+should not be used for anything other than testing or development.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>EnableDynamicProvisioning</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableDynamicProvisioning enables the provisioning of volumes when running within an environment
+that supports dynamic provisioning. Defaults to true.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>PersistentVolumeRecyclerConfiguration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeRecyclerConfiguration">
+                <span style="font-family: monospace">PersistentVolumeRecyclerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          persistentVolumeRecyclerConfiguration holds configuration for persistent volume plugins.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>FlexVolumePluginDir</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          volumePluginDir is the full path of the directory in which the flex
+volume plugin should search for additional third party volume plugins
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+          
+          
+            
+            
+              
+                
+  <H3 id="ServiceControllerConfiguration">ServiceControllerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>, 
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>ServiceControllerConfiguration contains elements describing ServiceController.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ConcurrentServiceSyncs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+              
+            
+          
+
+          <HR />
+        
+          
+          
+            <H2 id="cloudcontrollermanager-config-k8s-io-v1alpha1">Package: <span style="font-family: monospace">cloudcontrollermanager.config.k8s.io/v1alpha1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration
+    </H3>
+
+  
+
+  <p></p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>cloudcontrollermanager.config.k8s.io/v1alpha1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>CloudControllerManagerConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>Generic</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration">
+                <span style="font-family: monospace">GenericControllerManagerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Generic holds configuration for a generic controller-manager
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>KubeCloudShared</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration">
+                <span style="font-family: monospace">KubeCloudSharedConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ServiceController</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#ServiceControllerConfiguration">
+                <span style="font-family: monospace">ServiceControllerConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ServiceControllerConfiguration holds configuration for ServiceController
+related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeStatusUpdateFrequency</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration">CloudProviderConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration">KubeCloudSharedConfiguration</a>)
+    </p>
+  
+
+  <p>CloudProviderConfiguration contains basically elements about cloud provider.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>Name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name is the provider for cloud services.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>CloudConfigFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          cloudConfigFile is the path to the cloud provider configuration file.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration">KubeCloudSharedConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>, 
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
+and cloud-controller manager, but not genericconfig.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>CloudProvider</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration">
+                <span style="font-family: monospace">CloudProviderConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          CloudProviderConfiguration holds configuration for CloudProvider related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ExternalCloudVolumePlugin</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          externalCloudVolumePlugin specifies the plugin to use when cloudProvider is "external".
+It is currently used by the in repo cloud providers to handle node and volume control in the KCM.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>UseServiceAccountCredentials</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          useServiceAccountCredentials indicates whether controllers should be run with
+individual service account credentials.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>AllowUntaggedCloud</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          run with untagged cloud instances
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>RouteReconciliationPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeMonitorPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ClusterName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterName is the instance prefix for the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ClusterCIDR</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterCIDR is CIDR Range for Pods in cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>AllocateNodeCIDRs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+ConfigureCloudRoutes is true, to be set on the cloud provider.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>CIDRAllocatorType</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          CIDRAllocatorType determines what kind of pod CIDR allocator will be used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ConfigureCloudRoutes</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
+to be configured on the cloud provider.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>NodeSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
+periods will result in fewer calls to cloud provider, but may delay addition
+of new nodes to cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+          
+          
+            <H2 id="controllermanager-config-k8s-io-v1alpha1">Package: <span style="font-family: monospace">controllermanager.config.k8s.io/v1alpha1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul></ul>
+
+            
+            
+              
+  <H3 id="controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration">ControllerLeaderConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration">LeaderMigrationConfiguration</a>)
+    </p>
+  
+
+  <p>ControllerLeaderConfiguration provides the configuration for a migrating leader lock.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name is the name of the controller being migrated
+E.g. service-controller, route-controller, cloud-node-controller, etc
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>component</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Component is the name of the component in which the controller should be running.
+E.g. kube-controller-manager, cloud-controller-manager, etc
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration">GenericControllerManagerConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration">CloudControllerManagerConfiguration</a>, 
+        <a href="#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration">KubeControllerManagerConfiguration</a>)
+    </p>
+  
+
+  <p>GenericControllerManagerConfiguration holds configuration for a generic controller-manager.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>Port</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          port is the port that the controller-manager's http service runs on.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>Address</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>MinResyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          minResyncPeriod is the resync period in reflectors; will be random between
+minResyncPeriod and 2&lowast;minResyncPeriod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ClientConnection</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#ClientConnectionConfiguration">
+                <span style="font-family: monospace">ClientConnectionConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ControllerStartInterval</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          How long to wait between starting controller managers
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>LeaderElection</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#LeaderElectionConfiguration">
+                <span style="font-family: monospace">LeaderElectionConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          leaderElection defines the configuration of leader election client.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>Controllers</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Controllers is the list of controllers to enable or disable
+'&lowast;' means "all enabled by default controllers"
+'foo' means "enable 'foo'"
+'-foo' means "disable 'foo'"
+first item for a particular name wins
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>Debugging</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#DebuggingConfiguration">
+                <span style="font-family: monospace">DebuggingConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          DebuggingConfiguration holds configuration for Debugging related features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration">LeaderMigrationConfiguration
+    </H3>
+
+  
+
+  <p>LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>leaderName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          LeaderName is the name of the leader election resource that protects the migration
+E.g. 1-20-KCM-to-1-21-CCM
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resourceLock</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ResourceLock indicates the resource object type that will be used to lock
+Should be "leases" or "endpoints"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>controllerLeaders</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration">
+                <span style="font-family: monospace">[]ControllerLeaderConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ControllerLeaders contains a list of migrating leader lock configurations
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/kube-proxy-config.v1alpha1.html
+++ b/genref/output/html/kube-proxy-config.v1alpha1.html
@@ -1,0 +1,1479 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="kubeproxy-config-k8s-io-v1alpha1">Package: <span style="font-family: monospace">kubeproxy.config.k8s.io/v1alpha1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration">KubeProxyConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration">KubeProxyConfiguration
+    </H3>
+
+  
+
+  <p>KubeProxyConfiguration contains everything necessary to configure the
+Kubernetes proxy server.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeproxy.config.k8s.io/v1alpha1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>KubeProxyConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>featureGates</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          featureGates is a map of feature names to bools that enable or disable alpha/experimental features.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bindAddress</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
+for all interfaces)
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>healthzBindAddress</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          healthzBindAddress is the IP address and port for the health check server to serve on,
+defaulting to 0.0.0.0:10256
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>metricsBindAddress</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          metricsBindAddress is the IP address and port for the metrics server to serve on,
+defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bindAddressHardFail</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          bindAddressHardFail, if true, kube-proxy will treat failure to bind to a port as fatal and exit
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableProfiling</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableProfiling enables profiling via web interface on /debug/pprof handler.
+Profiling handlers will be handled by metrics server.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clusterCIDR</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterCIDR is the CIDR range of the pods in the cluster. It is used to
+bridge traffic coming from outside of the cluster. If not provided,
+no off-cluster bridging will be performed.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>hostnameOverride</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clientConnection</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#ClientConnectionConfiguration">
+                <span style="font-family: monospace">ClientConnectionConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          clientConnection specifies the kubeconfig file and client connection settings for the proxy
+server to use when communicating with the apiserver.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>iptables</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPTablesConfiguration">
+                <span style="font-family: monospace">KubeProxyIPTablesConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          iptables contains iptables-related configuration options.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ipvs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPVSConfiguration">
+                <span style="font-family: monospace">KubeProxyIPVSConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ipvs contains ipvs-related configuration options.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>oomScoreAdj</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
+the range [-1000, 1000]
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>mode</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeproxy-config-k8s-io-v1alpha1-ProxyMode">
+                <span style="font-family: monospace">ProxyMode</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          mode specifies which proxy mode to use.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>portRange</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
+in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>udpIdleTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
+Must be greater than 0. Only applicable for proxyMode=userspace.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>conntrack</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConntrackConfiguration">
+                <span style="font-family: monospace">KubeProxyConntrackConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          conntrack contains conntrack-related configuration options.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>configSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
+than 0.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodePortAddresses</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          nodePortAddresses is the --nodeport-addresses value for kube-proxy process. Values must be valid
+IP blocks. These values are as a parameter to select the interfaces where nodeport works.
+In case someone would like to expose a service on localhost for local visit and some other interfaces for
+particular purpose, a list of IP blocks would do that.
+If set it to "127.0.0.0/8", kube-proxy will only select the loopback interface for NodePort.
+If set it to a non-zero IP block, kube-proxy will filter that down to just the IPs that applied to the node.
+An empty string slice is meant to select all network interfaces.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>winkernel</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyWinkernelConfiguration">
+                <span style="font-family: monospace">KubeProxyWinkernelConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          winkernel contains winkernel-related configuration options.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>showHiddenMetricsForVersion</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ShowHiddenMetricsForVersion is the version for which you want to show hidden metrics.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>detectLocalMode</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeproxy-config-k8s-io-v1alpha1-LocalMode">
+                <span style="font-family: monospace">LocalMode</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeproxy-config-k8s-io-v1alpha1-KubeProxyConntrackConfiguration">KubeProxyConntrackConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration">KubeProxyConfiguration</a>)
+    </p>
+  
+
+  <p>KubeProxyConntrackConfiguration contains conntrack settings for
+the Kubernetes proxy server.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>maxPerCore</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          maxPerCore is the maximum number of NAT connections to track
+per CPU core (0 to leave the limit as-is and ignore min).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>min</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          min is the minimum value of connect-tracking records to allocate,
+regardless of conntrackMaxPerCore (set maxPerCore=0 to leave the limit as-is).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tcpEstablishedTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          tcpEstablishedTimeout is how long an idle TCP connection will be kept open
+(e.g. '2s').  Must be greater than 0 to set.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tcpCloseWaitTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          tcpCloseWaitTimeout is how long an idle conntrack entry
+in CLOSE_WAIT state will remain in the conntrack
+table. (e.g. '60s'). Must be greater than 0 to set.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPTablesConfiguration">KubeProxyIPTablesConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration">KubeProxyConfiguration</a>)
+    </p>
+  
+
+  <p>KubeProxyIPTablesConfiguration contains iptables-related configuration
+details for the Kubernetes proxy server.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>masqueradeBit</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
+the pure iptables proxy mode. Values must be within the range [0, 31].
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>masqueradeAll</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>syncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
+'2h22m').  Must be greater than 0.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>minSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
+'2h22m').
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPVSConfiguration">KubeProxyIPVSConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration">KubeProxyConfiguration</a>)
+    </p>
+  
+
+  <p>KubeProxyIPVSConfiguration contains ipvs-related configuration
+details for the Kubernetes proxy server.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>syncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
+'2h22m').  Must be greater than 0.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>minSyncPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
+'2h22m').
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>scheduler</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ipvs scheduler
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>excludeCIDRs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
+when cleaning up ipvs services.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>strictARP</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
+from kube-ipvs0 interface
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tcpTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          tcpTimeout is the timeout value used for idle IPVS TCP sessions.
+The default value is 0, which preserves the current timeout value on the system.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tcpFinTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          tcpFinTimeout is the timeout value used for IPVS TCP sessions after receiving a FIN.
+The default value is 0, which preserves the current timeout value on the system.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>udpTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          udpTimeout is the timeout value used for IPVS UDP packets.
+The default value is 0, which preserves the current timeout value on the system.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeproxy-config-k8s-io-v1alpha1-KubeProxyWinkernelConfiguration">KubeProxyWinkernelConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration">KubeProxyConfiguration</a>)
+    </p>
+  
+
+  <p>KubeProxyWinkernelConfiguration contains Windows/HNS settings for
+the Kubernetes proxy server.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>networkName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          networkName is the name of the network kube-proxy will use
+to create endpoints and policies
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>sourceVip</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          sourceVip is the IP address of the source VIP endoint used for
+NAT when loadbalancing
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableDSR</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableDSR tells kube-proxy whether HNS policies should be created
+with DSR
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeproxy-config-k8s-io-v1alpha1-LocalMode">LocalMode
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration">KubeProxyConfiguration</a>)
+    </p>
+  
+
+  <p>LocalMode represents modes to detect local traffic from the node</p>
+
+  
+
+            
+              
+  <H3 id="kubeproxy-config-k8s-io-v1alpha1-ProxyMode">ProxyMode
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration">KubeProxyConfiguration</a>)
+    </p>
+  
+
+  <p>ProxyMode represents modes used by the Kubernetes proxy server.
+
+Currently, three modes of proxy are available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'
+(newer, faster), 'ipvs'(newest, better in performance and scalability).
+
+Two modes of proxy are available in Windows platform: 'userspace'(older, stable) and 'kernelspace' (newer, faster).
+
+In Linux platform, if proxy mode is blank, use the best-available proxy (currently iptables, but may change in the
+future). If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are
+insufficient, this always falls back to the userspace proxy. IPVS mode will be enabled when proxy mode is set to 'ipvs',
+and the fall back path is firstly iptables and then userspace.
+
+In Windows platform, if proxy mode is blank, use the best-available proxy (currently userspace, but may change in the
+future). If winkernel proxy is selected, regardless of how, but the Windows kernel can't support this mode of proxy,
+this always falls back to the userspace proxy.</p>
+
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/kube-scheduler-config.v1beta1.html
+++ b/genref/output/html/kube-scheduler-config.v1beta1.html
@@ -1,0 +1,5586 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="kubescheduler-config-k8s-io-v1">Package: <span style="font-family: monospace">kubescheduler.config.k8s.io/v1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#kubescheduler-config-k8s-io-v1-Policy">Policy</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-Policy">Policy
+    </H3>
+
+  
+
+  <p>Policy describes a struct for a policy resource used in api.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>Policy</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>predicates</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-PredicatePolicy">
+                <span style="font-family: monospace">[]PredicatePolicy</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the information to configure the fit predicate functions
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>priorities</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-PriorityPolicy">
+                <span style="font-family: monospace">[]PriorityPolicy</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the information to configure the priority functions
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>extenders</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-LegacyExtender">
+                <span style="font-family: monospace">[]LegacyExtender</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the information to communicate with the extender(s)
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>hardPodAffinitySymmetricWeight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
+corresponding to every RequiredDuringScheduling affinity rule.
+HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>alwaysCheckAllPredicates</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          When AlwaysCheckAllPredicates is set to true, scheduler checks all
+the configured predicates even after one or more of them fails.
+When the flag is set to false, scheduler skips checking the rest
+of the predicates after it finds one predicate that failed.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ExtenderManagedResource">ExtenderManagedResource
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-Extender">Extender</a>, 
+        <a href="#kubescheduler-config-k8s-io-v1-LegacyExtender">LegacyExtender</a>)
+    </p>
+  
+
+  <p>ExtenderManagedResource describes the arguments of extended resources
+managed by an extender.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name is the extended resource name.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ignoredByScheduler</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          IgnoredByScheduler indicates whether kube-scheduler should ignore this
+resource when applying predicates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ExtenderTLSConfig">ExtenderTLSConfig
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-Extender">Extender</a>, 
+        <a href="#kubescheduler-config-k8s-io-v1-LegacyExtender">LegacyExtender</a>)
+    </p>
+  
+
+  <p>ExtenderTLSConfig contains settings to enable TLS with extender</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>insecure</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Server should be accessed without verifying the TLS certificate. For testing only.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>serverName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ServerName is passed to the server for SNI and is used in the client to check server
+certificates against. If ServerName is empty, the hostname used to contact the
+server is used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Server requires TLS client certificate authentication
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>keyFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Server requires TLS client certificate authentication
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Trusted root certificates for server
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certData</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]byte</span>
+            
+          
+        </td>
+        <td>
+          
+
+          CertData holds PEM-encoded bytes (typically read from a client certificate file).
+CertData takes precedence over CertFile
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>keyData</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]byte</span>
+            
+          
+        </td>
+        <td>
+          
+
+          KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
+KeyData takes precedence over KeyFile
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caData</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]byte</span>
+            
+          
+        </td>
+        <td>
+          
+
+          CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
+CAData takes precedence over CAFile
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-LabelPreference">LabelPreference
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PriorityArgument">PriorityArgument</a>)
+    </p>
+  
+
+  <p>LabelPreference holds the parameters that are used to configure the corresponding priority function</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>label</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Used to identify node "groups"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>presence</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          This is a boolean flag
+If true, higher priority is given to nodes that have the label
+If false, higher priority is given to nodes that do not have the label
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-LabelsPresence">LabelsPresence
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PredicateArgument">PredicateArgument</a>)
+    </p>
+  
+
+  <p>LabelsPresence holds the parameters that are used to configure the corresponding predicate in scheduler policy configuration.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>labels</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The list of labels that identify node "groups"
+All of the labels should be either present (or absent) for the node to be considered a fit for hosting the pod
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>presence</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The boolean flag that indicates whether the labels should be present or absent from the node
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-LegacyExtender">LegacyExtender
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-Policy">Policy</a>)
+    </p>
+  
+
+  <p>LegacyExtender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
+it is assumed that the extender chose not to provide that extension.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>urlPrefix</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          URLPrefix at which the extender is available
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>filterVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>preemptVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>prioritizeVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The numeric multiplier for the node scores that the prioritize call generates.
+The weight should be a positive integer
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bindVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
+can implement this function.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableHttps</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          EnableHTTPS specifies whether https should be used to communicate with the extender
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsConfig</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ExtenderTLSConfig">
+                <span style="font-family: monospace">ExtenderTLSConfig</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          TLSConfig specifies the transport layer security config
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>httpTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/time#Duration">
+                <span style="font-family: monospace">time.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
+timeout is ignored, k8s/other extenders priorities are used to select the node.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeCacheCapable</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeCacheCapable specifies that the extender is capable of caching node information,
+so the scheduler should only send minimal information about the eligible nodes
+assuming that the extender already cached full details of all nodes in the cluster
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>managedResources</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ExtenderManagedResource">
+                <span style="font-family: monospace">[]ExtenderManagedResource</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ManagedResources is a list of extended resources that are managed by
+this extender.
+- A pod will be sent to the extender on the Filter, Prioritize and Bind
+  (if the extender is the binder) phases iff the pod requests at least
+  one of the extended resources in this list. If empty or unspecified,
+  all pods will be sent to this extender.
+- If IgnoredByScheduler is set to true for a resource, kube-scheduler
+  will skip checking the resource in predicates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ignorable</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+fail when the extender returns an error or is not reachable.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-PredicateArgument">PredicateArgument
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PredicatePolicy">PredicatePolicy</a>)
+    </p>
+  
+
+  <p>PredicateArgument represents the arguments to configure predicate functions in scheduler policy configuration.
+Only one of its members may be specified</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>serviceAffinity</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ServiceAffinity">
+                <span style="font-family: monospace">ServiceAffinity</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The predicate that provides affinity for pods belonging to a service
+It uses a label to identify nodes that belong to the same "group"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>labelsPresence</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-LabelsPresence">
+                <span style="font-family: monospace">LabelsPresence</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The predicate that checks whether a particular node has a certain label
+defined or not, regardless of value
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-PredicatePolicy">PredicatePolicy
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-Policy">Policy</a>)
+    </p>
+  
+
+  <p>PredicatePolicy describes a struct of a predicate policy.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Identifier of the predicate policy
+For a custom predicate, the name can be user-defined
+For the Kubernetes provided predicates, the name is the identifier of the pre-defined predicate
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>argument</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-PredicateArgument">
+                <span style="font-family: monospace">PredicateArgument</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the parameters to configure the given predicate
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-PriorityArgument">PriorityArgument
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PriorityPolicy">PriorityPolicy</a>)
+    </p>
+  
+
+  <p>PriorityArgument represents the arguments to configure priority functions in scheduler policy configuration.
+Only one of its members may be specified</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>serviceAntiAffinity</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ServiceAntiAffinity">
+                <span style="font-family: monospace">ServiceAntiAffinity</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The priority function that ensures a good spread (anti-affinity) for pods belonging to a service
+It uses a label to identify nodes that belong to the same "group"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>labelPreference</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-LabelPreference">
+                <span style="font-family: monospace">LabelPreference</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The priority function that checks whether a particular node has a certain label
+defined or not, regardless of value
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>requestedToCapacityRatioArguments</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments">
+                <span style="font-family: monospace">RequestedToCapacityRatioArguments</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The RequestedToCapacityRatio priority function is parametrized with function shape.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-PriorityPolicy">PriorityPolicy
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-Policy">Policy</a>)
+    </p>
+  
+
+  <p>PriorityPolicy describes a struct of a priority policy.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Identifier of the priority policy
+For a custom priority, the name can be user-defined
+For the Kubernetes provided priority functions, the name is the identifier of the pre-defined priority function
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The numeric multiplier for the node scores that the priority function generates
+The weight should be non-zero and can be a positive or a negative integer
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>argument</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-PriorityArgument">
+                <span style="font-family: monospace">PriorityArgument</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the parameters to configure the given priority function
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments">RequestedToCapacityRatioArguments
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PriorityArgument">PriorityArgument</a>)
+    </p>
+  
+
+  <p>RequestedToCapacityRatioArguments holds arguments specific to RequestedToCapacityRatio priority function.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>shape</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-UtilizationShapePoint">
+                <span style="font-family: monospace">[]UtilizationShapePoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Array of point defining priority function shape.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ResourceSpec">
+                <span style="font-family: monospace">[]ResourceSpec</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ResourceSpec">ResourceSpec
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments">RequestedToCapacityRatioArguments</a>)
+    </p>
+  
+
+  <p>ResourceSpec represents single resource and weight for bin packing of priority RequestedToCapacityRatioArguments.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name of the resource to be managed by RequestedToCapacityRatio function.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Weight of the resource.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ServiceAffinity">ServiceAffinity
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PredicateArgument">PredicateArgument</a>)
+    </p>
+  
+
+  <p>ServiceAffinity holds the parameters that are used to configure the corresponding predicate in scheduler policy configuration.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>labels</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The list of labels that identify node "groups"
+All of the labels should match for the node to be considered a fit for hosting the pod
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ServiceAntiAffinity">ServiceAntiAffinity
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PriorityArgument">PriorityArgument</a>)
+    </p>
+  
+
+  <p>ServiceAntiAffinity holds the parameters that are used to configure the corresponding priority function</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>label</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Used to identify node "groups"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-UtilizationShapePoint">UtilizationShapePoint
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments">RequestedToCapacityRatioArguments</a>)
+    </p>
+  
+
+  <p>UtilizationShapePoint represents single point of priority function shape.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>utilization</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>score</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Score assigned to given utilization (y axis). Valid values are 0 to 10.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+          
+          
+            
+            
+              
+                
+  <H3 id="ClientConnectionConfiguration">ClientConnectionConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration">KubeSchedulerConfiguration</a>)
+    </p>
+  
+
+  <p>ClientConnectionConfiguration contains details for constructing a client.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>kubeconfig</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          kubeconfig is the path to a KubeConfig file.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>acceptContentTypes</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
+default value of 'application/json'. This field will control all connections to the server used by a particular
+client.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>contentType</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          contentType is the content type used when sending data to the server from this client.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>qps</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">float32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          qps controls the number of queries per second allowed for this connection.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>burst</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          burst allows extra queries to accumulate when a client is exceeding its rate.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+              
+            
+              
+                
+  <H3 id="DebuggingConfiguration">DebuggingConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration">KubeSchedulerConfiguration</a>)
+    </p>
+  
+
+  <p>DebuggingConfiguration holds configuration for Debugging related features.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>enableProfiling</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableProfiling enables profiling via web interface host:port/debug/pprof/
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableContentionProfiling</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableContentionProfiling enables lock contention profiling, if
+enableProfiling is true.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+              
+            
+              
+                
+  <H3 id="LeaderElectionConfiguration">LeaderElectionConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration">KubeSchedulerConfiguration</a>)
+    </p>
+  
+
+  <p>LeaderElectionConfiguration defines the configuration of leader election
+clients for components that can run with leader election enabled.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>leaderElect</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          leaderElect enables a leader election client to gain leadership
+before executing the main loop. Enable this when running replicated
+components for high availability.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>leaseDuration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          leaseDuration is the duration that non-leader candidates will wait
+after observing a leadership renewal until attempting to acquire
+leadership of a led but unrenewed leader slot. This is effectively the
+maximum duration that a leader can be stopped before it is replaced
+by another candidate. This is only applicable if leader election is
+enabled.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>renewDeadline</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          renewDeadline is the interval between attempts by the acting master to
+renew a leadership slot before it stops leading. This must be less
+than or equal to the lease duration. This is only applicable if leader
+election is enabled.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>retryPeriod</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          retryPeriod is the duration the clients should wait between attempting
+acquisition and renewal of a leadership. This is only applicable if
+leader election is enabled.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resourceLock</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          resourceLock indicates the resource object type that will be used to lock
+during leader election cycles.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resourceName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          resourceName indicates the name of resource object that will be used to lock
+during leader election cycles.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resourceNamespace</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          resourceName indicates the namespace of resource object that will be used to lock
+during leader election cycles.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+              
+            
+              
+                
+  <H3 id="LoggingConfiguration">LoggingConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletConfiguration">KubeletConfiguration</a>)
+    </p>
+  
+
+  <p>LoggingConfiguration contains logging options
+Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>format</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Format Flag specifies the structure of log messages.
+default value of format is `text`
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>sanitization</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+              
+            
+          
+
+          <HR />
+        
+          
+          
+            <H2 id="kubescheduler-config-k8s-io-v1beta1">Package: <span style="font-family: monospace">kubescheduler.config.k8s.io/v1beta1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-DefaultPreemptionArgs">DefaultPreemptionArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-InterPodAffinityArgs">InterPodAffinityArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration">KubeSchedulerConfiguration</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-NodeAffinityArgs">NodeAffinityArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-NodeLabelArgs">NodeLabelArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-NodeResourcesFitArgs">NodeResourcesFitArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-NodeResourcesLeastAllocatedArgs">NodeResourcesLeastAllocatedArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-NodeResourcesMostAllocatedArgs">NodeResourcesMostAllocatedArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadArgs">PodTopologySpreadArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-RequestedToCapacityRatioArgs">RequestedToCapacityRatioArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-ServiceAffinityArgs">ServiceAffinityArgs</a>
+                  </li><li>
+                    <a href="#kubescheduler-config-k8s-io-v1beta1-VolumeBindingArgs">VolumeBindingArgs</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-DefaultPreemptionArgs">DefaultPreemptionArgs
+    </H3>
+
+  
+
+  <p>DefaultPreemptionArgs holds arguments used to configure the
+DefaultPreemption plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>DefaultPreemptionArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>minCandidateNodesPercentage</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          MinCandidateNodesPercentage is the minimum number of candidates to
+shortlist when dry running preemption as a percentage of number of nodes.
+Must be in the range [0, 100]. Defaults to 10% of the cluster size if
+unspecified.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>minCandidateNodesAbsolute</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          MinCandidateNodesAbsolute is the absolute minimum number of candidates to
+shortlist. The likely number of candidates enumerated for dry running
+preemption is given by the formula:
+numCandidates = max(numNodes &lowast; minCandidateNodesPercentage, minCandidateNodesAbsolute)
+We say "likely" because there are other factors such as PDB violations
+that play a role in the number of candidates shortlisted. Must be at least
+0 nodes. Defaults to 100 nodes if unspecified.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-InterPodAffinityArgs">InterPodAffinityArgs
+    </H3>
+
+  
+
+  <p>InterPodAffinityArgs holds arguments used to configure the InterPodAffinity plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>InterPodAffinityArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>hardPodAffinityWeight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          HardPodAffinityWeight is the scoring weight for existing pods with a
+matching hard affinity to the incoming pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration">KubeSchedulerConfiguration
+    </H3>
+
+  
+
+  <p>KubeSchedulerConfiguration configures a scheduler</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>KubeSchedulerConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>parallelism</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Parallelism defines the amount of parallelism in algorithms for scheduling a Pods. Must be greater than 0. Defaults to 16
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>leaderElection</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#LeaderElectionConfiguration">
+                <span style="font-family: monospace">LeaderElectionConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          LeaderElection defines the configuration of leader election client.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clientConnection</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#ClientConnectionConfiguration">
+                <span style="font-family: monospace">ClientConnectionConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>healthzBindAddress</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          HealthzBindAddress is the IP address and port for the health check server to serve on,
+defaulting to 0.0.0.0:10251
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>metricsBindAddress</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          MetricsBindAddress is the IP address and port for the metrics server to
+serve on, defaulting to 0.0.0.0:10251.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>DebuggingConfiguration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#DebuggingConfiguration">
+                <span style="font-family: monospace">DebuggingConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+            <p>(Members of <code>DebuggingConfiguration</code> are embedded into this type.)</p>
+          
+
+          DebuggingConfiguration holds configuration for Debugging related features
+TODO: We might wanna make this a substruct like Debugging componentbaseconfigv1alpha1.DebuggingConfiguration
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>percentageOfNodesToScore</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          PercentageOfNodesToScore is the percentage of all nodes that once found feasible
+for running a pod, the scheduler stops its search for more feasible nodes in
+the cluster. This helps improve scheduler's performance. Scheduler always tries to find
+at least "minFeasibleNodesToFind" feasible nodes no matter what the value of this flag is.
+Example: if the cluster size is 500 nodes and the value of this flag is 30,
+then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
+When the value is 0, default percentage (5%--50% based on the size of the cluster) of the
+nodes will be scored.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>podInitialBackoffSeconds</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
+If specified, it must be greater than 0. If this value is null, the default value (1s)
+will be used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>podMaxBackoffSeconds</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          PodMaxBackoffSeconds is the max backoff for unschedulable pods.
+If specified, it must be greater than podInitialBackoffSeconds. If this value is null,
+the default value (10s) will be used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>profiles</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerProfile">
+                <span style="font-family: monospace">[]KubeSchedulerProfile</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Profiles are scheduling profiles that kube-scheduler supports. Pods can
+choose to be scheduled under a particular profile by setting its associated
+scheduler name. Pods that don't specify any scheduler name are scheduled
+with the "default-scheduler" profile, if present here.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>extenders</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-Extender">
+                <span style="font-family: monospace">[]Extender</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Extenders are the list of scheduler extenders, each holding the values of how to communicate
+with the extender. These extenders are shared by all scheduler profiles.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-NodeAffinityArgs">NodeAffinityArgs
+    </H3>
+
+  
+
+  <p>NodeAffinityArgs holds arguments to configure the NodeAffinity plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>NodeAffinityArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>addedAffinity</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#nodeaffinity-v1-core">
+                <span style="font-family: monospace">core/v1.NodeAffinity</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          AddedAffinity is applied to all Pods additionally to the NodeAffinity
+specified in the PodSpec. That is, Nodes need to satisfy AddedAffinity
+AND .spec.NodeAffinity. AddedAffinity is empty by default (all Nodes
+match).
+When AddedAffinity is used, some Pods with affinity requirements that match
+a specific Node (such as Daemonset Pods) might remain unschedulable.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-NodeLabelArgs">NodeLabelArgs
+    </H3>
+
+  
+
+  <p>NodeLabelArgs holds arguments used to configure the NodeLabel plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>NodeLabelArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>presentLabels</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          PresentLabels should be present for the node to be considered a fit for hosting the pod
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>absentLabels</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          AbsentLabels should be absent for the node to be considered a fit for hosting the pod
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>presentLabelsPreference</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Nodes that have labels in the list will get a higher score.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>absentLabelsPreference</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Nodes that don't have labels in the list will get a higher score.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-NodeResourcesFitArgs">NodeResourcesFitArgs
+    </H3>
+
+  
+
+  <p>NodeResourcesFitArgs holds arguments used to configure the NodeResourcesFit plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>NodeResourcesFitArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>ignoredResources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          IgnoredResources is the list of resources that NodeResources fit filter
+should ignore.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ignoredResourceGroups</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          IgnoredResourceGroups defines the list of resource groups that NodeResources fit filter should ignore.
+e.g. if group is ["example.com"], it will ignore all resource names that begin
+with "example.com", such as "example.com/aaa" and "example.com/bbb".
+A resource group name can't contain '/'.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-NodeResourcesLeastAllocatedArgs">NodeResourcesLeastAllocatedArgs
+    </H3>
+
+  
+
+  <p>NodeResourcesLeastAllocatedArgs holds arguments used to configure NodeResourcesLeastAllocated plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>NodeResourcesLeastAllocatedArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-ResourceSpec">
+                <span style="font-family: monospace">[]ResourceSpec</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Resources to be managed, if no resource is provided, default resource set with both
+the weight of "cpu" and "memory" set to "1" will be applied.
+Resource with "0" weight will not accountable for the final score.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-NodeResourcesMostAllocatedArgs">NodeResourcesMostAllocatedArgs
+    </H3>
+
+  
+
+  <p>NodeResourcesMostAllocatedArgs holds arguments used to configure NodeResourcesMostAllocated plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>NodeResourcesMostAllocatedArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-ResourceSpec">
+                <span style="font-family: monospace">[]ResourceSpec</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Resources to be managed, if no resource is provided, default resource set with both
+the weight of "cpu" and "memory" set to "1" will be applied.
+Resource with "0" weight will not accountable for the final score.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadArgs">PodTopologySpreadArgs
+    </H3>
+
+  
+
+  <p>PodTopologySpreadArgs holds arguments used to configure the PodTopologySpread plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>PodTopologySpreadArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>defaultConstraints</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#topologyspreadconstraint-v1-core">
+                <span style="font-family: monospace">[]core/v1.TopologySpreadConstraint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          DefaultConstraints defines topology spread constraints to be applied to
+Pods that don't define any in `pod.spec.topologySpreadConstraints`.
+`.defaultConstraints[&lowast;].labelSelectors` must be empty, as they are
+deduced from the Pod's membership to Services, ReplicationControllers,
+ReplicaSets or StatefulSets.
+When not empty, .defaultingType must be "List".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>defaultingType</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadConstraintsDefaulting">
+                <span style="font-family: monospace">PodTopologySpreadConstraintsDefaulting</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          DefaultingType determines how .defaultConstraints are deduced. Can be one
+of "System" or "List".
+
+- "System": Use kubernetes defined constraints that spread Pods among
+  Nodes and Zones.
+- "List": Use constraints defined in .defaultConstraints.
+
+Defaults to "List" if feature gate DefaultPodTopologySpread is disabled
+and to "System" if enabled.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-RequestedToCapacityRatioArgs">RequestedToCapacityRatioArgs
+    </H3>
+
+  
+
+  <p>RequestedToCapacityRatioArgs holds arguments used to configure RequestedToCapacityRatio plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>RequestedToCapacityRatioArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>shape</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-UtilizationShapePoint">
+                <span style="font-family: monospace">[]UtilizationShapePoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Points defining priority function shape
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-ResourceSpec">
+                <span style="font-family: monospace">[]ResourceSpec</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Resources to be managed
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-ServiceAffinityArgs">ServiceAffinityArgs
+    </H3>
+
+  
+
+  <p>ServiceAffinityArgs holds arguments used to configure the ServiceAffinity plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>ServiceAffinityArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>affinityLabels</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          AffinityLabels are homogeneous for pods that are scheduled to a node.
+(i.e. it returns true IFF this pod can be added to this node such that all other pods in
+the same service are running on nodes with the exact same values for Labels).
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>antiAffinityLabelsPreference</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          AntiAffinityLabelsPreference are the labels to consider for service anti affinity scoring.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-VolumeBindingArgs">VolumeBindingArgs
+    </H3>
+
+  
+
+  <p>VolumeBindingArgs holds arguments used to configure the VolumeBinding plugin.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>VolumeBindingArgs</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>bindTimeoutSeconds</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          BindTimeoutSeconds is the timeout in seconds in volume binding operation.
+Value must be non-negative integer. The value zero indicates no waiting.
+If this value is nil, the default value (600) will be used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-Extender">Extender
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration">KubeSchedulerConfiguration</a>)
+    </p>
+  
+
+  <p>Extender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
+it is assumed that the extender chose not to provide that extension.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>urlPrefix</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          URLPrefix at which the extender is available
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>filterVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>preemptVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>prioritizeVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The numeric multiplier for the node scores that the prioritize call generates.
+The weight should be a positive integer
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bindVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
+can implement this function.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableHTTPS</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          EnableHTTPS specifies whether https should be used to communicate with the extender
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsConfig</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ExtenderTLSConfig">
+                <span style="font-family: monospace">ExtenderTLSConfig</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          TLSConfig specifies the transport layer security config
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>httpTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
+timeout is ignored, k8s/other extenders priorities are used to select the node.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeCacheCapable</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeCacheCapable specifies that the extender is capable of caching node information,
+so the scheduler should only send minimal information about the eligible nodes
+assuming that the extender already cached full details of all nodes in the cluster
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>managedResources</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ExtenderManagedResource">
+                <span style="font-family: monospace">[]ExtenderManagedResource</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ManagedResources is a list of extended resources that are managed by
+this extender.
+- A pod will be sent to the extender on the Filter, Prioritize and Bind
+  (if the extender is the binder) phases iff the pod requests at least
+  one of the extended resources in this list. If empty or unspecified,
+  all pods will be sent to this extender.
+- If IgnoredByScheduler is set to true for a resource, kube-scheduler
+  will skip checking the resource in predicates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ignorable</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+fail when the extender returns an error or is not reachable.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-KubeSchedulerProfile">KubeSchedulerProfile
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration">KubeSchedulerConfiguration</a>)
+    </p>
+  
+
+  <p>KubeSchedulerProfile is a scheduling profile.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>schedulerName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          SchedulerName is the name of the scheduler associated to this profile.
+If SchedulerName matches with the pod's "spec.schedulerName", then the pod
+is scheduled with this profile.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>plugins</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-Plugins">
+                <span style="font-family: monospace">Plugins</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Plugins specify the set of plugins that should be enabled or disabled.
+Enabled plugins are the ones that should be enabled in addition to the
+default plugins. Disabled plugins are any of the default plugins that
+should be disabled.
+When no enabled or disabled plugin is specified for an extension point,
+default plugins for that extension point will be used if there is any.
+If a QueueSort plugin is specified, the same QueueSort Plugin and
+PluginConfig must be specified for all profiles.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>pluginConfig</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginConfig">
+                <span style="font-family: monospace">[]PluginConfig</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          PluginConfig is an optional set of custom plugin arguments for each plugin.
+Omitting config args for a plugin is equivalent to using the default config
+for that plugin.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-Plugin">Plugin
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">PluginSet</a>)
+    </p>
+  
+
+  <p>Plugin specifies a plugin name and its weight when applicable. Weight is used only for Score plugins.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name defines the name of plugin
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Weight defines the weight of plugin, only used for Score plugins.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-PluginConfig">PluginConfig
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerProfile">KubeSchedulerProfile</a>)
+    </p>
+  
+
+  <p>PluginConfig specifies arguments that should be passed to a plugin at the time of initialization.
+A plugin that is invoked at multiple extension points is initialized once. Args can have arbitrary structure.
+It is up to the plugin to process these Args.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name defines the name of plugin being configured
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>args</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension">
+                <span style="font-family: monospace">k8s.io/apimachinery/pkg/runtime.RawExtension</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Args defines the arguments passed to the plugins at the time of initialization. Args can have arbitrary structure.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-PluginSet">PluginSet
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-Plugins">Plugins</a>)
+    </p>
+  
+
+  <p>PluginSet specifies enabled and disabled plugins for an extension point.
+If an array is empty, missing, or nil, default plugins at that extension point will be used.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>enabled</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-Plugin">
+                <span style="font-family: monospace">[]Plugin</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Enabled specifies plugins that should be enabled in addition to default plugins.
+These are called after default plugins and in the same order specified here.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>disabled</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-Plugin">
+                <span style="font-family: monospace">[]Plugin</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Disabled specifies default plugins that should be disabled.
+When all default plugins need to be disabled, an array containing only one "&lowast;" should be provided.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-Plugins">Plugins
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerProfile">KubeSchedulerProfile</a>)
+    </p>
+  
+
+  <p>Plugins include multiple extension points. When specified, the list of plugins for
+a particular extension point are the only ones enabled. If an extension point is
+omitted from the config, then the default set of plugins is used for that extension point.
+Enabled plugins are called in the order specified here, after default plugins. If they need to
+be invoked before default plugins, default plugins must be disabled and re-enabled here in desired order.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>queueSort</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          QueueSort is a list of plugins that should be invoked when sorting pods in the scheduling queue.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>preFilter</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          PreFilter is a list of plugins that should be invoked at "PreFilter" extension point of the scheduling framework.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>filter</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>postFilter</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          PostFilter is a list of plugins that are invoked after filtering phase, no matter whether filtering succeeds or not.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>preScore</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          PreScore is a list of plugins that are invoked before scoring.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>score</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Score is a list of plugins that should be invoked when ranking nodes that have passed the filtering phase.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>reserve</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Reserve is a list of plugins invoked when reserving/unreserving resources
+after a node is assigned to run the pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>permit</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Permit is a list of plugins that control binding of a Pod. These plugins can prevent or delay binding of a Pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>preBind</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          PreBind is a list of plugins that should be invoked before a pod is bound.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bind</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Bind is a list of plugins that should be invoked at "Bind" extension point of the scheduling framework.
+The scheduler call these plugins in order. Scheduler skips the rest of these plugins as soon as one returns success.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>postBind</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet">
+                <span style="font-family: monospace">PluginSet</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          PostBind is a list of plugins that should be invoked after a pod is successfully bound.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadConstraintsDefaulting">PodTopologySpreadConstraintsDefaulting
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadArgs">PodTopologySpreadArgs</a>)
+    </p>
+  
+
+  <p>PodTopologySpreadConstraintsDefaulting defines how to set default constraints
+for the PodTopologySpread plugin.</p>
+
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-ResourceSpec">ResourceSpec
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-NodeResourcesLeastAllocatedArgs">NodeResourcesLeastAllocatedArgs</a>, 
+        <a href="#kubescheduler-config-k8s-io-v1beta1-NodeResourcesMostAllocatedArgs">NodeResourcesMostAllocatedArgs</a>, 
+        <a href="#kubescheduler-config-k8s-io-v1beta1-RequestedToCapacityRatioArgs">RequestedToCapacityRatioArgs</a>)
+    </p>
+  
+
+  <p>ResourceSpec represents single resource and weight for bin packing of priority RequestedToCapacityRatioArguments.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name of the resource to be managed by RequestedToCapacityRatio function.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Weight of the resource.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1beta1-UtilizationShapePoint">UtilizationShapePoint
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-RequestedToCapacityRatioArgs">RequestedToCapacityRatioArgs</a>)
+    </p>
+  
+
+  <p>UtilizationShapePoint represents single point of priority function shape.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>utilization</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>score</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Score assigned to given utilization (y axis). Valid values are 0 to 10.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/kube-scheduler-policy-config.v1.html
+++ b/genref/output/html/kube-scheduler-policy-config.v1.html
@@ -1,0 +1,2051 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="kubescheduler-config-k8s-io-v1">Package: <span style="font-family: monospace">kubescheduler.config.k8s.io/v1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#kubescheduler-config-k8s-io-v1-Policy">Policy</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-Policy">Policy
+    </H3>
+
+  
+
+  <p>Policy describes a struct for a policy resource used in api.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubescheduler.config.k8s.io/v1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>Policy</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>predicates</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-PredicatePolicy">
+                <span style="font-family: monospace">[]PredicatePolicy</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the information to configure the fit predicate functions
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>priorities</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-PriorityPolicy">
+                <span style="font-family: monospace">[]PriorityPolicy</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the information to configure the priority functions
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>extenders</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-LegacyExtender">
+                <span style="font-family: monospace">[]LegacyExtender</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the information to communicate with the extender(s)
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>hardPodAffinitySymmetricWeight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
+corresponding to every RequiredDuringScheduling affinity rule.
+HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>alwaysCheckAllPredicates</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          When AlwaysCheckAllPredicates is set to true, scheduler checks all
+the configured predicates even after one or more of them fails.
+When the flag is set to false, scheduler skips checking the rest
+of the predicates after it finds one predicate that failed.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ExtenderManagedResource">ExtenderManagedResource
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-Extender">Extender</a>, 
+        <a href="#kubescheduler-config-k8s-io-v1-LegacyExtender">LegacyExtender</a>)
+    </p>
+  
+
+  <p>ExtenderManagedResource describes the arguments of extended resources
+managed by an extender.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name is the extended resource name.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ignoredByScheduler</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          IgnoredByScheduler indicates whether kube-scheduler should ignore this
+resource when applying predicates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ExtenderTLSConfig">ExtenderTLSConfig
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1beta1-Extender">Extender</a>, 
+        <a href="#kubescheduler-config-k8s-io-v1-LegacyExtender">LegacyExtender</a>)
+    </p>
+  
+
+  <p>ExtenderTLSConfig contains settings to enable TLS with extender</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>insecure</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Server should be accessed without verifying the TLS certificate. For testing only.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>serverName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ServerName is passed to the server for SNI and is used in the client to check server
+certificates against. If ServerName is empty, the hostname used to contact the
+server is used.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Server requires TLS client certificate authentication
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>keyFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Server requires TLS client certificate authentication
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Trusted root certificates for server
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certData</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]byte</span>
+            
+          
+        </td>
+        <td>
+          
+
+          CertData holds PEM-encoded bytes (typically read from a client certificate file).
+CertData takes precedence over CertFile
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>keyData</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]byte</span>
+            
+          
+        </td>
+        <td>
+          
+
+          KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
+KeyData takes precedence over KeyFile
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caData</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]byte</span>
+            
+          
+        </td>
+        <td>
+          
+
+          CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
+CAData takes precedence over CAFile
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-LabelPreference">LabelPreference
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PriorityArgument">PriorityArgument</a>)
+    </p>
+  
+
+  <p>LabelPreference holds the parameters that are used to configure the corresponding priority function</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>label</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Used to identify node "groups"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>presence</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          This is a boolean flag
+If true, higher priority is given to nodes that have the label
+If false, higher priority is given to nodes that do not have the label
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-LabelsPresence">LabelsPresence
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PredicateArgument">PredicateArgument</a>)
+    </p>
+  
+
+  <p>LabelsPresence holds the parameters that are used to configure the corresponding predicate in scheduler policy configuration.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>labels</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The list of labels that identify node "groups"
+All of the labels should be either present (or absent) for the node to be considered a fit for hosting the pod
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>presence</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The boolean flag that indicates whether the labels should be present or absent from the node
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-LegacyExtender">LegacyExtender
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-Policy">Policy</a>)
+    </p>
+  
+
+  <p>LegacyExtender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
+it is assumed that the extender chose not to provide that extension.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>urlPrefix</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          URLPrefix at which the extender is available
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>filterVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>preemptVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>prioritizeVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The numeric multiplier for the node scores that the prioritize call generates.
+The weight should be a positive integer
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bindVerb</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
+can implement this function.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableHttps</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          EnableHTTPS specifies whether https should be used to communicate with the extender
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsConfig</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ExtenderTLSConfig">
+                <span style="font-family: monospace">ExtenderTLSConfig</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          TLSConfig specifies the transport layer security config
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>httpTimeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/time#Duration">
+                <span style="font-family: monospace">time.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
+timeout is ignored, k8s/other extenders priorities are used to select the node.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeCacheCapable</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          NodeCacheCapable specifies that the extender is capable of caching node information,
+so the scheduler should only send minimal information about the eligible nodes
+assuming that the extender already cached full details of all nodes in the cluster
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>managedResources</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ExtenderManagedResource">
+                <span style="font-family: monospace">[]ExtenderManagedResource</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ManagedResources is a list of extended resources that are managed by
+this extender.
+- A pod will be sent to the extender on the Filter, Prioritize and Bind
+  (if the extender is the binder) phases iff the pod requests at least
+  one of the extended resources in this list. If empty or unspecified,
+  all pods will be sent to this extender.
+- If IgnoredByScheduler is set to true for a resource, kube-scheduler
+  will skip checking the resource in predicates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ignorable</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+fail when the extender returns an error or is not reachable.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-PredicateArgument">PredicateArgument
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PredicatePolicy">PredicatePolicy</a>)
+    </p>
+  
+
+  <p>PredicateArgument represents the arguments to configure predicate functions in scheduler policy configuration.
+Only one of its members may be specified</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>serviceAffinity</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ServiceAffinity">
+                <span style="font-family: monospace">ServiceAffinity</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The predicate that provides affinity for pods belonging to a service
+It uses a label to identify nodes that belong to the same "group"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>labelsPresence</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-LabelsPresence">
+                <span style="font-family: monospace">LabelsPresence</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The predicate that checks whether a particular node has a certain label
+defined or not, regardless of value
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-PredicatePolicy">PredicatePolicy
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-Policy">Policy</a>)
+    </p>
+  
+
+  <p>PredicatePolicy describes a struct of a predicate policy.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Identifier of the predicate policy
+For a custom predicate, the name can be user-defined
+For the Kubernetes provided predicates, the name is the identifier of the pre-defined predicate
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>argument</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-PredicateArgument">
+                <span style="font-family: monospace">PredicateArgument</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the parameters to configure the given predicate
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-PriorityArgument">PriorityArgument
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PriorityPolicy">PriorityPolicy</a>)
+    </p>
+  
+
+  <p>PriorityArgument represents the arguments to configure priority functions in scheduler policy configuration.
+Only one of its members may be specified</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>serviceAntiAffinity</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ServiceAntiAffinity">
+                <span style="font-family: monospace">ServiceAntiAffinity</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The priority function that ensures a good spread (anti-affinity) for pods belonging to a service
+It uses a label to identify nodes that belong to the same "group"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>labelPreference</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-LabelPreference">
+                <span style="font-family: monospace">LabelPreference</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The priority function that checks whether a particular node has a certain label
+defined or not, regardless of value
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>requestedToCapacityRatioArguments</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments">
+                <span style="font-family: monospace">RequestedToCapacityRatioArguments</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The RequestedToCapacityRatio priority function is parametrized with function shape.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-PriorityPolicy">PriorityPolicy
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-Policy">Policy</a>)
+    </p>
+  
+
+  <p>PriorityPolicy describes a struct of a priority policy.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Identifier of the priority policy
+For a custom priority, the name can be user-defined
+For the Kubernetes provided priority functions, the name is the identifier of the pre-defined priority function
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The numeric multiplier for the node scores that the priority function generates
+The weight should be non-zero and can be a positive or a negative integer
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>argument</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-PriorityArgument">
+                <span style="font-family: monospace">PriorityArgument</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Holds the parameters to configure the given priority function
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments">RequestedToCapacityRatioArguments
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PriorityArgument">PriorityArgument</a>)
+    </p>
+  
+
+  <p>RequestedToCapacityRatioArguments holds arguments specific to RequestedToCapacityRatio priority function.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>shape</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-UtilizationShapePoint">
+                <span style="font-family: monospace">[]UtilizationShapePoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Array of point defining priority function shape.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resources</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubescheduler-config-k8s-io-v1-ResourceSpec">
+                <span style="font-family: monospace">[]ResourceSpec</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ResourceSpec">ResourceSpec
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments">RequestedToCapacityRatioArguments</a>)
+    </p>
+  
+
+  <p>ResourceSpec represents single resource and weight for bin packing of priority RequestedToCapacityRatioArguments.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Name of the resource to be managed by RequestedToCapacityRatio function.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>weight</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Weight of the resource.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ServiceAffinity">ServiceAffinity
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PredicateArgument">PredicateArgument</a>)
+    </p>
+  
+
+  <p>ServiceAffinity holds the parameters that are used to configure the corresponding predicate in scheduler policy configuration.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>labels</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The list of labels that identify node "groups"
+All of the labels should match for the node to be considered a fit for hosting the pod
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-ServiceAntiAffinity">ServiceAntiAffinity
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-PriorityArgument">PriorityArgument</a>)
+    </p>
+  
+
+  <p>ServiceAntiAffinity holds the parameters that are used to configure the corresponding priority function</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>label</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Used to identify node "groups"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubescheduler-config-k8s-io-v1-UtilizationShapePoint">UtilizationShapePoint
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments">RequestedToCapacityRatioArguments</a>)
+    </p>
+  
+
+  <p>UtilizationShapePoint represents single point of priority function shape.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>utilization</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>score</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Score assigned to given utilization (y axis). Valid values are 0 to 10.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/kubeadm-config.v1beta1.html
+++ b/genref/output/html/kubeadm-config.v1beta1.html
@@ -1,0 +1,3376 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="kubeadm-k8s-io-v1beta1">Package: <span style="font-family: monospace">kubeadm.k8s.io/v1beta1</span></H2>
+            <p>&lowast;&lowast;Package v1beta1 has been deprecated by v1beta2&lowast;&lowast;
+
+Package v1beta1 defines the v1beta1 version of the kubeadm configuration file format.
+This version graduates the configuration format to BETA and is a big step towards GA.
+
+A list of changes since v1alpha3:
+
+- `apiServerEndpoint` in `InitConfiguration` was renamed to `localAPIEndpoint` for better clarity of what the field
+  represents.
+- Common fields in ClusterConfiguration such as `&lowast;extraArgs` and `&lowast;extraVolumes` for control plane components are now moved
+  under component structs - i.e. `apiServer`, `controllerManager`, `scheduler`.
+- `auditPolicy` was removed from ClusterConfiguration. Use `extraArgs` in `apiServer` to configure this feature instead.
+- `unifiedControlPlaneImage` in ClusterConfiguration was changed to a boolean field called `useHyperKubeImage`.
+- ClusterConfiguration now has a `dns` field which can be used to select and configure the cluster DNS addon.
+- `featureGates` still exists under ClusterConfiguration, but there are no supported feature gates in 1.13.
+  See the Kubernetes 1.13 changelog for further details.
+- Both `localEtcd` and `dns` configurations now support custom image repositories.
+- The `controlPlane&lowast;`-related fields in JoinConfiguration were refactored into a sub-structure.
+- `clusterName` was removed from JoinConfiguration and the name is now fetched from the existing cluster.
+
+&lowast;&lowast;Migration from old kubeadm config versions&lowast;&lowast;
+
+Please convert your v1alpha3 configuration files to v1beta1 using the `kubeadm config migrate` command of kubeadm v1.13.x
+
+&lowast;&lowast;Basics&lowast;&lowast;
+
+The preferred way to configure kubeadm is to pass an YAML configuration file with the `--config` option. Some of the
+configuration options defined in the kubeadm config file are also available as command line flags, but only
+the most common/simple use case are supported with this approach.
+
+A kubeadm config file could contain multiple configuration types separated using three dashes (`---`).
+
+kubeadm supports the following configuration types:
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+```
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+```
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+```
+```yaml
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+```
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: JoinConfiguration
+```
+
+To print the defaults for `init` and `join` actions use the following commands:
+
+```shell
+kubeadm config print init-defaults
+kubeadm config print join-defaults
+```
+
+The list of configuration types that must be included in a configuration file depends by the action you are
+performing (init or join) and by the configuration options you are going to use (defaults or advanced customization).
+
+If some configuration types are not provided, or provided only partially, kubeadm will use default values.
+Defaults provided by kubeadm help enforce consistency of values across components when required (e.g.
+`--cluster-cidr` flag on controller manager and `clusterCIDR` on kube-proxy).
+
+Users are always allowed to override default values, with the exception of a small subset of setting
+related to security (e.g. enforce authorization-mode Node and RBAC on the API server)
+If the user provides a configuration types that is not expected for the action you are performing,
+kubeadm will ignore those types and print a warning.
+
+&lowast;&lowast;Kubeadm init configuration types&lowast;&lowast;
+
+When executing `kubeadm init` with the `--config` option, the following configuration types could be used:
+`InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`, but only one
+between `InitConfiguration` and `ClusterConfiguration` is mandatory.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+bootstrapTokens:
+  # ...
+nodeRegistration:
+  # ...
+```
+
+The `InitConfiguration` type is used to configure runtime settings. In the case of `kubeadm init`,
+it contains the bootstrap token configuration and all the setting specific to the node where kubeadm
+is executed, including:
+
+- `NodeRegistration`: fields related to registering the new node to the cluster.
+  You can use it to customize the node name, the CRI socket to use or any other
+  settings that should apply to this node only (for example. the node IP).
+
+- `LocalAPIEndpoint`: the endpoint of the API server instance to be deployed on this node.
+  You can use it to customize the API server advertise address, for example.
+
+  ```yaml
+  apiVersion: kubeadm.k8s.io/v1beta1
+  kind: ClusterConfiguration
+  networking:
+    # ...
+  etcd:
+    # ...
+  apiServer:
+    extraArgs:
+      # ...
+    extraVolumes:
+      #  ...
+  # ...
+  ```
+
+The `ClusterConfiguration` type is used to configure cluster-wide settings, including:
+
+- Networking, holds configuration for the networking topology of the cluster.
+  For example, you can use it to customize node subnet or services subnet.
+
+- Etcd configurations that can be used to customize the local etcd or to configure
+  the API server for using an external etcd cluster.
+
+- kube-apiserver, kube-scheduler, kube-controller-manager configurations.
+  You can use it to customize control-plane components by adding customized setting
+  or overriding kubeadm default settings.
+
+```yaml
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+# ...
+```
+
+The `KubeProxyConfiguration` type should be used to change the configuration passed to
+kube-proxy instances deployed in the cluster. If this object is not provided or provided
+only partially, kubeadm applies defaults.
+See [kube-proxy reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) or
+[kube-proxy source code](https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration)
+for more information.
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# ...
+```
+
+The `KubeletConfiguration` type is used to change the configurations passed to all kubelet instances
+deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
+See [kubelet reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) or
+[kubelet source code](https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration)
+for more information.
+
+Here is a fully populated example of a single YAML file containing multiple
+configuration types to be used during a `kubeadm init` run.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+bootstrapTokens:
+- token: "9a08jv.c0izixklcxtmnze7"
+  description: "kubeadm bootstrap token"
+  ttl: "24h"
+- token: "783bde.3f89s0fje9f38fhf"
+  description: "another bootstrap token"
+  usages:
+  - authentication
+  - signing
+  groups:
+  - system:bootstrappers:kubeadm:default-node-token
+nodeRegistration:
+  name: "ec2-10-100-0-1"
+  criSocket: "/var/run/dockershim.sock"
+  taints:
+  - key: "kubeadmNode"
+    value: "master"
+    effect: "NoSchedule"
+  kubeletExtraArgs:
+    cgroup-driver: "cgroupfs"
+localAPIEndpoint:
+  advertiseAddress: "10.100.0.1"
+  bindPort: 6443
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+etcd:
+  # one of local or external
+  local:
+    imageRepository: "k8s.gcr.io"
+    imageTag: "3.2.24"
+    dataDir: "/var/lib/etcd"
+    extraArgs:
+      listen-client-urls: "http://10.100.0.1:2379"
+    serverCertSANs:
+    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
+    peerCertSANs:
+    - "10.100.0.1"
+  # external:
+    # endpoints:
+    # - "10.100.0.1:2379"
+    # - "10.100.0.2:2379"
+    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
+    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
+    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
+networking:
+  serviceSubnet: "10.96.0.0/12"
+  podSubnet: "10.100.0.1/24"
+  dnsDomain: "cluster.local"
+kubernetesVersion: "v1.12.0"
+controlPlaneEndpoint: "10.100.0.1:6443"
+apiServer:
+  extraArgs:
+    authorization-mode: "Node,RBAC"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+  certSANs:
+  - "10.100.1.1"
+  - "ec2-10-100-0-1.compute-1.amazonaws.com"
+  timeoutForControlPlane: 4m0s
+controllerManager:
+  extraArgs:
+    "node-cidr-mask-size": "20"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+scheduler:
+  extraArgs:
+    address: "10.100.0.1"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+certificatesDir: "/etc/kubernetes/pki"
+imageRepository: "k8s.gcr.io"
+useHyperKubeImage: false
+clusterName: "example-cluster"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# kubelet specific options here
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+# kube-proxy specific options here
+```
+
+&lowast;&lowast;Kubeadm join configuration types&lowast;&lowast;
+
+When executing `kubeadm join` with the `--config` option, the `JoinConfiguration` type should be provided.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: JoinConfiguration
+# ...
+```
+
+The `JoinConfiguration` type is used to configure runtime settings. In the case of `kubeadm join`,
+it contains the discovery method used for accessing the cluster info and all the setting which are specific
+to the node where kubeadm is executed, including:
+
+- `NodeRegistration`: fields related to registering the new node to the cluster.
+  You can use it to customize the node name, the CRI socket to use or any other
+  settings that should apply to this node only (e.g. the node ip).
+
+- `APIEndpoint`: the endpoint of the API server instance to be eventually deployed on this node.</p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#kubeadm-k8s-io-v1beta1-ClusterConfiguration">ClusterConfiguration</a>
+                  </li><li>
+                    <a href="#kubeadm-k8s-io-v1beta1-ClusterStatus">ClusterStatus</a>
+                  </li><li>
+                    <a href="#kubeadm-k8s-io-v1beta1-InitConfiguration">InitConfiguration</a>
+                  </li><li>
+                    <a href="#kubeadm-k8s-io-v1beta1-JoinConfiguration">JoinConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-ClusterConfiguration">ClusterConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-InitConfiguration">InitConfiguration</a>)
+    </p>
+  
+
+  <p>DEPRECATED - This group version of ClusterConfiguration is deprecated by apis/kubeadm/v1beta2.ClusterConfiguration.
+ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeadm.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>ClusterConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>etcd</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-Etcd">
+                <span style="font-family: monospace">Etcd</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `etcd` holds configuration for etcd.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>networking</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-Networking">
+                <span style="font-family: monospace">Networking</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `networking` holds configuration for the networking topology of the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubernetesVersion</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `kubernetesVersion` is the target version of the control plane.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>controlPlaneEndpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `controlPlaneEndpoint` sets a stable IP address or DNS name for the control plane.
+It can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+If `controlPlaneEndpoint` is not specified, the `advertiseAddress` + `bindPort`
+are used. If `controlPlaneEndpoint` is specified without a TCP port, the `bindPort` is used.
+Possible usages are:
+
+- In a cluster with more than one control plane nodes, this field should be
+  assigned the address of the external load balancer in front of the
+  control plane nodes.
+- In environments with enforced node recycling, the `controlPlaneEndpoint`
+  could be used for assigning a stable DNS to the control plane.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>apiServer</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-APIServer">
+                <span style="font-family: monospace">APIServer</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `apiServer` contains extra settings for the API server.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>controllerManager</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-ControlPlaneComponent">
+                <span style="font-family: monospace">ControlPlaneComponent</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `controllerManager` contains extra settings for the controller manager.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>scheduler</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-ControlPlaneComponent">
+                <span style="font-family: monospace">ControlPlaneComponent</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `scheduler` contains extra settings for the scheduler.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>dns</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-DNS">
+                <span style="font-family: monospace">DNS</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `dns` defines the options for the DNS add-on installed in the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certificatesDir</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `certificatesDir` specifies where to store or look for all required certificates.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>imageRepository</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `imageRepository` specifies the container registry from which images are pulled.
+If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
+`gcr.io/kubernetes-ci-images` will be used for control plane components and
+kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>useHyperKubeImage</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `useHyperKubeImage` controls if hyperkube should be used for Kubernetes components
+instead of their respective separate images.
+DEPRECATED: As hyperkube is deprecated, this field is deprecated too.
+It will be removed in future kubeadm config versions. Kubeadm may print multiple
+warnings or ignore it when this is set to true.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>featureGates</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `featureGates` is a map containing the feature gates to be enabled.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clusterName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `clusterName` contains the cluster name.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-ClusterStatus">ClusterStatus
+    </H3>
+
+  
+
+  <p>ClusterStatus contains the cluster status. The ClusterStatus will be stored in the `kubeadm-config` ConfigMap in the
+cluster, and then updated by kubeadm when additional control plane nodes joins or leaves the cluster.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeadm.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>ClusterStatus</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>apiEndpoints</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-APIEndpoint">
+                <span style="font-family: monospace">map[string]github.com/tengqm/kubeconfig/config/kubeadm/v1beta1.APIEndpoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `apiEndpoints` contains a list of API endpoints currently available in the cluster,
+one for each control-plane or API server instance. The key of the map is the IP
+of the node's default interface.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-InitConfiguration">InitConfiguration
+    </H3>
+
+  
+
+  <p>DEPRECATED - This group version of InitConfiguration is deprecated by apis/kubeadm/v1beta2.InitConfiguration.
+InitConfiguration contains runtime information that are specific to "kubeadm init".</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeadm.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>InitConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>-</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-ClusterConfiguration">
+                <span style="font-family: monospace">ClusterConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          This field holds the cluster-wide information, and embeds that struct (which can be (un)marshalled separately as well)
+When InitConfiguration is marshalled to bytes in the external version, this information IS NOT preserved (which can be seen from
+the `json:"-"` tag. This is due to that when InitConfiguration is (un)marshalled, it turns into two YAML documents, one for the
+InitConfiguration and ClusterConfiguration. Hence, the information must not be duplicated, and is therefore omitted here.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bootstrapTokens</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-BootstrapToken">
+                <span style="font-family: monospace">[]BootstrapToken</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `bootstrapTokens` describes a set of Bootstrap Tokens to create during `kubeadm init`.
+This information is NOT uploaded to the `kubeadm-config` ConfigMap, partly because of its sensitive nature
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeRegistration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-NodeRegistrationOptions">
+                <span style="font-family: monospace">NodeRegistrationOptions</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `nodeRegistration` holds fields related to registering the new control-plane node to the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>localAPIEndpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-APIEndpoint">
+                <span style="font-family: monospace">APIEndpoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `localAPIEndpoint` represents the endpoint of the API server instance that's deployed on this control plane
+instance.  In HA setups, this differs from `ClusterConfiguration.controlPlaneEndpoint` in the sense that
+`controlPlaneEndpoint` is the global endpoint for the cluster, which loadbalances the requests to each individual
+API server. This configuration object lets you customize what IP/DNS name and port on which the local API server
+is accessible. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in
+case that process fails you may set the desired value here.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-JoinConfiguration">JoinConfiguration
+    </H3>
+
+  
+
+  <p>DEPRECATED - This group version of JoinConfiguration is deprecated by apis/kubeadm/v1beta2.JoinConfiguration.
+JoinConfiguration contains elements describing a particular node.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeadm.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>JoinConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeRegistration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-NodeRegistrationOptions">
+                <span style="font-family: monospace">NodeRegistrationOptions</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `nodeRegistration` holds fields related to registering a new control-plane node to the cluster
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caCertPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `caCertPath` is the path to the SSL certificate authority (CA) used to
+secure comunications between the node and the control-plane.
+Defaults to "/etc/kubernetes/pki/ca.crt".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>discovery</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-Discovery">
+                <span style="font-family: monospace">Discovery</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `discovery` specifies the options for the kubelet to use during the TLS Bootstrap process.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>controlPlane</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-JoinControlPlane">
+                <span style="font-family: monospace">JoinControlPlane</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `controlPlane` defines the additional control plane instance to be deployed on the joining node.
+If not specified, no additional control plane instance will be deployed.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-APIEndpoint">APIEndpoint
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-ClusterStatus">ClusterStatus</a>, 
+        <a href="#kubeadm-k8s-io-v1beta1-InitConfiguration">InitConfiguration</a>, 
+        <a href="#kubeadm-k8s-io-v1beta1-JoinControlPlane">JoinControlPlane</a>)
+    </p>
+  
+
+  <p>APIEndpoint struct contains elements of API server instance deployed on a node.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>advertiseAddress</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `advertiseAddress` sets the IP address for the API server to advertise.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bindPort</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `bindPort` sets the secure port for the API Server to bind to. Defaults to 6443.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-APIServer">APIServer
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-ClusterConfiguration">ClusterConfiguration</a>)
+    </p>
+  
+
+  <p>APIServer holds settings necessary for API server instances in the cluster</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ControlPlaneComponent</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-ControlPlaneComponent">
+                <span style="font-family: monospace">ControlPlaneComponent</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+            <p>(Members of <code>ControlPlaneComponent</code> are embedded into this type.)</p>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certSANs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `certSANs` sets extra Subject Alternative Names (SANs) for the API Server signing cert.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>timeoutForControlPlane</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `timeoutForControlPlane` controls the timeout that kubeadm waits for the API server to appear.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-BootstrapToken">BootstrapToken
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-InitConfiguration">InitConfiguration</a>)
+    </p>
+  
+
+  <p>BootstrapToken describes one bootstrap token, stored as a Secret in the cluster</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>token</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-BootstrapTokenString">
+                <span style="font-family: monospace">BootstrapTokenString</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `token` is used for establishing bidirectional trust between nodes and control-planes.
+Used for joining nodes in the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>description</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `description` contains a human-friendly message why this token exists and what it's used
+for, so other administrators can know its purpose.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ttl</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `ttl`  defines the time to live (TTL) for this token. Defaults to `24h`.
+The `expires` field and the `ttl` field are mutually exclusive.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>expires</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+                <span style="font-family: monospace">meta/v1.Time</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `expires` specifies the timestamp when this token expires. Defaults to being set
+dynamically at runtime based on the `ttl`. The `expires` field and the `ttl` field are
+mutually exclusive.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>usages</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `usages` describes the ways in which this token can be used. Can by default be used
+for establishing bidirectional trust, but that can be changed here.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>groups</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `groups` specifies the extra groups that this token will authenticate as when/if
+used for authentication.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-BootstrapTokenDiscovery">BootstrapTokenDiscovery
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-Discovery">Discovery</a>)
+    </p>
+  
+
+  <p>BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>token</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `token` is a token used to validate cluster information fetched from the control-plane.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>apiServerEndpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `apiServerEndpoint` is an IP or domain name for the API server from which info will be fetched.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caCertHashes</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `caCertHashes` specifies a set of public key pins to verify when token-based discovery is used.
+The root CA found during discovery must match one of these values. Specifying an empty set disables
+root CA pinning, which can be unsafe. Each hash is specified as `<type>:<value>`, where the only
+type currently supported is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key
+Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>unsafeSkipCAVerification</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `unsafeSkipCAVerification` allows token-based discovery without CA verification via `caCertHashes`.
+This can weaken the kubeadm security since other nodes can impersonate the control-plane.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-BootstrapTokenString">BootstrapTokenString
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-BootstrapToken">BootstrapToken</a>)
+    </p>
+  
+
+  <p>DEPRECATED - This group version of BootstrapTokenString is deprecated by apis/kubeadm/v1beta2/BootstrapTokenString.
+BootstrapTokenString is a token of the format abcdef.abcdef0123456789 that is used
+for both validation of the practically of the API server from a joining node's point
+of view and as an authentication method for the node in the bootstrap phase of
+"kubeadm join". This token is and should be short-lived</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>-</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>-</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-ControlPlaneComponent">ControlPlaneComponent
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-ClusterConfiguration">ClusterConfiguration</a>, 
+        <a href="#kubeadm-k8s-io-v1beta1-APIServer">APIServer</a>)
+    </p>
+  
+
+  <p>ControlPlaneComponent holds settings common to control plane component of the cluster</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>extraArgs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `extraArgs` is an extra set of flags to pass to the control plane components.
+TODO: This is temporary and ideally we would like to switch all components to
+use ComponentConfig + ConfigMaps.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>extraVolumes</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-HostPathMount">
+                <span style="font-family: monospace">[]HostPathMount</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `extraVolumes` is an extra set of HostPath volumes to be mounted by the control plane component.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-DNS">DNS
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-ClusterConfiguration">ClusterConfiguration</a>)
+    </p>
+  
+
+  <p>DNS defines the DNS add-on that should be used in the cluster</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>type</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-DNSAddOnType">
+                <span style="font-family: monospace">DNSAddOnType</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `type` defines the DNS add-on to be used. Can be one of "CoreDNS" or "kube-dns".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ImageMeta</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-ImageMeta">
+                <span style="font-family: monospace">ImageMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+            <p>(Members of <code>ImageMeta</code> are embedded into this type.)</p>
+          
+
+          `imageMeta` is used to customize the image used for the DNS add-on.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-DNSAddOnType">DNSAddOnType
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-DNS">DNS</a>)
+    </p>
+  
+
+  <p>DNSAddOnType defines string identifying DNS add-on types.</p>
+
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-Discovery">Discovery
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-JoinConfiguration">JoinConfiguration</a>)
+    </p>
+  
+
+  <p>Discovery specifies the options for the kubelet to use during the TLS Bootstrap process</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>bootstrapToken</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-BootstrapTokenDiscovery">
+                <span style="font-family: monospace">BootstrapTokenDiscovery</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `bootstrapToken` is used to set the options for bootstrap token based discovery.
+The `bootstrapToken` field and the `file` field are mutually exclusive.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>file</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-FileDiscovery">
+                <span style="font-family: monospace">FileDiscovery</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `file` is used to specify a file or URL to a kubeconfig file from which to load cluster information.
+The `bootstrapToken` field and the `file` field are mutually exclusive.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsBootstrapToken</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `tlsBootstrapToken` is a token used for TLS bootstrapping.
+If `bootstrapToken` is set, this field is defaulted to `.bootstrapToken.token`, but can be overridden.
+If `file` is set, this field &lowast;&lowast;must be set&lowast;&lowast; in case the KubeConfigFile does not contain any other
+authentication information.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>timeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `timeout` is used to customize timeout period for the discovery.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-Etcd">Etcd
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-ClusterConfiguration">ClusterConfiguration</a>)
+    </p>
+  
+
+  <p>Etcd contains elements describing Etcd configuration.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>local</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-LocalEtcd">
+                <span style="font-family: monospace">LocalEtcd</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `local` provides configurations for the local etcd instance.
+The `local` field and the `external` field are mutually exclusive.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>external</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-ExternalEtcd">
+                <span style="font-family: monospace">ExternalEtcd</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `external` describes how to connect to an external etcd service.
+The `local` field and the `external` field are mutually exclusive.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-ExternalEtcd">ExternalEtcd
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-Etcd">Etcd</a>)
+    </p>
+  
+
+  <p>ExternalEtcd describes an external etcd cluster.
+Kubeadm has no knowledge of where certificate files live and they must be supplied.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>endpoints</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `endpoints` contains a list of etcd members. This field is required.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `caFile` is an SSL Certificate Authority (CA) file used to secure etcd communication.
+Required if using a TLS connection.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `certFile` is an SSL certification file used to secure etcd communication.
+Required if using a TLS connection.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>keyFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `keyFile` is an SSL key file used to secure etcd communication.
+Required if using a TLS connection.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-FileDiscovery">FileDiscovery
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-Discovery">Discovery</a>)
+    </p>
+  
+
+  <p>FileDiscovery is used to specify a file or a URL to a kubeconfig file from which to load cluster information.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>kubeConfigPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `kubeConfigPath` is used to specify the file path or a URL to the kubeconfig file from which
+to load cluster information
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-HostPathMount">HostPathMount
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-ControlPlaneComponent">ControlPlaneComponent</a>)
+    </p>
+  
+
+  <p>HostPathMount contains elements describing volumes that are mounted from the host.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `name` is the name of the volume inside the Pod template.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>hostPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `hostPath` is the path on the host that will be mounted inside the Pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>mountPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `mountPath` is the path inside the Pod where `hostPath` will be mounted.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>readOnly</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `readOnly` indicates whether the volume is mounted in read-only mode.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>pathType</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#hostpathtype-v1-core">
+                <span style="font-family: monospace">core/v1.HostPathType</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `pathType` is the type of the HostPath, for example, "DirectoryOrCreate", "File", etc.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-ImageMeta">ImageMeta
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-DNS">DNS</a>, 
+        <a href="#kubeadm-k8s-io-v1beta1-LocalEtcd">LocalEtcd</a>)
+    </p>
+  
+
+  <p>ImageMeta allows to customize the image used for components that are not
+originated from the Kubernetes/Kubernetes release process</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>imageRepository</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `imageRepository` sets the container registry to pull images from.
+If not set, the `imageRepository` defined in ClusterConfiguration will be used instead.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>imageTag</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `imageTag` allows for specifying a tag for the image.
+When this value is set, kubeadm does not automatically change the version
+of the above components during upgrades.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-JoinControlPlane">JoinControlPlane
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-JoinConfiguration">JoinConfiguration</a>)
+    </p>
+  
+
+  <p>JoinControlPlane contains elements describing an additional control plane instance to be deployed on the joining node.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>localAPIEndpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-APIEndpoint">
+                <span style="font-family: monospace">APIEndpoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `localAPIEndpoint` represents the endpoint of the API server instance to be deployed on this node.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-LocalEtcd">LocalEtcd
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-Etcd">Etcd</a>)
+    </p>
+  
+
+  <p>LocalEtcd describes that kubeadm should run an etcd cluster locally</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ImageMeta</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta1-ImageMeta">
+                <span style="font-family: monospace">ImageMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+            <p>(Members of <code>ImageMeta</code> are embedded into this type.)</p>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>dataDir</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `dataDir` is the directory for etcd to place its data. Defaults to "/var/lib/etcd".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>extraArgs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `extraArgs` are extra arguments provided to the etcd binary when run inside a static pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>serverCertSANs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `serverCertSANs` sets extra Subject Alternative Names (SANs) for the etcd server signing cert.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>peerCertSANs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `peerCertSANs` sets extra Subject Alternative Names (SANs) for the etcd peer signing cert.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-Networking">Networking
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-ClusterConfiguration">ClusterConfiguration</a>)
+    </p>
+  
+
+  <p>Networking contains elements describing cluster's networking configuration</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>serviceSubnet</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `serviceSubnet` is the subnet used by Services. Defaults to "10.96.0.0/12".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>podSubnet</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `podSubnet` is the subnet used by Pods.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>dnsDomain</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `dnsDomain` is the DNS domain used by Services. Defaults to "cluster.local".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta1-NodeRegistrationOptions">NodeRegistrationOptions
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta1-InitConfiguration">InitConfiguration</a>, 
+        <a href="#kubeadm-k8s-io-v1beta1-JoinConfiguration">JoinConfiguration</a>)
+    </p>
+  
+
+  <p>NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either via "kubeadm init" or "kubeadm join"</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `name` is the `.metadata.name` field of the Node API object that will be created in this `kubeadm init` or
+`kubeadm join` operation. This field is also used in the CommonName field of the kubelet's
+client certificate to the API server. Defaults to the hostname of the node.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>criSocket</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `criSocket` is used to retrieve container runtime information. This information will be
+annotated to the Node API object, for later re-use.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>taints</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#taint-v1-core">
+                <span style="font-family: monospace">[]core/v1.Taint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `taints` specifies the taints the Node API object should be registered with. If this field is not set, i.e. nil,
+it will be defaulted to `['node-role.kubernetes.io/master=""']` during `kubeadm init`.
+If you don't want to taint your control-plane node, set this field to an empty list (`[]`).
+This field is only used for node registration.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubeletExtraArgs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `kubeletExtraArgs` contains extra arguments to pass to the kubelet. Kubeadm writes these arguments into an
+environment file for the kubelet to source.
+This overrides the generic base-level configuration in the `kubelet-config-1.x` ConfigMap
+Command line flags have higher priority when parsing.
+These values are local and specific to the node kubeadm is executing on.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/kubeadm-config.v1beta2.html
+++ b/genref/output/html/kubeadm-config.v1beta2.html
@@ -1,0 +1,3444 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="kubeadm-k8s-io-v1beta2">Package: <span style="font-family: monospace">kubeadm.k8s.io/v1beta2</span></H2>
+            <p>Package v1beta2 defines the v1beta2 version of the kubeadm configuration file format.
+This version improves on the v1beta1 format by fixing some minor issues and adding a few new fields.
+
+A list of changes since v1beta1:
+
+- `certificateKey` field is added to `InitConfiguration` and `JoinConfiguration`.
+- `ignorePreflightErrors` field is added to the `NodeRegistrationOptions`.
+- The JSON `omitempty` tag is used in more places where appropriate.
+- The JSON `omitempty` tag of the "taints" field (in `NodeRegistrationOptions`) is removed.
+
+See the Kubernetes 1.15 changelog for further details.
+
+&lowast;&lowast;Migration from old kubeadm config versions&lowast;&lowast;
+
+Please convert your v1beta1 configuration files to v1beta2 using the `kubeadm config migrate` command of kubeadm
+v1.15.x. kubeadm v1.15.x supports reading from v1beta1 version of the kubeadm config file format.
+
+&lowast;&lowast;Basics&lowast;&lowast;
+
+The preferred way to configure kubeadm is to pass an YAML configuration file with the `--config` option. Some of the
+configuration options defined in the kubeadm config file are also available as command line flags, but only
+the most common/simple use case are supported with this approach.
+
+A kubeadm config file could contain multiple configuration types separated using three dashes (`---`).
+
+kubeadm supports the following configuration types:
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+```
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+```
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+```
+```yaml
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+```
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+```
+
+To print the defaults for `init` and `join` actions use the following commands:
+
+```shell
+kubeadm config print init-defaults
+kubeadm config print join-defaults
+```
+
+The list of configuration types that must be included in a configuration file depends by the action you are
+performing (`init` or `join`) and by the configuration options you are going to use (defaults or advanced customization).
+
+If some configuration types are not provided, or provided only partially, kubeadm will use default values.
+Defaults provided by kubeadm help enforce consistency of values across components when required (e.g.
+`--cluster-cidr` flag on controller manager and `clusterCIDR` on kube-proxy).
+
+Users are always allowed to override default values, with the only exception of a small subset of setting
+related to security (e.g. enforce authorization-mode Node and RBAC on the API server)
+If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
+ignore those types and print a warning.
+
+&lowast;&lowast;Kubeadm init configuration types&lowast;&lowast;
+
+When executing kubeadm init with the `--config` option, the following configuration types could be used:
+`InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`, but only one
+between `InitConfiguration` and `ClusterConfiguration` is mandatory.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+bootstrapTokens:
+  # ...
+nodeRegistration:
+  # ...
+```
+
+The `InitConfiguration` type is used to configure runtime settings. In the case of `kubeadm init`,
+it includes the configuration of the bootstrap token and all the setting specific to the node
+where kubeadm is executed, including:
+
+- `nodeRegistration`: fields that relate to registering the new node to the cluster.
+  You can use it to customize the node name, the CRI socket to use or any other
+  settings that should apply to this node only (for example. the node IP).
+
+- `localAPIEndpoint`: the endpoint of the API server instance to be deployed on this node.
+  For example, you can use it to customize the API server advertise address.
+
+  ```yaml
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: ClusterConfiguration
+  networking:
+    # ...
+  etcd:
+    # ...
+  apiServer:
+    extraArgs:
+      # ...
+    extraVolumes:
+      # ...
+  # ...
+  ```
+
+The `ClusterConfiguration` type can be used to configure cluster-wide settings, including:
+
+- Networking, that holds configuration for the networking topology of the cluster;
+  For example, uou can use it to customize node subnet or services subnet.
+
+- Etcd configurations that can be used for customizing the local etcd or to configure
+  the API server for using an external etcd cluster.
+
+- kube-apiserver, kube-scheduler, kube-controller-manager configurations.
+  You can use it to customize control-plane components by adding customized setting
+  or overriding kubeadm default settings.
+
+```yaml
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+# ...
+```
+
+The `KubeProxyConfiguration` type is used to change the configurations passed to the kube-proxy
+instances deployed in the cluster. If this object is not provided or provided only partially,
+kubeadm applies defaults.
+See [kube-proxy reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)
+or [kube-proxy source code](https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration)
+for the official documentation.
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# ...
+```
+
+The `KubeletConfiguration` type is used to change the configurations passed to all kubelet instances
+deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
+See [kubelet reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) or
+[kubelet source code](https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration)
+for the official documentation.
+
+Here is a fully populated example of a single YAML file containing multiple
+configuration types to be used during a `kubeadm init` run.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+bootstrapTokens:
+- token: "9a08jv.c0izixklcxtmnze7"
+  description: "kubeadm bootstrap token"
+  ttl: "24h"
+- token: "783bde.3f89s0fje9f38fhf"
+  description: "another bootstrap token"
+  usages:
+  - authentication
+  - signing
+  groups:
+  - system:bootstrappers:kubeadm:default-node-token
+nodeRegistration:
+  name: "ec2-10-100-0-1"
+  criSocket: "/var/run/dockershim.sock"
+  taints:
+  - key: "kubeadmNode"
+    value: "master"
+    effect: "NoSchedule"
+  kubeletExtraArgs:
+    cgroup-driver: "cgroupfs"
+  ignorePreflightErrors:
+  - IsPrivilegedUser
+localAPIEndpoint:
+  advertiseAddress: "10.100.0.1"
+  bindPort: 6443
+certificateKey: "e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204"
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+etcd:
+  # one of local or external
+  local:
+    imageRepository: "k8s.gcr.io"
+    imageTag: "3.2.24"
+    dataDir: "/var/lib/etcd"
+    extraArgs:
+      listen-client-urls: "http://10.100.0.1:2379"
+    serverCertSANs:
+    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
+    peerCertSANs:
+    - "10.100.0.1"
+  # external:
+    # endpoints:
+    # - "10.100.0.1:2379"
+    # - "10.100.0.2:2379"
+    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
+    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
+    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
+networking:
+  serviceSubnet: "10.96.0.0/12"
+  podSubnet: "10.100.0.1/24"
+  dnsDomain: "cluster.local"
+kubernetesVersion: "v1.12.0"
+controlPlaneEndpoint: "10.100.0.1:6443"
+apiServer:
+  extraArgs:
+    authorization-mode: "Node,RBAC"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+  certSANs:
+  - "10.100.1.1"
+  - "ec2-10-100-0-1.compute-1.amazonaws.com"
+  timeoutForControlPlane: 4m0s
+controllerManager:
+  extraArgs:
+    "node-cidr-mask-size": "20"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+scheduler:
+  extraArgs:
+    address: "10.100.0.1"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+certificatesDir: "/etc/kubernetes/pki"
+imageRepository: "k8s.gcr.io"
+useHyperKubeImage: false
+clusterName: "example-cluster"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# kubelet specific options here
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+# kube-proxy specific options here
+```
+
+&lowast;&lowast;Kubeadm join configuration types&lowast;&lowast;
+
+When executing `kubeadm join` with the `--config` option, the `JoinConfiguration` type should be provided.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+# ...
+```
+
+The `JoinConfiguration` type is used to configure runtime settings. In the case of `kubeadm join`,
+it contains the discovery method used for accessing the cluster info and all the setting which are specific
+to the node where kubeadm is executed, including:
+
+- `nodeRegistration`: fields related to registering the new node to the cluster.
+  You can use it to customize the node name, the CRI socket to use or any other settings that should
+  apply to this node only (e.g. the node ip).
+
+- `apiEndpoint`: the endpoint of the API server instance to be eventually deployed on this node.</p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#kubeadm-k8s-io-v1beta2-ClusterConfiguration">ClusterConfiguration</a>
+                  </li><li>
+                    <a href="#kubeadm-k8s-io-v1beta2-ClusterStatus">ClusterStatus</a>
+                  </li><li>
+                    <a href="#kubeadm-k8s-io-v1beta2-InitConfiguration">InitConfiguration</a>
+                  </li><li>
+                    <a href="#kubeadm-k8s-io-v1beta2-JoinConfiguration">JoinConfiguration</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-ClusterConfiguration">ClusterConfiguration
+    </H3>
+
+  
+
+  <p>ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeadm.k8s.io/v1beta2</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>ClusterConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>etcd</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-Etcd">
+                <span style="font-family: monospace">Etcd</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `etcd` holds configuration for etcd.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>networking</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-Networking">
+                <span style="font-family: monospace">Networking</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `networking` holds configuration for the networking topology of the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubernetesVersion</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `kubernetesVersion` is the target version of the control plane.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>controlPlaneEndpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `controlPlaneEndpoint` sets a stable IP address or DNS name for the control plane.
+It can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+If `controlPlaneEndpoint` is not specified, the `advertiseAddress` + `bindPort`
+are used. If `controlPlaneEndpoint` is specified without a TCP port, the `bindPort` is used.
+Possible usages are:
+
+- In a cluster with more than one control plane nodes, this field should be
+  assigned the address of the external load balancer in front of the
+  control plane nodes.
+- In environments with enforced node recycling, the `controlPlaneEndpoint`
+  could be used for assigning a stable DNS to the control plane.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>apiServer</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-APIServer">
+                <span style="font-family: monospace">APIServer</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `apiServer` contains extra settings for the API server.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>controllerManager</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent">
+                <span style="font-family: monospace">ControlPlaneComponent</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `controllerManager` contains extra settings for the controller manager.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>scheduler</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent">
+                <span style="font-family: monospace">ControlPlaneComponent</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `scheduler` contains extra settings for the scheduler.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>dns</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-DNS">
+                <span style="font-family: monospace">DNS</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `dns` defines the options for the DNS add-on installed in the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certificatesDir</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `certificatesDir` specifies where to store or look for all required certificates.
+The value must be an absolute path.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>imageRepository</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `imageRepository` specifies the container registry from which images are pulled.
+If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
+`gcr.io/kubernetes-ci-images` will be used for control plane components and
+kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>useHyperKubeImage</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `useHyperKubeImage` controls if hyperkube should be used for Kubernetes components
+instead of their respective separate images.
+DEPRECATED: As hyperkube is deprecated, this field is deprecated too.
+It will be removed in future kubeadm config versions. Kubeadm may print multiple
+warnings or ignore it when this is set to true.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>featureGates</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `featureGates` is a map containing the feature gates to be enabled.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clusterName</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `clusterName` contains the cluster name.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-ClusterStatus">ClusterStatus
+    </H3>
+
+  
+
+  <p>ClusterStatus contains the cluster status. The ClusterStatus will be stored in the `kubeadm-config` ConfigMap in the
+cluster, and then updated by kubeadm when additional control plane nodes joins or leaves the cluster.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeadm.k8s.io/v1beta2</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>ClusterStatus</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>apiEndpoints</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-APIEndpoint">
+                <span style="font-family: monospace">map[string]github.com/tengqm/kubeconfig/config/kubeadm/v1beta2.APIEndpoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `apiEndpoints` contains a list of API endpoints currently available in the cluster,
+one for each control-plane or API server instance. The key of the map is the IP
+of the node's default interface.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-InitConfiguration">InitConfiguration
+    </H3>
+
+  
+
+  <p>InitConfiguration contains runtime information that are specific to "kubeadm init".
+These information are only used the first time `kubeadm init` runs.
+After that, the information in the fields IS NOT uploaded to the `kubeadm-config` ConfigMap
+that is used by `kubeadm upgrade` for instance. These fields must be optional.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeadm.k8s.io/v1beta2</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>InitConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>bootstrapTokens</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-BootstrapToken">
+                <span style="font-family: monospace">[]BootstrapToken</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `bootstrapTokens` describes a set of Bootstrap Tokens to create during `kubeadm init`.
+This information is NOT uploaded to the `kubeadm-config` ConfigMap, partly because of its sensitive nature.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeRegistration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-NodeRegistrationOptions">
+                <span style="font-family: monospace">NodeRegistrationOptions</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `nodeRegistration` holds fields related to registering the new control-plane node to the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>localAPIEndpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-APIEndpoint">
+                <span style="font-family: monospace">APIEndpoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `localAPIEndpoint` represents the endpoint of the API server instance that's deployed on this control plane node.
+In HA setups, this differs from `ClusterConfiguration.controlPlaneEndpoint` in the sense that
+`controlPlaneEndpoint` is the global endpoint for the cluster, which loadbalances the requests to each individual
+API server. This configuration object lets you customize what IP/DNS name and port on which the local API server
+is accessible.  By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in
+case that process fails you may set the desired value here.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certificateKey</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `certificateKey` sets the key with which certificates and keys are encrypted prior to being uploaded in
+a secret in the cluster during the uploadcerts init phase.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-JoinConfiguration">JoinConfiguration
+    </H3>
+
+  
+
+  <p>JoinConfiguration contains elements describing a particular node.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubeadm.k8s.io/v1beta2</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>JoinConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeRegistration</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-NodeRegistrationOptions">
+                <span style="font-family: monospace">NodeRegistrationOptions</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `nodeRegistration` holds fields related to registering a new control-plane node to the cluster
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caCertPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `caCertPath` is the path to the SSL certificate authority (CA) used to
+secure comunications between the node and the control-plane.
+Defaults to "/etc/kubernetes/pki/ca.crt".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>discovery</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-Discovery">
+                <span style="font-family: monospace">Discovery</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `discovery` specifies the options for the kubelet to use during the TLS Bootstrap process.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>controlPlane</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-JoinControlPlane">
+                <span style="font-family: monospace">JoinControlPlane</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `controlPlane` defines the additional control plane instance to be deployed on the joining node.
+If not specified, no additional control plane instance will be deployed.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-APIEndpoint">APIEndpoint
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-ClusterStatus">ClusterStatus</a>, 
+        <a href="#kubeadm-k8s-io-v1beta2-InitConfiguration">InitConfiguration</a>, 
+        <a href="#kubeadm-k8s-io-v1beta2-JoinControlPlane">JoinControlPlane</a>)
+    </p>
+  
+
+  <p>APIEndpoint struct contains elements of API server instance deployed on a node.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>advertiseAddress</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `advertiseAddress` sets the IP address for the API server to advertise.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>bindPort</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `bindPort` sets the secure port for the API Server to bind to. Defaults to 6443.
+The value must be greater or equal to 1, while less than or equal to 65535.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-APIServer">APIServer
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-ClusterConfiguration">ClusterConfiguration</a>)
+    </p>
+  
+
+  <p>APIServer holds settings necessary for API server instances in the cluster.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ControlPlaneComponent</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent">
+                <span style="font-family: monospace">ControlPlaneComponent</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+            <p>(Members of <code>ControlPlaneComponent</code> are embedded into this type.)</p>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certSANs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `certSANs` sets extra Subject Alternative Names (SANs) for the API Server signing cert.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>timeoutForControlPlane</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `timeoutForControlPlane` controls the timeout that kubeadm waits for the API server to appear.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-BootstrapToken">BootstrapToken
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-InitConfiguration">InitConfiguration</a>)
+    </p>
+  
+
+  <p>BootstrapToken describes a bootstrap token that is stored as a Secret in the cluster</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>token</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-BootstrapTokenString">
+                <span style="font-family: monospace">BootstrapTokenString</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `token` is used for establishing bidirectional trust between nodes and control-planes.
+Used for joining nodes in the cluster.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>description</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `description` contains a human-friendly message why this token exists and what it's used
+for, so other administrators can know its purpose.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ttl</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `ttl`  defines the time to live (TTL) for this token. Defaults to `24h`.
+The `expires` field and the `ttl` field are mutually exclusive.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>expires</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+                <span style="font-family: monospace">meta/v1.Time</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `expires` specifies the timestamp when this token expires. Defaults to being set
+dynamically at runtime based on the `ttl`. The `expires` field and the `ttl` field are
+mutually exclusive.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>usages</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `usages` describes the ways in which this token can be used. Can by default be used
+for establishing bidirectional trust, but that can be changed here.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>groups</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `groups` specifies the extra groups that this token will authenticate as when/if
+used for authentication. This field can be specified only when `usages` contains
+"authentication".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-BootstrapTokenDiscovery">BootstrapTokenDiscovery
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-Discovery">Discovery</a>)
+    </p>
+  
+
+  <p>BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>token</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `token` is a token used to validate cluster information fetched from the control-plane.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>apiServerEndpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `apiServerEndpoint` is an IP or domain name for the API server from which info will be fetched.
+This field is required.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caCertHashes</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `caCertHashes` specifies a set of public key pins to verify when token-based discovery is used.
+The root CA found during discovery must match one of these values. Specifying an empty set disables
+root CA pinning, which can be unsafe. Each hash is specified as `<type>:<value>`, where the only
+type currently supported is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key
+Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>unsafeSkipCAVerification</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `unsafeSkipCAVerification` allows token-based discovery without CA verification via `caCertHashes`.
+This can weaken the kubeadm security since other nodes can impersonate the control-plane.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-BootstrapTokenString">BootstrapTokenString
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-BootstrapToken">BootstrapToken</a>)
+    </p>
+  
+
+  <p>BootstrapTokenString is a token of the format abcdef.abcdef0123456789 that is used
+for both validation of the practically of the API server from a joining node's point
+of view and as an authentication method for the node in the bootstrap phase of
+"kubeadm join". This token is and should be short-lived</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>-</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>-</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-ControlPlaneComponent">ControlPlaneComponent
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-ClusterConfiguration">ClusterConfiguration</a>, 
+        <a href="#kubeadm-k8s-io-v1beta2-APIServer">APIServer</a>)
+    </p>
+  
+
+  <p>ControlPlaneComponent holds settings common to control plane component for the cluster</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>extraArgs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `extraArgs` is an extra set of flags to pass to the control plane components.
+TODO: This is temporary and ideally we would like to switch all components to
+use ComponentConfig + ConfigMaps.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>extraVolumes</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-HostPathMount">
+                <span style="font-family: monospace">[]HostPathMount</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `extraVolumes` is an extra set of HostPath volumes to be mounted by the control plane component.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-DNS">DNS
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-ClusterConfiguration">ClusterConfiguration</a>)
+    </p>
+  
+
+  <p>DNS defines the DNS add-on that should be used in the cluster</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>type</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-DNSAddOnType">
+                <span style="font-family: monospace">DNSAddOnType</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `type` defines the DNS add-on to be used. Can be one of "CoreDNS" or "kube-dns".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ImageMeta</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-ImageMeta">
+                <span style="font-family: monospace">ImageMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+            <p>(Members of <code>ImageMeta</code> are embedded into this type.)</p>
+          
+
+          `imageMeta` is used to customize the image used for the DNS add-on.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-DNSAddOnType">DNSAddOnType
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-DNS">DNS</a>)
+    </p>
+  
+
+  <p>DNSAddOnType defines string identifying DNS add-on types.</p>
+
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-Discovery">Discovery
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-JoinConfiguration">JoinConfiguration</a>)
+    </p>
+  
+
+  <p>Discovery specifies the options for the kubelet to use during the TLS Bootstrap process</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>bootstrapToken</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-BootstrapTokenDiscovery">
+                <span style="font-family: monospace">BootstrapTokenDiscovery</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `bootstrapToken` is used to set the options for bootstrap token based discovery.
+One and only one of the `bootstrapToken` field and the `file` field must be set.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>file</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-FileDiscovery">
+                <span style="font-family: monospace">FileDiscovery</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `file` is used to specify a file or URL to a kubeconfig file from which to load cluster information.
+One and only one of the `bootstrapToken` field and the `file` field must be set.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsBootstrapToken</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `tlsBootstrapToken` is a token used for TLS bootstrapping.
+If `bootstrapToken` is set, this field is defaulted to `.bootstrapToken.token`, but can be overridden.
+If `file` is set, this field &lowast;&lowast;must be set&lowast;&lowast; in case the KubeConfigFile does not contain any other
+authentication information.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>timeout</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `timeout` is used to customize timeout period for the discovery.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-Etcd">Etcd
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-ClusterConfiguration">ClusterConfiguration</a>)
+    </p>
+  
+
+  <p>Etcd contains elements describing Etcd configuration.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>local</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-LocalEtcd">
+                <span style="font-family: monospace">LocalEtcd</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `local` provides configurations for the local etcd instance.
+One and only one of the `local` field and the `external` field must be specified.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>external</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-ExternalEtcd">
+                <span style="font-family: monospace">ExternalEtcd</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `external` describes how to connect to an external etcd service.
+One and only one of the `local` field and the `external` field must be specified.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-ExternalEtcd">ExternalEtcd
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-Etcd">Etcd</a>)
+    </p>
+  
+
+  <p>ExternalEtcd describes an external etcd cluster.
+Kubeadm has no knowledge of where certificate files live and they must be supplied.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>endpoints</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `endpoints` contains a list of etcd members. This field is required.
+When TLS connection is used, `caFile`, `certFile` and `keyFile` are all specified,
+the endpoints listed must use the HTTPS scheme.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>caFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `caFile` is an SSL Certificate Authority (CA) file used to secure etcd communication.
+Required if using a TLS connection.
+The value must be an absolute path.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `certFile` is an SSL certification file used to secure etcd communication.
+Required if using a TLS connection.
+When this is specified, the `keyFile` field cannot be left unset.
+When either 'certFile` or `keyFile` are provided, the `caFile` cannot be empty.
+The value must be an absolute path.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>keyFile</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `keyFile` is an SSL key file used to secure etcd communication.
+Required if using a TLS connection.
+When this is specified, the `certFile` field cannot be left unset.
+When either 'certFile` or `keyFile` are provided, the `caFile` cannot be empty.
+The value must be an absolute path.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-FileDiscovery">FileDiscovery
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-Discovery">Discovery</a>)
+    </p>
+  
+
+  <p>FileDiscovery is used to specify a file or a URL to a kubeconfig file from which to load cluster information.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>kubeConfigPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `kubeConfigPath` is used to specify the file path or a URL to the kubeconfig file from which
+to load cluster information. If the path is a URL, its scheme must be HTTPS.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-HostPathMount">HostPathMount
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent">ControlPlaneComponent</a>)
+    </p>
+  
+
+  <p>HostPathMount contains elements describing volumes that are mounted from the host.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `name` is the name of the volume inside the Pod template.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>hostPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `hostPath` is the path on the host that will be mounted inside the Pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>mountPath</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `mountPath` is the path inside the Pod where `hostPath` will be mounted.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>readOnly</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `readOnly` indicates whether the volume is mounted in read-only mode.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>pathType</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#hostpathtype-v1-core">
+                <span style="font-family: monospace">core/v1.HostPathType</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `pathType` is the type of the HostPath, for example, "DirectoryOrCreate", "File", etc.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-ImageMeta">ImageMeta
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-DNS">DNS</a>, 
+        <a href="#kubeadm-k8s-io-v1beta2-LocalEtcd">LocalEtcd</a>)
+    </p>
+  
+
+  <p>ImageMeta allows to customize the image used for components that are not
+originated from the Kubernetes/Kubernetes release process</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>imageRepository</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `imageRepository` sets the container registry to pull images from.
+If not set, the `imageRepository` defined in ClusterConfiguration will be used instead.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>imageTag</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `imageTag` allows for specifying a tag for the image.
+When this value is set, kubeadm does not automatically change the version
+of the above components during upgrades.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-JoinControlPlane">JoinControlPlane
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-JoinConfiguration">JoinConfiguration</a>)
+    </p>
+  
+
+  <p>JoinControlPlane contains elements describing an additional control plane instance to be deployed on the joining node.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>localAPIEndpoint</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-APIEndpoint">
+                <span style="font-family: monospace">APIEndpoint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `localAPIEndpoint` represents the endpoint of the API server instance to be deployed on this node.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>certificateKey</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `certificateKey` is the key for decrypting certificates after they are downloaded from the Secret
+upon joining a new control plane node. The corresponding encryption key is in the `initConfiguration`.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-LocalEtcd">LocalEtcd
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-Etcd">Etcd</a>)
+    </p>
+  
+
+  <p>LocalEtcd describes that kubeadm should run an etcd cluster locally</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>ImageMeta</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubeadm-k8s-io-v1beta2-ImageMeta">
+                <span style="font-family: monospace">ImageMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+            <p>(Members of <code>ImageMeta</code> are embedded into this type.)</p>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>dataDir</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `dataDir` is the directory for etcd to place its data. Defaults to "/var/lib/etcd".
+The path must be an absolute path.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>extraArgs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `extraArgs` are extra arguments provided to the etcd binary when run inside a static pod.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>serverCertSANs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `serverCertSANs` sets extra Subject Alternative Names (SANs) for the etcd server signing cert.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>peerCertSANs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `peerCertSANs` sets extra Subject Alternative Names (SANs) for the etcd peer signing cert.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-Networking">Networking
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-ClusterConfiguration">ClusterConfiguration</a>)
+    </p>
+  
+
+  <p>Networking contains elements describing cluster's networking configuration</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>serviceSubnet</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `serviceSubnet` is the subnet used by Services. Defaults to "10.96.0.0/12".
+When DualStack is enabled, you can specify two CIDRs separated by a comma,
+one CIDR for IPv4 and the other for IPv6.
+If DualStack is not enabled, only one CIDR can be specified.
+The service subnet can be at most 20 bits, so the largest supported Service subnet is `/12` for IPv4
+and `/108` for IPv6.
+Also, the subnet defined must have at least 10 nodes.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>podSubnet</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `podSubnet` is the subnet used by Pods.
+When DualStack is enabled, you can specify two CIDRs separated by a comma,
+one CIDR for IPv4 and the other for IPv6.
+If DualStack is not enabled, only one CIDR can be specified.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>dnsDomain</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `dnsDomain` is the DNS domain used by Services. Defaults to "cluster.local".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubeadm-k8s-io-v1beta2-NodeRegistrationOptions">NodeRegistrationOptions
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubeadm-k8s-io-v1beta2-InitConfiguration">InitConfiguration</a>, 
+        <a href="#kubeadm-k8s-io-v1beta2-JoinConfiguration">JoinConfiguration</a>)
+    </p>
+  
+
+  <p>NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either
+via "kubeadm init" or "kubeadm join".</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `name` is the `.metadata.name` field of the Node API object that will be created in this `kubeadm init` or
+`kubeadm join` operation. This field is also used in the CommonName field of the kubelet's
+client certificate to the API server. Defaults to the hostname of the node.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>criSocket</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `criSocket` is used to retrieve container runtime information. This information will be
+annotated to the Node API object, for later re-use.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>taints</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#taint-v1-core">
+                <span style="font-family: monospace">[]core/v1.Taint</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          `taints` specifies the taints the Node API object should be registered with. If this field is not set, i.e. nil,
+it will be defaulted to `['node-role.kubernetes.io/master=""']` during `kubeadm init`.
+If you don't want to taint your control-plane node, set this field to an empty list (`[]`).
+This field is only used for node registration.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubeletExtraArgs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `kubeletExtraArgs` contains extra arguments to pass to the kubelet. Kubeadm writes these arguments into an
+environment file for the kubelet to source.
+This overrides the generic base-level configuration in the `kubelet-config-1.x` ConfigMap
+Command line flags have higher priority when parsing.
+These values are local and specific to the node kubeadm is executing on.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>ignorePreflightErrors</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          `ignorePreflightErrors` provides a list of pre-flight errors that are ignored during node registration.
+This list cannot contain "all".
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/kubelet-config.v1beta1.html
+++ b/genref/output/html/kubelet-config.v1beta1.html
@@ -1,0 +1,3799 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            
+            
+              
+            
+              
+            
+              
+            
+              
+                
+  <H3 id="LoggingConfiguration">LoggingConfiguration
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletConfiguration">KubeletConfiguration</a>)
+    </p>
+  
+
+  <p>LoggingConfiguration contains logging options
+Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>format</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Format Flag specifies the structure of log messages.
+default value of format is `text`
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>sanitization</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+              
+            
+          
+
+          <HR />
+        
+          
+          
+            <H2 id="kubelet-config-k8s-io-v1beta1">Package: <span style="font-family: monospace">kubelet.config.k8s.io/v1beta1</span></H2>
+            <p></p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#kubelet-config-k8s-io-v1beta1-KubeletConfiguration">KubeletConfiguration</a>
+                  </li><li>
+                    <a href="#kubelet-config-k8s-io-v1beta1-SerializedNodeConfigSource">SerializedNodeConfigSource</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-KubeletConfiguration">KubeletConfiguration
+    </H3>
+
+  
+
+  <p>KubeletConfiguration contains the configuration for the Kubelet</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubelet.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>KubeletConfiguration</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>enableServer</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableServer enables Kubelet's secured server.
+Note: Kubelet's insecure port is controlled by the readOnlyPort option.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>staticPodPath</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          staticPodPath is the path to the directory containing local (static) pods to
+run, or the path to a single static pod file.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+the set of static pods specified at the new path may be different than the
+ones the Kubelet initially started with, and this may disrupt your node.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>syncFrequency</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          syncFrequency is the max period between synchronizing running
+containers and config.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening this duration may have a negative performance impact, especially
+as the number of Pods on the node increases. Alternatively, increasing this
+duration will result in longer refresh times for ConfigMaps and Secrets.
+Default: "1m"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>fileCheckFrequency</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          fileCheckFrequency is the duration between checking config files for
+new data
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the duration will cause the Kubelet to reload local Static Pod
+configurations more frequently, which may have a negative performance impact.
+Default: "20s"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>httpCheckFrequency</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          httpCheckFrequency is the duration between checking http for new data
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the duration will cause the Kubelet to poll staticPodURL more
+frequently, which may have a negative performance impact.
+Default: "20s"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>staticPodURL</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          staticPodURL is the URL for accessing static pods to run
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+the set of static pods specified at the new URL may be different than the
+ones the Kubelet initially started with, and this may disrupt your node.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>staticPodURLHeader</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string][]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt the ability to read the latest set of static pods from StaticPodURL.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>address</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          address is the IP address for the Kubelet to serve on (set to 0.0.0.0
+for all interfaces).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: "0.0.0.0"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>port</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          port is the port for the Kubelet to serve on.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: 10250
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>readOnlyPort</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          readOnlyPort is the read-only port for the Kubelet to serve on with
+no authentication/authorization.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: 0 (disabled)
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsCertFile</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,
+if any, concatenated after server cert). If tlsCertFile and
+tlsPrivateKeyFile are not provided, a self-signed certificate
+and key are generated for the public address and saved to the directory
+passed to the Kubelet's --cert-dir flag.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsPrivateKeyFile</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          tlsPrivateKeyFile is the file containing x509 private key matching tlsCertFile
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsCipherSuites</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          TLSCipherSuites is the list of allowed cipher suites for the server.
+Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>tlsMinVersion</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          TLSMinVersion is the minimum TLS version supported.
+Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>rotateCertificates</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          rotateCertificates enables client certificate rotation. The Kubelet will request a
+new certificate from the certificates.k8s.io API. This requires an approver to approve the
+certificate signing requests.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may disrupt the Kubelet's ability to authenticate with the API server
+after the current certificate expires.
+Default: false
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>serverTLSBootstrap</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          serverTLSBootstrap enables server certificate bootstrap. Instead of self
+signing a serving certificate, the Kubelet will request a certificate from
+the certificates.k8s.io API. This requires an approver to approve the
+certificate signing requests. The RotateKubeletServerCertificate feature
+must be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it will stop the renewal of Kubelet server certificates, which can
+disrupt components that interact with the Kubelet server in the long term,
+due to certificate expiration.
+Default: false
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>authentication</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthentication">
+                <span style="font-family: monospace">KubeletAuthentication</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          authentication specifies how requests to the Kubelet's server are authenticated
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Defaults:
+  anonymous:
+    enabled: false
+  webhook:
+    enabled: true
+    cacheTTL: "2m"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>authorization</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorization">
+                <span style="font-family: monospace">KubeletAuthorization</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          authorization specifies how requests to the Kubelet's server are authorized
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Defaults:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: "5m"
+    cacheUnauthorizedTTL: "30s"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>registryPullQPS</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          registryPullQPS is the limit of registry pulls per second.
+Set to 0 for no limit.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced
+by image pulls.
+Default: 5
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>registryBurst</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          registryBurst is the maximum size of bursty pulls, temporarily allows
+pulls to burst to this number, while still not exceeding registryPullQPS.
+Only used if registryPullQPS > 0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced
+by image pulls.
+Default: 10
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>eventRecordQPS</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          eventRecordQPS is the maximum event creations per second. If 0, there
+is no limit enforced.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced by
+event creations.
+Default: 5
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>eventBurst</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          eventBurst is the maximum size of a burst of event creations, temporarily
+allows event creations to burst to this number, while still not exceeding
+eventRecordQPS. Only used if eventRecordQPS > 0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced by
+event creations.
+Default: 10
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableDebuggingHandlers</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableDebuggingHandlers enables server endpoints for log access
+and local running of containers and commands, including the exec,
+attach, logs, and portforward features.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may disrupt components that interact with the Kubelet server.
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableContentionProfiling</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableContentionProfiling enables lock contention profiling, if enableDebuggingHandlers is true.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+enabling it may carry a performance impact.
+Default: false
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>healthzPort</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          healthzPort is the port of the localhost healthz endpoint (set to 0 to disable)
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that monitor Kubelet health.
+Default: 10248
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>healthzBindAddress</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          healthzBindAddress is the IP address for the healthz server to serve on
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that monitor Kubelet health.
+Default: "127.0.0.1"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>oomScoreAdj</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          oomScoreAdj is The oom-score-adj value for kubelet process. Values
+must be within the range [-1000, 1000].
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the stability of nodes under memory pressure.
+Default: -999
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clusterDomain</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterDomain is the DNS domain for this cluster. If set, kubelet will
+configure all containers to search this domain in addition to the
+host's search domains.
+Dynamic Kubelet Config (beta): Dynamically updating this field is not recommended,
+as it should be kept in sync with the rest of the cluster.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>clusterDNS</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clusterDNS is a list of IP addresses for the cluster DNS server. If set,
+kubelet will configure all containers to use this for DNS resolution
+instead of the host's DNS servers.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes will only take effect on Pods created after the update. Draining
+the node is recommended before changing this field.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>streamingConnectionIdleTimeout</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          streamingConnectionIdleTimeout is the maximum time a streaming connection
+can be idle before the connection is automatically closed.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact components that rely on infrequent updates over streaming
+connections to the Kubelet server.
+Default: "4h"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeStatusUpdateFrequency</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeStatusUpdateFrequency is the frequency that kubelet computes node
+status. If node lease feature is not enabled, it is also the frequency that
+kubelet posts node status to master.
+Note: When node lease feature is not enabled, be cautious when changing the
+constant, it must work with nodeMonitorGracePeriod in nodecontroller.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact node scalability, and also that the node controller's
+nodeMonitorGracePeriod must be set to N&lowast;NodeStatusUpdateFrequency,
+where N is the number of retries before the node controller marks
+the node unhealthy.
+Default: "10s"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeStatusReportFrequency</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeStatusReportFrequency is the frequency that kubelet posts node
+status to master if node status does not change. Kubelet will ignore this
+frequency and post node status immediately if any change is detected. It is
+only used when node lease feature is enabled. nodeStatusReportFrequency's
+default value is 1m. But if nodeStatusUpdateFrequency is set explicitly,
+nodeStatusReportFrequency's default value will be set to
+nodeStatusUpdateFrequency for backward compatibility.
+Default: "1m"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeLeaseDurationSeconds</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeLeaseDurationSeconds is the duration the Kubelet will set on its corresponding Lease,
+when the NodeLease feature is enabled. This feature provides an indicator of node
+health by having the Kubelet create and periodically renew a lease, named after the node,
+in the kube-node-lease namespace. If the lease expires, the node can be considered unhealthy.
+The lease is currently renewed every 10s, per KEP-0009. In the future, the lease renewal interval
+may be set based on the lease duration.
+Requires the NodeLease feature gate to be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+decreasing the duration may reduce tolerance for issues that temporarily prevent
+the Kubelet from renewing the lease (e.g. a short-lived network issue).
+Default: 40
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>imageMinimumGCAge</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          imageMinimumGCAge is the minimum age for an unused image before it is
+garbage collected.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: "2m"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>imageGCHighThresholdPercent</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          imageGCHighThresholdPercent is the percent of disk usage after which
+image garbage collection is always run. The percent is calculated as
+this field value out of 100.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: 85
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>imageGCLowThresholdPercent</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          imageGCLowThresholdPercent is the percent of disk usage before which
+image garbage collection is never run. Lowest disk usage to garbage
+collect to. The percent is calculated as this field value out of 100.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: 80
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>volumeStatsAggPeriod</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          How frequently to calculate and cache volume disk usage for all pods
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the period may carry a performance impact.
+Default: "1m"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubeletCgroups</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          kubeletCgroups is the absolute name of cgroups to isolate the kubelet in
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>systemCgroups</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          systemCgroups is absolute name of cgroups in which to place
+all non-kernel processes that are not already in a container. Empty
+for no container. Rolling back the flag requires a reboot.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cgroupRoot</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          cgroupRoot is the root cgroup to use for pods. This is handled by the
+container runtime on a best effort basis.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cgroupsPerQOS</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Enable QoS based Cgroup hierarchy: top level cgroups for QoS Classes
+And all Burstable and BestEffort pods are brought up under their
+specific top level QoS cgroup.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cgroupDriver</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          driver that the kubelet uses to manipulate cgroups on the host (cgroupfs or systemd)
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: "cgroupfs"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cpuManagerPolicy</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          CPUManagerPolicy is the name of the policy to use.
+Requires the CPUManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: "none"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cpuManagerReconcilePeriod</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          CPU Manager reconciliation period.
+Requires the CPUManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the period may carry a performance impact.
+Default: "10s"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>topologyManagerPolicy</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          TopologyManagerPolicy is the name of the policy to use.
+Policies other than "none" require the TopologyManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: "none"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>topologyManagerScope</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          TopologyManagerScope represents the scope of topology hint generation
+that topology manager requests and hint providers generate.
+"pod" scope requires the TopologyManager feature gate to be enabled.
+Default: "container"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>qosReserved</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          qosReserved is a set of resource name to percentage pairs that specify
+the minimum percentage of a resource reserved for exclusive use by the
+guaranteed QoS tier.
+Currently supported resources: "memory"
+Requires the QOSReserved feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>runtimeRequestTimeout</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          runtimeRequestTimeout is the timeout for all runtime requests except long running
+requests - pull, logs, exec and attach.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: "2m"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>hairpinMode</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          hairpinMode specifies how the Kubelet should configure the container
+bridge for hairpin packets.
+Setting this flag allows endpoints in a Service to loadbalance back to
+themselves if they should try to access their own Service. Values:
+  "promiscuous-bridge": make the container bridge promiscuous.
+  "hairpin-veth":       set the hairpin flag on container veth interfaces.
+  "none":               do nothing.
+Generally, one must set --hairpin-mode=hairpin-veth to achieve hairpin NAT,
+because promiscuous-bridge assumes the existence of a container bridge named cbr0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may require a node reboot, depending on the network plugin.
+Default: "promiscuous-bridge"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>maxPods</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          maxPods is the number of pods that can run on this Kubelet.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes may cause Pods to fail admission on Kubelet restart, and may change
+the value reported in Node.Status.Capacity[v1.ResourcePods], thus affecting
+future scheduling decisions. Increasing this value may also decrease performance,
+as more Pods can be packed into a single node.
+Default: 110
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>podCIDR</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The CIDR to use for pod IP addresses, only used in standalone mode.
+In cluster mode, this is obtained from the master.
+Dynamic Kubelet Config (beta): This field should always be set to the empty default.
+It should only set for standalone Kubelets, which cannot use Dynamic Kubelet Config.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>podPidsLimit</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          PodPidsLimit is the maximum number of pids in any pod.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may prevent container processes from forking after the change.
+Default: -1
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>resolvConf</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          ResolverConfig is the resolver configuration file used as the basis
+for the container DNS resolution configuration.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes will only take effect on Pods created after the update. Draining
+the node is recommended before changing this field.
+Default: "/etc/resolv.conf"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>runOnce</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          RunOnce causes the Kubelet to check the API server once for pods,
+run those in addition to the pods specified by static pod files, and exit.
+Default: false
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cpuCFSQuota</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          cpuCFSQuota enables CPU CFS quota enforcement for containers that
+specify CPU limits.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may reduce node stability.
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cpuCFSQuotaPeriod</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          CPUCFSQuotaPeriod is the CPU CFS quota period value, cpu.cfs_period_us.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+limits set for containers will result in different cpu.cfs_quota settings. This
+will trigger container restarts on the node being reconfigured.
+Default: "100ms"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>nodeStatusMaxImages</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          nodeStatusMaxImages caps the number of images reported in Node.Status.Images.
+Note: If -1 is specified, no cap will be applied. If 0 is specified, no image is returned.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+different values can be reported on node status.
+Default: 50
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>maxOpenFiles</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int64</span>
+            
+          
+        </td>
+        <td>
+          
+
+          maxOpenFiles is Number of files that can be opened by Kubelet process.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability of the Kubelet to interact with the node's filesystem.
+Default: 1000000
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>contentType</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          contentType is contentType of requests sent to apiserver.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability for the Kubelet to communicate with the API server.
+If the Kubelet loses contact with the API server due to a change to this field,
+the change cannot be reverted via dynamic Kubelet config.
+Default: "application/vnd.kubernetes.protobuf"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubeAPIQPS</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          kubeAPIQPS is the QPS to use while talking with kubernetes apiserver
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic the Kubelet
+sends to the API server.
+Default: 5
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubeAPIBurst</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          kubeAPIBurst is the burst to allow while talking with kubernetes apiserver
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic the Kubelet
+sends to the API server.
+Default: 10
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>serializeImagePulls</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          serializeImagePulls when enabled, tells the Kubelet to pull images one
+at a time. We recommend &lowast;not&lowast; changing the default value on nodes that
+run docker daemon with version  < 1.9 or an Aufs storage backend.
+Issue #10959 has more details.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the performance of image pulls.
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>evictionHard</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Map of signal names to quantities that defines hard eviction thresholds. For example: {"memory.available": "300Mi"}.
+To explicitly disable, pass a 0% or 100% threshold on an arbitrary resource.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions.
+Default:
+  memory.available:  "100Mi"
+  nodefs.available:  "10%"
+  nodefs.inodesFree: "5%"
+  imagefs.available: "15%"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>evictionSoft</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Map of signal names to quantities that defines soft eviction thresholds.
+For example: {"memory.available": "300Mi"}.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions, and may change the allocatable reported
+by the node.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>evictionSoftGracePeriod</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Map of signal names to quantities that defines grace periods for each soft eviction signal.
+For example: {"memory.available": "30s"}.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>evictionPressureTransitionPeriod</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may decrease the stability of the node when the node is overcommitted.
+Default: "5m"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>evictionMaxPodGracePeriod</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Maximum allowed grace period (in seconds) to use when terminating pods in
+response to a soft eviction threshold being met. This value effectively caps
+the Pod's TerminationGracePeriodSeconds value during soft evictions.
+Note: Due to issue #64530, the behavior has a bug where this value currently just
+overrides the grace period during soft eviction, which can increase the grace
+period from what is set on the Pod. This bug will be fixed in a future release.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it decreases the amount of time Pods will have to gracefully clean
+up before being killed during a soft eviction.
+Default: 0
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>evictionMinimumReclaim</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Map of signal names to quantities that defines minimum reclaims, which describe the minimum
+amount of a given resource the kubelet will reclaim when performing a pod eviction while
+that resource is under pressure. For example: {"imagefs.available": "2Gi"}
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may change how well eviction can manage resource pressure.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>podsPerCore</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          podsPerCore is the maximum number of pods per core. Cannot exceed MaxPods.
+If 0, this field is ignored.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes may cause Pods to fail admission on Kubelet restart, and may change
+the value reported in Node.Status.Capacity[v1.ResourcePods], thus affecting
+future scheduling decisions. Increasing this value may also decrease performance,
+as more Pods can be packed into a single node.
+Default: 0
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableControllerAttachDetach</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableControllerAttachDetach enables the Attach/Detach controller to
+manage attachment/detachment of volumes scheduled to this node, and
+disables kubelet from executing any attach/detach operations
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changing which component is responsible for volume management on a live node
+may result in volumes refusing to detach if the node is not drained prior to
+the update, and if Pods are scheduled to the node before the
+volumes.kubernetes.io/controller-managed-attach-detach annotation is updated by the
+Kubelet. In general, it is safest to leave this value set the same as local config.
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>protectKernelDefaults</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          protectKernelDefaults, if true, causes the Kubelet to error if kernel
+flags are not as it expects. Otherwise the Kubelet will attempt to modify
+kernel flags to match its expectation.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+enabling it may cause the Kubelet to crash-loop if the Kernel is not configured as
+Kubelet expects.
+Default: false
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>makeIPTablesUtilChains</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          If true, Kubelet ensures a set of iptables rules are present on host.
+These rules will serve as utility rules for various components, e.g. KubeProxy.
+The rules will be created based on IPTablesMasqueradeBit and IPTablesDropBit.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it will prevent the Kubelet from healing locally misconfigured iptables rules.
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>iptablesMasqueradeBit</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          iptablesMasqueradeBit is the bit of the iptables fwmark space to mark for SNAT
+Values must be within the range [0, 31]. Must be different from other mark bits.
+Warning: Please match the value of the corresponding parameter in kube-proxy.
+TODO: clean up IPTablesMasqueradeBit in kube-proxy
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it needs to be coordinated with other components, like kube-proxy, and the update
+will only be effective if MakeIPTablesUtilChains is enabled.
+Default: 14
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>iptablesDropBit</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          iptablesDropBit is the bit of the iptables fwmark space to mark for dropping packets.
+Values must be within the range [0, 31]. Must be different from other mark bits.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it needs to be coordinated with other components, like kube-proxy, and the update
+will only be effective if MakeIPTablesUtilChains is enabled.
+Default: 15
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>featureGates</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          featureGates is a map of feature names to bools that enable or disable alpha/experimental
+features. This field modifies piecemeal the built-in default values from
+"k8s.io/kubernetes/pkg/features/kube_features.go".
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider the
+documentation for the features you are enabling or disabling. While we
+encourage feature developers to make it possible to dynamically enable
+and disable features, some changes may require node reboots, and some
+features may require careful coordination to retroactively disable.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>failSwapOn</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          failSwapOn tells the Kubelet to fail to start if swap is enabled on the node.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+setting it to true will cause the Kubelet to crash-loop if swap is enabled.
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>containerLogMaxSize</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          A quantity defines the maximum size of the container log file before it is rotated.
+For example: "5Mi" or "256Ki".
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger log rotation.
+Default: "10Mi"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>containerLogMaxFiles</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">int32</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Maximum number of container log files that can be present for a container.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may cause log files to be deleted.
+Default: 5
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>configMapAndSecretChangeDetectionStrategy</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubelet-config-k8s-io-v1beta1-ResourceChangeDetectionStrategy">
+                <span style="font-family: monospace">ResourceChangeDetectionStrategy</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ConfigMapAndSecretChangeDetectionStrategy is a mode in which
+config map and secret managers are running.
+Default: "Watch"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>systemReserved</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          systemReserved is a set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G)
+pairs that describe resources reserved for non-kubernetes components.
+Currently only cpu and memory are supported.
+See http://kubernetes.io/docs/user-guide/compute-resources for more detail.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may not be possible to increase the reserved resources, because this
+requires resizing cgroups. Always look for a NodeAllocatableEnforced event
+after updating this field to ensure that the update was successful.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubeReserved</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs
+that describe resources reserved for kubernetes system components.
+Currently cpu, memory and local storage for root file system are supported.
+See http://kubernetes.io/docs/user-guide/compute-resources for more detail.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may not be possible to increase the reserved resources, because this
+requires resizing cgroups. Always look for a NodeAllocatableEnforced event
+after updating this field to ensure that the update was successful.
+Default: nil
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>reservedSystemCPUs</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          This ReservedSystemCPUs option specifies the cpu list reserved for the host level system threads and kubernetes related threads.
+This provide a "static" CPU list rather than the "dynamic" list by system-reserved and kube-reserved.
+This option overwrites CPUs provided by system-reserved and kube-reserved.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>showHiddenMetricsForVersion</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          The previous version for which you want to show hidden metrics.
+Only the previous minor version is meaningful, other values will not be allowed.
+The format is <major>.<minor>, e.g.: '1.16'.
+The purpose of this format is make sure you have the opportunity to notice if the next release hides additional metrics,
+rather than being surprised when they are permanently removed in the release after that.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>systemReservedCgroup</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          This flag helps kubelet identify absolute name of top level cgroup used to enforce `SystemReserved` compute resource reservation for OS system daemons.
+Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kubeReservedCgroup</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          This flag helps kubelet identify absolute name of top level cgroup used to enforce `KubeReserved` compute resource reservation for Kubernetes node system daemons.
+Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enforceNodeAllocatable</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          This flag specifies the various Node Allocatable enforcements that Kubelet needs to perform.
+This flag accepts a list of options. Acceptable options are `none`, `pods`, `system-reserved` & `kube-reserved`.
+If `none` is specified, no other options may be specified.
+Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+removing enforcements may reduce the stability of the node. Alternatively, adding
+enforcements may reduce the stability of components which were using more than
+the reserved amount of resources; for example, enforcing kube-reserved may cause
+Kubelets to OOM if it uses more than the reserved resources, and enforcing system-reserved
+may cause system daemons to OOM if they use more than the reserved resources.
+Default: ["pods"]
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>allowedUnsafeSysctls</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">[]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          A comma separated whitelist of unsafe sysctls or sysctl patterns (ending in &lowast;).
+Unsafe sysctl groups are kernel.shm&lowast;, kernel.msg&lowast;, kernel.sem, fs.mqueue.&lowast;, and net.&lowast;.
+These sysctls are namespaced but not allowed by default.  For example: "kernel.msg&lowast;,net.ipv4.route.min_pmtu"
+Default: []
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>volumePluginDir</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          volumePluginDir is the full path of the directory in which to search
+for additional third party volume plugins.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that changing
+the volumePluginDir may disrupt workloads relying on third party volume plugins.
+Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>providerID</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          providerID, if set, sets the unique id of the instance that an external provider (i.e. cloudprovider)
+can use to identify a specific node.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability of the Kubelet to interact with cloud providers.
+Default: ""
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>kernelMemcgNotification</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          kernelMemcgNotification, if set, the kubelet will integrate with the kernel memcg notification
+to determine if memory eviction thresholds are crossed rather than polling.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the way Kubelet interacts with the kernel.
+Default: false
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>logging</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#LoggingConfiguration">
+                <span style="font-family: monospace">LoggingConfiguration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Logging specifies the options of logging.
+Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
+Defaults:
+  Format: text
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>enableSystemLogHandler</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enableSystemLogHandler enables system logs via web interface host:port/logs/
+Default: true
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>shutdownGracePeriod</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ShutdownGracePeriod specifies the total duration that the node should delay the shutdown and total grace period for pod termination during a node shutdown.
+Default: "30s"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>shutdownGracePeriodCriticalPods</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          ShutdownGracePeriodCriticalPods specifies the duration used to terminate critical pods during a node shutdown. This should be less than ShutdownGracePeriod.
+For example, if ShutdownGracePeriod=30s, and ShutdownGracePeriodCriticalPods=10s, during a node shutdown the first 20 seconds would be reserved for gracefully terminating normal pods, and the last 10 seconds would be reserved for terminating critical pods.
+Default: "10s"
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-SerializedNodeConfigSource">SerializedNodeConfigSource
+    </H3>
+
+  
+
+  <p>SerializedNodeConfigSource allows us to serialize v1.NodeConfigSource.
+This type is used internally by the Kubelet for tracking checkpointed dynamic configs.
+It exists in the kubeletconfig API group because it is classified as a versioned input to the Kubelet.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>kubelet.config.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>SerializedNodeConfigSource</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>source</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#nodeconfigsource-v1-core">
+                <span style="font-family: monospace">core/v1.NodeConfigSource</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Source is the source that we are serializing
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-HairpinMode">HairpinMode
+    (<code>string</code> alias)</p></H3>
+
+  
+
+  <p>HairpinMode denotes how the kubelet should configure networking to handle
+hairpin packets.</p>
+
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-KubeletAnonymousAuthentication">KubeletAnonymousAuthentication
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthentication">KubeletAuthentication</a>)
+    </p>
+  
+
+  <p></p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>enabled</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enabled allows anonymous requests to the kubelet server.
+Requests that are not rejected by another authentication method are treated as anonymous requests.
+Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-KubeletAuthentication">KubeletAuthentication
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletConfiguration">KubeletConfiguration</a>)
+    </p>
+  
+
+  <p></p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>x509</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubelet-config-k8s-io-v1beta1-KubeletX509Authentication">
+                <span style="font-family: monospace">KubeletX509Authentication</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          x509 contains settings related to x509 client certificate authentication
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>webhook</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthentication">
+                <span style="font-family: monospace">KubeletWebhookAuthentication</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          webhook contains settings related to webhook bearer token authentication
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>anonymous</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubelet-config-k8s-io-v1beta1-KubeletAnonymousAuthentication">
+                <span style="font-family: monospace">KubeletAnonymousAuthentication</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          anonymous contains settings related to anonymous authentication
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-KubeletAuthorization">KubeletAuthorization
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletConfiguration">KubeletConfiguration</a>)
+    </p>
+  
+
+  <p></p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>mode</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorizationMode">
+                <span style="font-family: monospace">KubeletAuthorizationMode</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          mode is the authorization mode to apply to requests to the kubelet server.
+Valid values are AlwaysAllow and Webhook.
+Webhook mode uses the SubjectAccessReview API to determine authorization.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>webhook</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthorization">
+                <span style="font-family: monospace">KubeletWebhookAuthorization</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          webhook contains settings related to Webhook authorization.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-KubeletAuthorizationMode">KubeletAuthorizationMode
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorization">KubeletAuthorization</a>)
+    </p>
+  
+
+  <p></p>
+
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthentication">KubeletWebhookAuthentication
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthentication">KubeletAuthentication</a>)
+    </p>
+  
+
+  <p></p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>enabled</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          enabled allows bearer token authentication backed by the tokenreviews.authentication.k8s.io API
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cacheTTL</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          cacheTTL enables caching of authentication results
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthorization">KubeletWebhookAuthorization
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorization">KubeletAuthorization</a>)
+    </p>
+  
+
+  <p></p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>cacheAuthorizedTTL</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          cacheAuthorizedTTL is the duration to cache 'authorized' responses from the webhook authorizer.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>cacheUnauthorizedTTL</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          cacheUnauthorizedTTL is the duration to cache 'unauthorized' responses from the webhook authorizer.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-KubeletX509Authentication">KubeletX509Authentication
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthentication">KubeletAuthentication</a>)
+    </p>
+  
+
+  <p></p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>clientCAFile</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          clientCAFile is the path to a PEM-encoded certificate bundle. If set, any request presenting a client certificate
+signed by one of the authorities in the bundle is authenticated with a username corresponding to the CommonName,
+and groups corresponding to the Organization in the client certificate.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="kubelet-config-k8s-io-v1beta1-ResourceChangeDetectionStrategy">ResourceChangeDetectionStrategy
+    (<code>string</code> alias)</p></H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#kubelet-config-k8s-io-v1beta1-KubeletConfiguration">KubeletConfiguration</a>)
+    </p>
+  
+
+  <p>ResourceChangeDetectionStrategy denotes a mode in which internal
+managers (secret, configmap) are discovering object changes.</p>
+
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/html/metrics.v1beta1.html
+++ b/genref/output/html/metrics.v1beta1.html
@@ -1,0 +1,705 @@
+
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/font-awesome.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+      <style type="text/css">
+        td p {
+          margin-bottom: 0
+        }
+        code {
+          color: #802060;
+          display: inline-block;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        
+        
+          
+          
+            <H2 id="metrics-k8s-io-v1beta1">Package: <span style="font-family: monospace">metrics.k8s.io/v1beta1</span></H2>
+            <p>Package v1beta1 is the v1beta1 version of the metrics API.</p>
+
+            
+            <H3>Resource Types:</H3>
+            <ul><li>
+                    <a href="#metrics-k8s-io-v1beta1-NodeMetrics">NodeMetrics</a>
+                  </li><li>
+                    <a href="#metrics-k8s-io-v1beta1-NodeMetricsList">NodeMetricsList</a>
+                  </li><li>
+                    <a href="#metrics-k8s-io-v1beta1-PodMetrics">PodMetrics</a>
+                  </li><li>
+                    <a href="#metrics-k8s-io-v1beta1-PodMetricsList">PodMetricsList</a>
+                  </li></ul>
+
+            
+            
+              
+  <H3 id="metrics-k8s-io-v1beta1-NodeMetrics">NodeMetrics
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#metrics-k8s-io-v1beta1-NodeMetricsList">NodeMetricsList</a>)
+    </p>
+  
+
+  <p>NodeMetrics sets resource usage metrics of a node.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>metrics.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>NodeMetrics</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>metadata</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+                <span style="font-family: monospace">meta/v1.ObjectMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+            Refer to the Kubernetes API documentation for the fields of the
+            <code>metadata</code> field.
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>timestamp</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+                <span style="font-family: monospace">meta/v1.Time</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The following fields define time interval from which metrics were
+collected from the interval [Timestamp-Window, Timestamp].
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>window</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>usage</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcelist-v1-core">
+                <span style="font-family: monospace">core/v1.ResourceList</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The memory usage is the memory working set.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="metrics-k8s-io-v1beta1-NodeMetricsList">NodeMetricsList
+    </H3>
+
+  
+
+  <p>NodeMetricsList is a list of NodeMetrics.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>metrics.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>NodeMetricsList</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>metadata</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta">
+                <span style="font-family: monospace">meta/v1.ListMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Standard list metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>items</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#metrics-k8s-io-v1beta1-NodeMetrics">
+                <span style="font-family: monospace">[]NodeMetrics</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          List of node metrics.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="metrics-k8s-io-v1beta1-PodMetrics">PodMetrics
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#metrics-k8s-io-v1beta1-PodMetricsList">PodMetricsList</a>)
+    </p>
+  
+
+  <p>PodMetrics sets resource usage metrics of a pod.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>metrics.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>PodMetrics</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>metadata</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">
+                <span style="font-family: monospace">meta/v1.ObjectMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+            Refer to the Kubernetes API documentation for the fields of the
+            <code>metadata</code> field.
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>timestamp</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta">
+                <span style="font-family: monospace">meta/v1.Time</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The following fields define time interval from which metrics were
+collected from the interval [Timestamp-Window, Timestamp].
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>window</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>containers</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#metrics-k8s-io-v1beta1-ContainerMetrics">
+                <span style="font-family: monospace">[]ContainerMetrics</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Metrics for all containers are collected within the same time window.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="metrics-k8s-io-v1beta1-PodMetricsList">PodMetricsList
+    </H3>
+
+  
+
+  <p>PodMetricsList is a list of PodMetrics.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+          
+          <tr>
+            <td><code>apiVersion</code></br>string</td>
+            <td><code>metrics.k8s.io/v1beta1</code></td>
+          </tr>
+          <tr>
+            <td><code>kind</code></br>string</td>
+            <td><code>PodMetricsList</code></td>
+          </tr>
+        
+
+        
+        
+
+  
+  
+    
+    
+  
+    
+    
+      <tr>
+        <td><code>metadata</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta">
+                <span style="font-family: monospace">meta/v1.ListMeta</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          Standard list metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>items</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="#metrics-k8s-io-v1beta1-PodMetrics">
+                <span style="font-family: monospace">[]PodMetrics</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          List of pod metrics.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+              
+  <H3 id="metrics-k8s-io-v1beta1-ContainerMetrics">ContainerMetrics
+    </H3>
+
+  
+    <p>
+      (<em>Appears in:</em>
+        <a href="#metrics-k8s-io-v1beta1-PodMetrics">PodMetrics</a>)
+    </p>
+  
+
+  <p>ContainerMetrics sets resource usage metrics of a container.</p>
+
+  
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+
+        
+        
+
+  
+  
+    
+    
+      <tr>
+        <td><code>name</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          Container name corresponding to the one from pod.spec.containers.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>usage</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcelist-v1-core">
+                <span style="font-family: monospace">core/v1.ResourceList</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          The memory usage is the memory working set.
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+
+
+      </tbody>
+    </table>
+  
+
+            
+          
+
+          <HR />
+        
+      </div>
+
+      <div class="container">
+        <p><em>Generated with <code>gendoc</code> on git commit <code>5cc67040</code></em></p>
+      </div>
+    </body>
+  </html>

--- a/genref/output/md/apiserver-audit.v1.md
+++ b/genref/output/md/apiserver-audit.v1.md
@@ -1,0 +1,620 @@
+---
+title: kube-apiserver Audit Configuration (v1)
+content_type: tool-reference
+package: audit.k8s.io/v1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [Event](#audit-k8s-io-v1-Event)
+- [EventList](#audit-k8s-io-v1-EventList)
+- [Policy](#audit-k8s-io-v1-Policy)
+- [PolicyList](#audit-k8s-io-v1-PolicyList)
+  
+    
+
+
+## `Event`     {#audit-k8s-io-v1-Event}
+    
+
+
+
+**Appears in:**
+
+- [EventList](#audit-k8s-io-v1-EventList)
+
+
+Event captures all the information that can be included in an API audit log.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>audit.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Event</code></td></tr>
+    
+
+  
+  
+<tr><td><code>level</code> <B>[Required]</B><br/>
+<a href="#audit-k8s-io-v1-Level"><code>Level</code></a>
+</td>
+<td>
+   AuditLevel at which event was generated</td>
+</tr>
+    
+  
+<tr><td><code>auditID</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
+</td>
+<td>
+   Unique audit ID, generated for each request.</td>
+</tr>
+    
+  
+<tr><td><code>stage</code> <B>[Required]</B><br/>
+<a href="#audit-k8s-io-v1-Stage"><code>Stage</code></a>
+</td>
+<td>
+   Stage of the request handling when this event instance was generated.</td>
+</tr>
+    
+  
+<tr><td><code>requestURI</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   RequestURI is the request URI as sent by the client to a server.</td>
+</tr>
+    
+  
+<tr><td><code>verb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb is the kubernetes verb associated with the request.
+For non-resource requests, this is the lower-cased HTTP method.</td>
+</tr>
+    
+  
+<tr><td><code>user</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#userinfo-v1-authentication"><code>authentication/v1.UserInfo</code></a>
+</td>
+<td>
+   Authenticated user information.</td>
+</tr>
+    
+  
+<tr><td><code>impersonatedUser</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#userinfo-v1-authentication"><code>authentication/v1.UserInfo</code></a>
+</td>
+<td>
+   Impersonated user information.</td>
+</tr>
+    
+  
+<tr><td><code>sourceIPs</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   Source IPs, from where the request originated and intermediate proxies.</td>
+</tr>
+    
+  
+<tr><td><code>userAgent</code><br/>
+<code>string</code>
+</td>
+<td>
+   UserAgent records the user agent string reported by the client.
+Note that the UserAgent is provided by the client, and must not be trusted.</td>
+</tr>
+    
+  
+<tr><td><code>objectRef</code><br/>
+<a href="#audit-k8s-io-v1-ObjectReference"><code>ObjectReference</code></a>
+</td>
+<td>
+   Object reference this request is targeted at.
+Does not apply for List-type requests, or non-resource requests.</td>
+</tr>
+    
+  
+<tr><td><code>responseStatus</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#status-v1-meta"><code>meta/v1.Status</code></a>
+</td>
+<td>
+   The response status, populated even when the ResponseObject is not a Status type.
+For successful responses, this will only include the Code and StatusSuccess.
+For non-status type error responses, this will be auto-populated with the error Message.</td>
+</tr>
+    
+  
+<tr><td><code>requestObject</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
+</td>
+<td>
+   API object from the request, in JSON format. The RequestObject is recorded as-is in the request
+(possibly re-encoded as JSON), prior to version conversion, defaulting, admission or
+merging. It is an external versioned object type, and may not be a valid object on its own.
+Omitted for non-resource requests.  Only logged at Request Level and higher.</td>
+</tr>
+    
+  
+<tr><td><code>responseObject</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
+</td>
+<td>
+   API object returned in the response, in JSON. The ResponseObject is recorded after conversion
+to the external type, and serialized as JSON.  Omitted for non-resource requests.  Only logged
+at Response Level.</td>
+</tr>
+    
+  
+<tr><td><code>requestReceivedTimestamp</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
+</td>
+<td>
+   Time the request reached the apiserver.</td>
+</tr>
+    
+  
+<tr><td><code>stageTimestamp</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
+</td>
+<td>
+   Time the request reached current audit stage.</td>
+</tr>
+    
+  
+<tr><td><code>annotations</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   Annotations is an unstructured key value map stored with an audit event that may be set by
+plugins invoked in the request serving chain, including authentication, authorization and
+admission plugins. Note that these annotations are for the audit event, and do not correspond
+to the metadata.annotations of the submitted object. Keys should uniquely identify the informing
+component to avoid name collisions (e.g. podsecuritypolicy.admission.k8s.io/policy). Values
+should be short. Annotations are included in the Metadata level.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `EventList`     {#audit-k8s-io-v1-EventList}
+    
+
+
+
+
+EventList is a list of audit Events.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>audit.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>EventList</code></td></tr>
+    
+
+  
+  
+<tr><td><code>metadata</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>items</code> <B>[Required]</B><br/>
+<a href="#audit-k8s-io-v1-Event"><code>[]Event</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Policy`     {#audit-k8s-io-v1-Policy}
+    
+
+
+
+**Appears in:**
+
+- [PolicyList](#audit-k8s-io-v1-PolicyList)
+
+
+Policy defines the configuration of audit logging, and the rules for how different request
+categories are logged.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>audit.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Policy</code></td></tr>
+    
+
+  
+  
+<tr><td><code>metadata</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+</td>
+<td>
+   ObjectMeta is included for interoperability with API infrastructure.Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
+</tr>
+    
+  
+<tr><td><code>rules</code> <B>[Required]</B><br/>
+<a href="#audit-k8s-io-v1-PolicyRule"><code>[]PolicyRule</code></a>
+</td>
+<td>
+   Rules specify the audit Level a request should be recorded at.
+A request may match multiple rules, in which case the FIRST matching rule is used.
+The default audit level is None, but can be overridden by a catch-all rule at the end of the list.
+PolicyRules are strictly ordered.</td>
+</tr>
+    
+  
+<tr><td><code>omitStages</code><br/>
+<a href="#audit-k8s-io-v1-Stage"><code>[]Stage</code></a>
+</td>
+<td>
+   OmitStages is a list of stages for which no events are created. Note that this can also
+be specified per rule in which case the union of both are omitted.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PolicyList`     {#audit-k8s-io-v1-PolicyList}
+    
+
+
+
+
+PolicyList is a list of audit Policies.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>audit.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>PolicyList</code></td></tr>
+    
+
+  
+  
+<tr><td><code>metadata</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>items</code> <B>[Required]</B><br/>
+<a href="#audit-k8s-io-v1-Policy"><code>[]Policy</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `GroupResources`     {#audit-k8s-io-v1-GroupResources}
+    
+
+
+
+**Appears in:**
+
+- [PolicyRule](#audit-k8s-io-v1-PolicyRule)
+
+
+GroupResources represents resource kinds in an API group.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>group</code><br/>
+<code>string</code>
+</td>
+<td>
+   Group is the name of the API group that contains the resources.
+The empty string represents the core API group.</td>
+</tr>
+    
+  
+<tr><td><code>resources</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   Resources is a list of resources this rule applies to.
+
+For example:
+'pods' matches pods.
+'pods/log' matches the log subresource of pods.
+'&lowast;' matches all resources and their subresources.
+'pods/&lowast;' matches all subresources of pods.
+'&lowast;/scale' matches all scale subresources.
+
+If wildcard is present, the validation rule will ensure resources do not
+overlap with each other.
+
+An empty list implies all resources and subresources in this API groups apply.</td>
+</tr>
+    
+  
+<tr><td><code>resourceNames</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   ResourceNames is a list of resource instance names that the policy matches.
+Using this field requires Resources to be specified.
+An empty list implies that every instance of the resource is matched.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Level`     {#audit-k8s-io-v1-Level}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [Event](#audit-k8s-io-v1-Event)
+
+- [PolicyRule](#audit-k8s-io-v1-PolicyRule)
+
+
+Level defines the amount of information logged during auditing
+
+
+    
+
+
+## `ObjectReference`     {#audit-k8s-io-v1-ObjectReference}
+    
+
+
+
+**Appears in:**
+
+- [Event](#audit-k8s-io-v1-Event)
+
+
+ObjectReference contains enough information to let you inspect or modify the referred object.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>resource</code><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>namespace</code><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>name</code><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>uid</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>apiGroup</code><br/>
+<code>string</code>
+</td>
+<td>
+   APIGroup is the name of the API group that contains the referred object.
+The empty string represents the core API group.</td>
+</tr>
+    
+  
+<tr><td><code>apiVersion</code><br/>
+<code>string</code>
+</td>
+<td>
+   APIVersion is the version of the API group that contains the referred object.</td>
+</tr>
+    
+  
+<tr><td><code>resourceVersion</code><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>subresource</code><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PolicyRule`     {#audit-k8s-io-v1-PolicyRule}
+    
+
+
+
+**Appears in:**
+
+- [Policy](#audit-k8s-io-v1-Policy)
+
+
+PolicyRule maps requests based off metadata to an audit Level.
+Requests must match the rules of every field (an intersection of rules).
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>level</code> <B>[Required]</B><br/>
+<a href="#audit-k8s-io-v1-Level"><code>Level</code></a>
+</td>
+<td>
+   The Level that requests matching this rule are recorded at.</td>
+</tr>
+    
+  
+<tr><td><code>users</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   The users (by authenticated user name) this rule applies to.
+An empty list implies every user.</td>
+</tr>
+    
+  
+<tr><td><code>userGroups</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   The user groups this rule applies to. A user is considered matching
+if it is a member of any of the UserGroups.
+An empty list implies every user group.</td>
+</tr>
+    
+  
+<tr><td><code>verbs</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   The verbs that match this rule.
+An empty list implies every verb.</td>
+</tr>
+    
+  
+<tr><td><code>resources</code><br/>
+<a href="#audit-k8s-io-v1-GroupResources"><code>[]GroupResources</code></a>
+</td>
+<td>
+   Resources that this rule matches. An empty list implies all kinds in all API groups.</td>
+</tr>
+    
+  
+<tr><td><code>namespaces</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   Namespaces that this rule matches.
+The empty string "" matches non-namespaced resources.
+An empty list implies every namespace.</td>
+</tr>
+    
+  
+<tr><td><code>nonResourceURLs</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   NonResourceURLs is a set of URL paths that should be audited.
+&lowast;s are allowed, but only as the full, final step in the path.
+Examples:
+ "/metrics" - Log requests for apiserver metrics
+ "/healthz&lowast;" - Log all health checks</td>
+</tr>
+    
+  
+<tr><td><code>omitStages</code><br/>
+<a href="#audit-k8s-io-v1-Stage"><code>[]Stage</code></a>
+</td>
+<td>
+   OmitStages is a list of stages for which no events are created. Note that this can also
+be specified policy wide in which case the union of both are omitted.
+An empty list means no restrictions will apply.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Stage`     {#audit-k8s-io-v1-Stage}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [Event](#audit-k8s-io-v1-Event)
+
+- [Policy](#audit-k8s-io-v1-Policy)
+
+- [PolicyRule](#audit-k8s-io-v1-PolicyRule)
+
+
+Stage defines the stages in request handling that audit events may be generated.
+
+
+    
+  

--- a/genref/output/md/apiserver-config.v1.md
+++ b/genref/output/md/apiserver-config.v1.md
@@ -1,0 +1,96 @@
+---
+title: kube-apiserver Configuration (v1)
+content_type: tool-reference
+package: apiserver.config.k8s.io/v1
+auto_generated: true
+---
+Package v1 is the v1 version of the API.
+
+## Resource Types 
+
+
+- [AdmissionConfiguration](#apiserver-config-k8s-io-v1-AdmissionConfiguration)
+  
+    
+
+
+## `AdmissionConfiguration`     {#apiserver-config-k8s-io-v1-AdmissionConfiguration}
+    
+
+
+
+
+AdmissionConfiguration provides versioned configuration for admission controllers.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>AdmissionConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>plugins</code><br/>
+<a href="#apiserver-config-k8s-io-v1-AdmissionPluginConfiguration"><code>[]AdmissionPluginConfiguration</code></a>
+</td>
+<td>
+   Plugins allows specifying a configuration per admission control plugin.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `AdmissionPluginConfiguration`     {#apiserver-config-k8s-io-v1-AdmissionPluginConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [AdmissionConfiguration](#apiserver-config-k8s-io-v1-AdmissionConfiguration)
+
+
+AdmissionPluginConfiguration provides the configuration for a single plug-in.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name is the name of the admission controller.
+It must match the registered admission plugin name.</td>
+</tr>
+    
+  
+<tr><td><code>path</code><br/>
+<code>string</code>
+</td>
+<td>
+   Path is the path to a configuration file that contains the plugin's
+configuration</td>
+</tr>
+    
+  
+<tr><td><code>configuration</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
+</td>
+<td>
+   Configuration is an embedded configuration object to be used as the plugin's
+configuration. If present, it will be used instead of the path to the configuration file.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/apiserver-config.v1beta1.md
+++ b/genref/output/md/apiserver-config.v1beta1.md
@@ -1,0 +1,311 @@
+---
+title: kube-apiserver Configuration (v1beta1)
+content_type: tool-reference
+package: apiserver.k8s.io/v1beta1
+auto_generated: true
+---
+Package v1beta1 is the v1beta1 version of the API.
+
+## Resource Types 
+
+
+- [EgressSelectorConfiguration](#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration)
+  
+    
+
+
+## `EgressSelectorConfiguration`     {#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration}
+    
+
+
+
+
+EgressSelectorConfiguration provides versioned configuration for egress selector clients.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>EgressSelectorConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>egressSelections</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1beta1-EgressSelection"><code>[]EgressSelection</code></a>
+</td>
+<td>
+   connectionServices contains a list of egress selection client configurations</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Connection`     {#apiserver-k8s-io-v1beta1-Connection}
+    
+
+
+
+**Appears in:**
+
+- [EgressSelection](#apiserver-k8s-io-v1beta1-EgressSelection)
+
+
+Connection provides the configuration for a single egress selection client.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>proxyProtocol</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1beta1-ProtocolType"><code>ProtocolType</code></a>
+</td>
+<td>
+   Protocol is the protocol used to connect from client to the konnectivity server.</td>
+</tr>
+    
+  
+<tr><td><code>transport</code><br/>
+<a href="#apiserver-k8s-io-v1beta1-Transport"><code>Transport</code></a>
+</td>
+<td>
+   Transport defines the transport configurations we use to dial to the konnectivity server.
+This is required if ProxyProtocol is HTTPConnect or GRPC.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `EgressSelection`     {#apiserver-k8s-io-v1beta1-EgressSelection}
+    
+
+
+
+**Appears in:**
+
+- [EgressSelectorConfiguration](#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration)
+
+
+EgressSelection provides the configuration for a single egress selection client.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   name is the name of the egress selection.
+Currently supported values are "controlplane", "master", "etcd" and "cluster"
+The "master" egress selector is deprecated in favor of "controlplane"</td>
+</tr>
+    
+  
+<tr><td><code>connection</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1beta1-Connection"><code>Connection</code></a>
+</td>
+<td>
+   connection is the exact information used to configure the egress selection</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ProtocolType`     {#apiserver-k8s-io-v1beta1-ProtocolType}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [Connection](#apiserver-k8s-io-v1beta1-Connection)
+
+
+ProtocolType is a set of valid values for Connection.ProtocolType
+
+
+    
+
+
+## `TCPTransport`     {#apiserver-k8s-io-v1beta1-TCPTransport}
+    
+
+
+
+**Appears in:**
+
+- [Transport](#apiserver-k8s-io-v1beta1-Transport)
+
+
+TCPTransport provides the information to connect to konnectivity server via TCP
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>url</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   URL is the location of the konnectivity server to connect to.
+As an example it might be "https://127.0.0.1:8131"</td>
+</tr>
+    
+  
+<tr><td><code>tlsConfig</code><br/>
+<a href="#apiserver-k8s-io-v1beta1-TLSConfig"><code>TLSConfig</code></a>
+</td>
+<td>
+   TLSConfig is the config needed to use TLS when connecting to konnectivity server</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `TLSConfig`     {#apiserver-k8s-io-v1beta1-TLSConfig}
+    
+
+
+
+**Appears in:**
+
+- [TCPTransport](#apiserver-k8s-io-v1beta1-TCPTransport)
+
+
+TLSConfig provides the authentication information to connect to konnectivity server
+Only used with TCPTransport
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>caBundle</code><br/>
+<code>string</code>
+</td>
+<td>
+   caBundle is the file location of the CA to be used to determine trust with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+If absent while TCPTransport.URL is prefixed with https://, default to system trust roots.</td>
+</tr>
+    
+  
+<tr><td><code>clientKey</code><br/>
+<code>string</code>
+</td>
+<td>
+   clientKey is the file location of the client key to be used in mtls handshakes with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+Must be configured if TCPTransport.URL is prefixed with https://</td>
+</tr>
+    
+  
+<tr><td><code>clientCert</code><br/>
+<code>string</code>
+</td>
+<td>
+   clientCert is the file location of the client certificate to be used in mtls handshakes with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+Must be configured if TCPTransport.URL is prefixed with https://</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Transport`     {#apiserver-k8s-io-v1beta1-Transport}
+    
+
+
+
+**Appears in:**
+
+- [Connection](#apiserver-k8s-io-v1beta1-Connection)
+
+
+Transport defines the transport configurations we use to dial to the konnectivity server
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>tcp</code><br/>
+<a href="#apiserver-k8s-io-v1beta1-TCPTransport"><code>TCPTransport</code></a>
+</td>
+<td>
+   TCP is the TCP configuration for communicating with the konnectivity server via TCP
+ProxyProtocol of GRPC is not supported with TCP transport at the moment
+Requires at least one of TCP or UDS to be set</td>
+</tr>
+    
+  
+<tr><td><code>uds</code><br/>
+<a href="#apiserver-k8s-io-v1beta1-UDSTransport"><code>UDSTransport</code></a>
+</td>
+<td>
+   UDS is the UDS configuration for communicating with the konnectivity server via UDS
+Requires at least one of TCP or UDS to be set</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `UDSTransport`     {#apiserver-k8s-io-v1beta1-UDSTransport}
+    
+
+
+
+**Appears in:**
+
+- [Transport](#apiserver-k8s-io-v1beta1-Transport)
+
+
+UDSTransport provides the information to connect to konnectivity server via UDS
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>udsName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   UDSName is the name of the unix domain socket to connect to konnectivity server
+This does not use a unix:// prefix. (Eg: /etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket)</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/apiserver-encryption.v1.md
+++ b/genref/output/md/apiserver-encryption.v1.md
@@ -1,0 +1,326 @@
+---
+title: kube-apiserver Encryption Configuration (v1)
+content_type: tool-reference
+package: apiserver.config.k8s.io/v1
+auto_generated: true
+---
+Package v1 is the v1 version of the API.
+
+## Resource Types 
+
+
+- [EncryptionConfiguration](#apiserver-config-k8s-io-v1-EncryptionConfiguration)
+  
+    
+
+
+## `EncryptionConfiguration`     {#apiserver-config-k8s-io-v1-EncryptionConfiguration}
+    
+
+
+
+
+EncryptionConfiguration stores the complete configuration for encryption providers.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>EncryptionConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-ResourceConfiguration"><code>[]ResourceConfiguration</code></a>
+</td>
+<td>
+   resources is a list containing resources, and their corresponding encryption providers.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `AESConfiguration`     {#apiserver-config-k8s-io-v1-AESConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [ProviderConfiguration](#apiserver-config-k8s-io-v1-ProviderConfiguration)
+
+
+AESConfiguration contains the API configuration for an AES transformer.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>keys</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-Key"><code>[]Key</code></a>
+</td>
+<td>
+   keys is a list of keys to be used for creating the AES transformer.
+Each key has to be 32 bytes long for AES-CBC and 16, 24 or 32 bytes for AES-GCM.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `IdentityConfiguration`     {#apiserver-config-k8s-io-v1-IdentityConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [ProviderConfiguration](#apiserver-config-k8s-io-v1-ProviderConfiguration)
+
+
+IdentityConfiguration is an empty struct to allow identity transformer in provider configuration.
+
+
+    
+
+
+## `KMSConfiguration`     {#apiserver-config-k8s-io-v1-KMSConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [ProviderConfiguration](#apiserver-config-k8s-io-v1-ProviderConfiguration)
+
+
+KMSConfiguration contains the name, cache size and path to configuration file for a KMS based envelope transformer.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   name is the name of the KMS plugin to be used.</td>
+</tr>
+    
+  
+<tr><td><code>cachesize</code><br/>
+<code>int32</code>
+</td>
+<td>
+   cachesize is the maximum number of secrets which are cached in memory. The default value is 1000.
+Set to a negative value to disable caching.</td>
+</tr>
+    
+  
+<tr><td><code>endpoint</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   endpoint is the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".</td>
+</tr>
+    
+  
+<tr><td><code>timeout</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Key`     {#apiserver-config-k8s-io-v1-Key}
+    
+
+
+
+**Appears in:**
+
+- [AESConfiguration](#apiserver-config-k8s-io-v1-AESConfiguration)
+
+- [SecretboxConfiguration](#apiserver-config-k8s-io-v1-SecretboxConfiguration)
+
+
+Key contains name and secret of the provided key for a transformer.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   name is the name of the key to be used while storing data to disk.</td>
+</tr>
+    
+  
+<tr><td><code>secret</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   secret is the actual key, encoded in base64.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ProviderConfiguration`     {#apiserver-config-k8s-io-v1-ProviderConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [ResourceConfiguration](#apiserver-config-k8s-io-v1-ResourceConfiguration)
+
+
+ProviderConfiguration stores the provided configuration for an encryption provider.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>aesgcm</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-AESConfiguration"><code>AESConfiguration</code></a>
+</td>
+<td>
+   aesgcm is the configuration for the AES-GCM transformer.</td>
+</tr>
+    
+  
+<tr><td><code>aescbc</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-AESConfiguration"><code>AESConfiguration</code></a>
+</td>
+<td>
+   aescbc is the configuration for the AES-CBC transformer.</td>
+</tr>
+    
+  
+<tr><td><code>secretbox</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-SecretboxConfiguration"><code>SecretboxConfiguration</code></a>
+</td>
+<td>
+   secretbox is the configuration for the Secretbox based transformer.</td>
+</tr>
+    
+  
+<tr><td><code>identity</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-IdentityConfiguration"><code>IdentityConfiguration</code></a>
+</td>
+<td>
+   identity is the (empty) configuration for the identity transformer.</td>
+</tr>
+    
+  
+<tr><td><code>kms</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-KMSConfiguration"><code>KMSConfiguration</code></a>
+</td>
+<td>
+   kms contains the name, cache size and path to configuration file for a KMS based envelope transformer.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ResourceConfiguration`     {#apiserver-config-k8s-io-v1-ResourceConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [EncryptionConfiguration](#apiserver-config-k8s-io-v1-EncryptionConfiguration)
+
+
+ResourceConfiguration stores per resource configuration.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   resources is a list of kubernetes resources which have to be encrypted.</td>
+</tr>
+    
+  
+<tr><td><code>providers</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-ProviderConfiguration"><code>[]ProviderConfiguration</code></a>
+</td>
+<td>
+   providers is a list of transformers to be used for reading and writing the resources to disk.
+eg: aesgcm, aescbc, secretbox, identity.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `SecretboxConfiguration`     {#apiserver-config-k8s-io-v1-SecretboxConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [ProviderConfiguration](#apiserver-config-k8s-io-v1-ProviderConfiguration)
+
+
+SecretboxConfiguration contains the API configuration for an Secretbox transformer.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>keys</code> <B>[Required]</B><br/>
+<a href="#apiserver-config-k8s-io-v1-Key"><code>[]Key</code></a>
+</td>
+<td>
+   keys is a list of keys to be used for creating the Secretbox transformer.
+Each key has to be 32 bytes long.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/apiserver-resourcequota.v1.md
+++ b/genref/output/md/apiserver-resourcequota.v1.md
@@ -1,0 +1,120 @@
+---
+title: kube-apiserver ResourceQuota Configuration (v1)
+content_type: tool-reference
+package: apiserver.config.k8s.io/v1
+auto_generated: true
+---
+Package v1 is the v1 version of the API.
+
+## Resource Types 
+
+
+- [Configuration](#apiserver-config-k8s-io-v1-Configuration)
+  
+    
+
+
+## `Configuration`     {#apiserver-config-k8s-io-v1-Configuration}
+    
+
+
+
+
+Configuration provides configuration for the ResourceQuota admission controller.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Configuration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>limitedResources</code><br/>
+<a href="#apiserver-config-k8s-io-v1-LimitedResource"><code>[]LimitedResource</code></a>
+</td>
+<td>
+   LimitedResources whose consumption is limited by default.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LimitedResource`     {#apiserver-config-k8s-io-v1-LimitedResource}
+    
+
+
+
+**Appears in:**
+
+- [Configuration](#apiserver-config-k8s-io-v1-Configuration)
+
+
+LimitedResource matches a resource whose consumption is limited by default.
+To consume the resource, there must exist an associated quota that limits
+its consumption.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>apiGroup</code><br/>
+<code>string</code>
+</td>
+<td>
+   APIGroup is the name of the APIGroup that contains the limited resource.</td>
+</tr>
+    
+  
+<tr><td><code>resource</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Resource is the name of the resource this rule applies to.
+For example, if the administrator wants to limit consumption
+of a storage resource associated with persistent volume claims,
+the value would be "persistentvolumeclaims".</td>
+</tr>
+    
+  
+<tr><td><code>matchContains</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   For each intercepted request, the quota system will evaluate
+its resource usage.  It will iterate through each resource consumed
+and if the resource contains any substring in this listing, the
+quota system will ensure that there is a covering quota.  In the
+absence of a covering quota, the quota system will deny the request.
+For example, if an administrator wants to globally enforce that
+that a quota must exist to consume persistent volume claims associated
+with any storage class, the list would include
+".storageclass.storage.k8s.io/requests.storage"</td>
+</tr>
+    
+  
+<tr><td><code>matchScopes</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#scopedresourceselectorrequirement-v1-core"><code>[]core/v1.ScopedResourceSelectorRequirement</code></a>
+</td>
+<td>
+   For each intercepted request, the quota system will figure out if the input object
+satisfies a scope which is present in this listing, then
+quota system will ensure that there is a covering quota.  In the
+absence of a covering quota, the quota system will deny the request.
+For example, if an administrator wants to globally enforce that
+a quota must exist to create a pod with "cluster-services" priorityclass
+the list would include "scopeName=PriorityClass, Operator=In, Value=cluster-services"</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/apiserver-webhookadmission.v1.md
+++ b/genref/output/md/apiserver-webhookadmission.v1.md
@@ -1,0 +1,46 @@
+---
+title: WebhookAdmission Configuration (v1)
+content_type: tool-reference
+package: apiserver.config.k8s.io/v1
+auto_generated: true
+---
+Package v1 is the v1 version of the API.
+
+## Resource Types 
+
+
+- [WebhookAdmission](#apiserver-config-k8s-io-v1-WebhookAdmission)
+  
+    
+
+
+## `WebhookAdmission`     {#apiserver-config-k8s-io-v1-WebhookAdmission}
+    
+
+
+
+
+WebhookAdmission provides configuration for the webhook admission controller.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>WebhookAdmission</code></td></tr>
+    
+
+  
+  
+<tr><td><code>kubeConfigFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   KubeConfigFile is the path to the kubeconfig file.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/client-authentication.v1beta1.md
+++ b/genref/output/md/client-authentication.v1beta1.md
@@ -1,0 +1,252 @@
+---
+title: Client Authentication (v1beta1)
+content_type: tool-reference
+package: client.authentication.k8s.io/v1beta1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+  
+    
+
+
+## `ExecCredential`     {#client-authentication-k8s-io-v1beta1-ExecCredential}
+    
+
+
+
+
+ExecCredential is used by exec-based plugins to communicate credentials to
+HTTP transports.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>client.authentication.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ExecCredential</code></td></tr>
+    
+
+  
+  
+<tr><td><code>spec</code> <B>[Required]</B><br/>
+<a href="#client-authentication-k8s-io-v1beta1-ExecCredentialSpec"><code>ExecCredentialSpec</code></a>
+</td>
+<td>
+   Spec holds information passed to the plugin by the transport.</td>
+</tr>
+    
+  
+<tr><td><code>status</code><br/>
+<a href="#client-authentication-k8s-io-v1beta1-ExecCredentialStatus"><code>ExecCredentialStatus</code></a>
+</td>
+<td>
+   Status is filled in by the plugin and holds the credentials that the transport
+should use to contact the API.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Cluster`     {#client-authentication-k8s-io-v1beta1-Cluster}
+    
+
+
+
+**Appears in:**
+
+- [ExecCredentialSpec](#client-authentication-k8s-io-v1beta1-ExecCredentialSpec)
+
+
+Cluster contains information to allow an exec plugin to communicate
+with the kubernetes cluster being authenticated to.
+
+To ensure that this struct contains everything someone would need to communicate
+with a kubernetes cluster (just like they would via a kubeconfig), the fields
+should shadow "k8s.io/client-go/tools/clientcmd/api/v1".Cluster, with the exception
+of CertificateAuthority, since CA data will always be passed to the plugin as bytes.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>server</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Server is the address of the kubernetes cluster (https://hostname:port).</td>
+</tr>
+    
+  
+<tr><td><code>tls-server-name</code><br/>
+<code>string</code>
+</td>
+<td>
+   TLSServerName is passed to the server for SNI and is used in the client to
+check server certificates against. If ServerName is empty, the hostname
+used to contact the server is used.</td>
+</tr>
+    
+  
+<tr><td><code>insecure-skip-tls-verify</code><br/>
+<code>bool</code>
+</td>
+<td>
+   InsecureSkipTLSVerify skips the validity check for the server's certificate.
+This will make your HTTPS connections insecure.</td>
+</tr>
+    
+  
+<tr><td><code>certificate-authority-data</code><br/>
+<code>[]byte</code>
+</td>
+<td>
+   CAData contains PEM-encoded certificate authority certificates.
+If empty, system roots should be used.</td>
+</tr>
+    
+  
+<tr><td><code>proxy-url</code><br/>
+<code>string</code>
+</td>
+<td>
+   ProxyURL is the URL to the proxy to be used for all requests to this
+cluster.</td>
+</tr>
+    
+  
+<tr><td><code>config</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+</td>
+<td>
+   Config holds additional config data that is specific to the exec
+plugin with regards to the cluster being authenticated to.
+
+This data is sourced from the clientcmd Cluster object's
+extensions[client.authentication.k8s.io/exec] field:
+
+clusters:
+- name: my-cluster
+  cluster:
+    ...
+    extensions:
+    - name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config
+      extension:
+        audience: 06e3fbd18de8  # arbitrary config
+
+In some environments, the user config may be exactly the same across many clusters
+(i.e. call this exec plugin) minus some details that are specific to each cluster
+such as the audience.  This field allows the per cluster config to be directly
+specified with the cluster info.  Using this field to store secret data is not
+recommended as one of the prime benefits of exec plugins is that no secrets need
+to be stored directly in the kubeconfig.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExecCredentialSpec`     {#client-authentication-k8s-io-v1beta1-ExecCredentialSpec}
+    
+
+
+
+**Appears in:**
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+
+
+ExecCredentialSpec holds request and runtime specific information provided by
+the transport.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>cluster</code><br/>
+<a href="#client-authentication-k8s-io-v1beta1-Cluster"><code>Cluster</code></a>
+</td>
+<td>
+   Cluster contains information to allow an exec plugin to communicate with the
+kubernetes cluster being authenticated to. Note that Cluster is non-nil only
+when provideClusterInfo is set to true in the exec provider config (i.e.,
+ExecConfig.ProvideClusterInfo).</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExecCredentialStatus`     {#client-authentication-k8s-io-v1beta1-ExecCredentialStatus}
+    
+
+
+
+**Appears in:**
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+
+
+ExecCredentialStatus holds credentials for the transport to use.
+
+Token and ClientKeyData are sensitive fields. This data should only be
+transmitted in-memory between client and exec plugin process. Exec plugin
+itself should at least be protected via file permissions.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>expirationTimestamp</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   ExpirationTimestamp indicates a time when the provided credentials expire.</td>
+</tr>
+    
+  
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Token is a bearer token used by the client for request authentication.</td>
+</tr>
+    
+  
+<tr><td><code>clientCertificateData</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   PEM-encoded client TLS certificates (including intermediates, if any).</td>
+</tr>
+    
+  
+<tr><td><code>clientKeyData</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   PEM-encoded private key for the above certificate.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/cloud-provider-config.v1alpha1.md
+++ b/genref/output/md/cloud-provider-config.v1alpha1.md
@@ -1,0 +1,459 @@
+---
+title: Cloud Provider Configuration (v1alpha1)
+content_type: tool-reference
+package: cloudcontrollermanager.config.k8s.io/v1alpha1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+  
+    
+
+
+## `CloudControllerManagerConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration}
+    
+
+
+
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>cloudcontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>CloudControllerManagerConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>Generic</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
+</td>
+<td>
+   Generic holds configuration for a generic controller-manager</td>
+</tr>
+    
+  
+<tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
+</td>
+<td>
+   KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.</td>
+</tr>
+    
+  
+<tr><td><code>ServiceController</code> <B>[Required]</B><br/>
+<a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
+</td>
+<td>
+   ServiceControllerConfiguration holds configuration for ServiceController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>NodeStatusUpdateFrequency</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `CloudProviderConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeCloudSharedConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration)
+
+
+CloudProviderConfiguration contains basically elements about cloud provider.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>Name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name is the provider for cloud services.</td>
+</tr>
+    
+  
+<tr><td><code>CloudConfigFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   cloudConfigFile is the path to the cloud provider configuration file.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeCloudSharedConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
+and cloud-controller manager, but not genericconfig.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>CloudProvider</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration"><code>CloudProviderConfiguration</code></a>
+</td>
+<td>
+   CloudProviderConfiguration holds configuration for CloudProvider related features.</td>
+</tr>
+    
+  
+<tr><td><code>ExternalCloudVolumePlugin</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   externalCloudVolumePlugin specifies the plugin to use when cloudProvider is "external".
+It is currently used by the in repo cloud providers to handle node and volume control in the KCM.</td>
+</tr>
+    
+  
+<tr><td><code>UseServiceAccountCredentials</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   useServiceAccountCredentials indicates whether controllers should be run with
+individual service account credentials.</td>
+</tr>
+    
+  
+<tr><td><code>AllowUntaggedCloud</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   run with untagged cloud instances</td>
+</tr>
+    
+  
+<tr><td><code>RouteReconciliationPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</td>
+</tr>
+    
+  
+<tr><td><code>NodeMonitorPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</td>
+</tr>
+    
+  
+<tr><td><code>ClusterName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   clusterName is the instance prefix for the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>ClusterCIDR</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   clusterCIDR is CIDR Range for Pods in cluster.</td>
+</tr>
+    
+  
+<tr><td><code>AllocateNodeCIDRs</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+ConfigureCloudRoutes is true, to be set on the cloud provider.</td>
+</tr>
+    
+  
+<tr><td><code>CIDRAllocatorType</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   CIDRAllocatorType determines what kind of pod CIDR allocator will be used.</td>
+</tr>
+    
+  
+<tr><td><code>ConfigureCloudRoutes</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
+to be configured on the cloud provider.</td>
+</tr>
+    
+  
+<tr><td><code>NodeSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
+periods will result in fewer calls to cloud provider, but may delay addition
+of new nodes to cluster.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  
+  
+    
+
+
+## `ControllerLeaderConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [LeaderMigrationConfiguration](#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration)
+
+
+ControllerLeaderConfiguration provides the configuration for a migrating leader lock.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name is the name of the controller being migrated
+E.g. service-controller, route-controller, cloud-node-controller, etc</td>
+</tr>
+    
+  
+<tr><td><code>component</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Component is the name of the component in which the controller should be running.
+E.g. kube-controller-manager, cloud-controller-manager, etc</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `GenericControllerManagerConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+GenericControllerManagerConfiguration holds configuration for a generic controller-manager.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>Port</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   port is the port that the controller-manager's http service runs on.</td>
+</tr>
+    
+  
+<tr><td><code>Address</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   address is the IP address to serve on (set to 0.0.0.0 for all interfaces).</td>
+</tr>
+    
+  
+<tr><td><code>MinResyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   minResyncPeriod is the resync period in reflectors; will be random between
+minResyncPeriod and 2&lowast;minResyncPeriod.</td>
+</tr>
+    
+  
+<tr><td><code>ClientConnection</code> <B>[Required]</B><br/>
+<a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
+</td>
+<td>
+   ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.</td>
+</tr>
+    
+  
+<tr><td><code>ControllerStartInterval</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   How long to wait between starting controller managers</td>
+</tr>
+    
+  
+<tr><td><code>LeaderElection</code> <B>[Required]</B><br/>
+<a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
+</td>
+<td>
+   leaderElection defines the configuration of leader election client.</td>
+</tr>
+    
+  
+<tr><td><code>Controllers</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   Controllers is the list of controllers to enable or disable
+'&lowast;' means "all enabled by default controllers"
+'foo' means "enable 'foo'"
+'-foo' means "disable 'foo'"
+first item for a particular name wins</td>
+</tr>
+    
+  
+<tr><td><code>Debugging</code> <B>[Required]</B><br/>
+<a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
+</td>
+<td>
+   DebuggingConfiguration holds configuration for Debugging related features.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LeaderMigrationConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration}
+    
+
+
+
+
+LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+  
+<tr><td><code>leaderName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   LeaderName is the name of the leader election resource that protects the migration
+E.g. 1-20-KCM-to-1-21-CCM</td>
+</tr>
+    
+  
+<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   ResourceLock indicates the resource object type that will be used to lock
+Should be "leases" or "endpoints"</td>
+</tr>
+    
+  
+<tr><td><code>controllerLeaders</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration"><code>[]ControllerLeaderConfiguration</code></a>
+</td>
+<td>
+   ControllerLeaders contains a list of migrating leader lock configurations</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  
+  
+    
+
+## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+ServiceControllerConfiguration contains elements describing ServiceController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>

--- a/genref/output/md/cloud-provider-service.v1alpha1.md
+++ b/genref/output/md/cloud-provider-service.v1alpha1.md
@@ -1,0 +1,40 @@
+
+
+## Resource Types 
+
+
+  
+    
+
+## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+ServiceControllerConfiguration contains elements describing ServiceController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>

--- a/genref/output/md/kube-controller-manager-config.v1alpha1.md
+++ b/genref/output/md/kube-controller-manager-config.v1alpha1.md
@@ -1,0 +1,2075 @@
+---
+title: kube-controller-manager Configuration (v1alpha1)
+content_type: tool-reference
+package: kubecontrollermanager.config.k8s.io/v1alpha1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+  
+    
+
+
+## `KubeControllerManagerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration}
+    
+
+
+
+
+KubeControllerManagerConfiguration contains elements describing kube-controller manager.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubecontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>KubeControllerManagerConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>Generic</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
+</td>
+<td>
+   Generic holds configuration for a generic controller-manager</td>
+</tr>
+    
+  
+<tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
+</td>
+<td>
+   KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.</td>
+</tr>
+    
+  
+<tr><td><code>AttachDetachController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-AttachDetachControllerConfiguration"><code>AttachDetachControllerConfiguration</code></a>
+</td>
+<td>
+   AttachDetachControllerConfiguration holds configuration for
+AttachDetachController related features.</td>
+</tr>
+    
+  
+<tr><td><code>CSRSigningController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration"><code>CSRSigningControllerConfiguration</code></a>
+</td>
+<td>
+   CSRSigningControllerConfiguration holds configuration for
+CSRSigningController related features.</td>
+</tr>
+    
+  
+<tr><td><code>DaemonSetController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DaemonSetControllerConfiguration"><code>DaemonSetControllerConfiguration</code></a>
+</td>
+<td>
+   DaemonSetControllerConfiguration holds configuration for DaemonSetController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>DeploymentController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DeploymentControllerConfiguration"><code>DeploymentControllerConfiguration</code></a>
+</td>
+<td>
+   DeploymentControllerConfiguration holds configuration for
+DeploymentController related features.</td>
+</tr>
+    
+  
+<tr><td><code>StatefulSetController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-StatefulSetControllerConfiguration"><code>StatefulSetControllerConfiguration</code></a>
+</td>
+<td>
+   StatefulSetControllerConfiguration holds configuration for
+StatefulSetController related features.</td>
+</tr>
+    
+  
+<tr><td><code>DeprecatedController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DeprecatedControllerConfiguration"><code>DeprecatedControllerConfiguration</code></a>
+</td>
+<td>
+   DeprecatedControllerConfiguration holds configuration for some deprecated
+features.</td>
+</tr>
+    
+  
+<tr><td><code>EndpointController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointControllerConfiguration"><code>EndpointControllerConfiguration</code></a>
+</td>
+<td>
+   EndpointControllerConfiguration holds configuration for EndpointController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>EndpointSliceController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceControllerConfiguration"><code>EndpointSliceControllerConfiguration</code></a>
+</td>
+<td>
+   EndpointSliceControllerConfiguration holds configuration for
+EndpointSliceController related features.</td>
+</tr>
+    
+  
+<tr><td><code>EndpointSliceMirroringController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceMirroringControllerConfiguration"><code>EndpointSliceMirroringControllerConfiguration</code></a>
+</td>
+<td>
+   EndpointSliceMirroringControllerConfiguration holds configuration for
+EndpointSliceMirroringController related features.</td>
+</tr>
+    
+  
+<tr><td><code>GarbageCollectorController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration"><code>GarbageCollectorControllerConfiguration</code></a>
+</td>
+<td>
+   GarbageCollectorControllerConfiguration holds configuration for
+GarbageCollectorController related features.</td>
+</tr>
+    
+  
+<tr><td><code>HPAController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-HPAControllerConfiguration"><code>HPAControllerConfiguration</code></a>
+</td>
+<td>
+   HPAControllerConfiguration holds configuration for HPAController related features.</td>
+</tr>
+    
+  
+<tr><td><code>JobController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-JobControllerConfiguration"><code>JobControllerConfiguration</code></a>
+</td>
+<td>
+   JobControllerConfiguration holds configuration for JobController related features.</td>
+</tr>
+    
+  
+<tr><td><code>CronJobController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CronJobControllerConfiguration"><code>CronJobControllerConfiguration</code></a>
+</td>
+<td>
+   CronJobControllerConfiguration holds configuration for CronJobController related features.</td>
+</tr>
+    
+  
+<tr><td><code>NamespaceController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NamespaceControllerConfiguration"><code>NamespaceControllerConfiguration</code></a>
+</td>
+<td>
+   NamespaceControllerConfiguration holds configuration for NamespaceController
+related features.
+NamespaceControllerConfiguration holds configuration for NamespaceController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>NodeIPAMController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NodeIPAMControllerConfiguration"><code>NodeIPAMControllerConfiguration</code></a>
+</td>
+<td>
+   NodeIPAMControllerConfiguration holds configuration for NodeIPAMController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>NodeLifecycleController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NodeLifecycleControllerConfiguration"><code>NodeLifecycleControllerConfiguration</code></a>
+</td>
+<td>
+   NodeLifecycleControllerConfiguration holds configuration for
+NodeLifecycleController related features.</td>
+</tr>
+    
+  
+<tr><td><code>PersistentVolumeBinderController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration"><code>PersistentVolumeBinderControllerConfiguration</code></a>
+</td>
+<td>
+   PersistentVolumeBinderControllerConfiguration holds configuration for
+PersistentVolumeBinderController related features.</td>
+</tr>
+    
+  
+<tr><td><code>PodGCController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PodGCControllerConfiguration"><code>PodGCControllerConfiguration</code></a>
+</td>
+<td>
+   PodGCControllerConfiguration holds configuration for PodGCController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>ReplicaSetController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicaSetControllerConfiguration"><code>ReplicaSetControllerConfiguration</code></a>
+</td>
+<td>
+   ReplicaSetControllerConfiguration holds configuration for ReplicaSet related features.</td>
+</tr>
+    
+  
+<tr><td><code>ReplicationController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicationControllerConfiguration"><code>ReplicationControllerConfiguration</code></a>
+</td>
+<td>
+   ReplicationControllerConfiguration holds configuration for
+ReplicationController related features.</td>
+</tr>
+    
+  
+<tr><td><code>ResourceQuotaController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceQuotaControllerConfiguration"><code>ResourceQuotaControllerConfiguration</code></a>
+</td>
+<td>
+   ResourceQuotaControllerConfiguration holds configuration for
+ResourceQuotaController related features.</td>
+</tr>
+    
+  
+<tr><td><code>SAController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-SAControllerConfiguration"><code>SAControllerConfiguration</code></a>
+</td>
+<td>
+   SAControllerConfiguration holds configuration for ServiceAccountController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>ServiceController</code> <B>[Required]</B><br/>
+<a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
+</td>
+<td>
+   ServiceControllerConfiguration holds configuration for ServiceController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>TTLAfterFinishedController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-TTLAfterFinishedControllerConfiguration"><code>TTLAfterFinishedControllerConfiguration</code></a>
+</td>
+<td>
+   TTLAfterFinishedControllerConfiguration holds configuration for
+TTLAfterFinishedController related features.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `AttachDetachControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-AttachDetachControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+AttachDetachControllerConfiguration contains elements describing AttachDetachController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>DisableAttachDetachReconcilerSync</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   Reconciler runs a periodic loop to reconcile the desired state of the with
+the actual state of the world by triggering attach detach operations.
+This flag enables or disables reconcile.  Is false by default, and thus enabled.</td>
+</tr>
+    
+  
+<tr><td><code>ReconcilerSyncLoopPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
+wait between successive executions. Is set to 5 sec by default.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `CSRSigningConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [CSRSigningControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration)
+
+
+CSRSigningConfiguration holds information about a particular CSR signer
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>CertFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   certFile is the filename containing a PEM-encoded
+X509 CA certificate used to issue certificates</td>
+</tr>
+    
+  
+<tr><td><code>KeyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   keyFile is the filename containing a PEM-encoded
+RSA or ECDSA private key used to issue certificates</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `CSRSigningControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+CSRSigningControllerConfiguration contains elements describing CSRSigningController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ClusterSigningCertFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   clusterSigningCertFile is the filename containing a PEM-encoded
+X509 CA certificate used to issue cluster-scoped certificates</td>
+</tr>
+    
+  
+<tr><td><code>ClusterSigningKeyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   clusterSigningCertFile is the filename containing a PEM-encoded
+RSA or ECDSA private key used to issue cluster-scoped certificates</td>
+</tr>
+    
+  
+<tr><td><code>KubeletServingSignerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
+</td>
+<td>
+   kubeletServingSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kubelet-serving signer</td>
+</tr>
+    
+  
+<tr><td><code>KubeletClientSignerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
+</td>
+<td>
+   kubeletClientSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kube-apiserver-client-kubelet</td>
+</tr>
+    
+  
+<tr><td><code>KubeAPIServerClientSignerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
+</td>
+<td>
+   kubeAPIServerClientSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kube-apiserver-client</td>
+</tr>
+    
+  
+<tr><td><code>LegacyUnknownSignerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
+</td>
+<td>
+   legacyUnknownSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/legacy-unknown</td>
+</tr>
+    
+  
+<tr><td><code>ClusterSigningDuration</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   clusterSigningDuration is the length of duration signed certificates
+will be given.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `CronJobControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CronJobControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+CronJobControllerConfiguration contains elements describing CrongJob2Controller.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentCronJobSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentCronJobSyncs is the number of job objects that are
+allowed to sync concurrently. Larger number = more responsive jobs,
+but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `DaemonSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DaemonSetControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+DaemonSetControllerConfiguration contains elements describing DaemonSetController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentDaemonSetSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentDaemonSetSyncs is the number of daemonset objects that are
+allowed to sync concurrently. Larger number = more responsive daemonset,
+but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `DeploymentControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DeploymentControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+DeploymentControllerConfiguration contains elements describing DeploymentController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentDeploymentSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentDeploymentSyncs is the number of deployment objects that are
+allowed to sync concurrently. Larger number = more responsive deployments,
+but more CPU (and network) load.</td>
+</tr>
+    
+  
+<tr><td><code>DeploymentControllerSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   deploymentControllerSyncPeriod is the period for syncing the deployments.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `DeprecatedControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DeprecatedControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+DeprecatedControllerConfiguration contains elements be deprecated.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>DeletingPodsQPS</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   DEPRECATED: deletingPodsQps is the number of nodes per second on which pods are deleted in
+case of node failure.</td>
+</tr>
+    
+  
+<tr><td><code>DeletingPodsBurst</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   DEPRECATED: deletingPodsBurst is the number of nodes on which pods are bursty deleted in
+case of node failure. For more details look into RateLimiter.</td>
+</tr>
+    
+  
+<tr><td><code>RegisterRetryCount</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   registerRetryCount is the number of retries for initial node registration.
+Retry interval equals node-sync-period.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `EndpointControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+EndpointControllerConfiguration contains elements describing EndpointController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentEndpointSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentEndpointSyncs is the number of endpoint syncing operations
+that will be done concurrently. Larger number = faster endpoint updating,
+but more CPU (and network) load.</td>
+</tr>
+    
+  
+<tr><td><code>EndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   EndpointUpdatesBatchPeriod describes the length of endpoint updates batching period.
+Processing of pod changes will be delayed by this duration to join them with potential
+upcoming updates and reduce the overall number of endpoints updates.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `EndpointSliceControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+EndpointSliceControllerConfiguration contains elements describing
+EndpointSliceController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentServiceEndpointSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentServiceEndpointSyncs is the number of service endpoint syncing
+operations that will be done concurrently. Larger number = faster
+endpoint slice updating, but more CPU (and network) load.</td>
+</tr>
+    
+  
+<tr><td><code>MaxEndpointsPerSlice</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   maxEndpointsPerSlice is the maximum number of endpoints that will be
+added to an EndpointSlice. More endpoints per slice will result in fewer
+and larger endpoint slices, but larger resources.</td>
+</tr>
+    
+  
+<tr><td><code>EndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   EndpointUpdatesBatchPeriod describes the length of endpoint updates batching period.
+Processing of pod changes will be delayed by this duration to join them with potential
+upcoming updates and reduce the overall number of endpoints updates.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `EndpointSliceMirroringControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceMirroringControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+EndpointSliceMirroringControllerConfiguration contains elements describing
+EndpointSliceMirroringController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>MirroringConcurrentServiceEndpointSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   mirroringConcurrentServiceEndpointSyncs is the number of service endpoint
+syncing operations that will be done concurrently. Larger number = faster
+endpoint slice updating, but more CPU (and network) load.</td>
+</tr>
+    
+  
+<tr><td><code>MirroringMaxEndpointsPerSubset</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   mirroringMaxEndpointsPerSubset is the maximum number of endpoints that
+will be mirrored to an EndpointSlice for an EndpointSubset.</td>
+</tr>
+    
+  
+<tr><td><code>MirroringEndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   mirroringEndpointUpdatesBatchPeriod can be used to batch EndpointSlice
+updates. All updates triggered by EndpointSlice changes will be delayed
+by up to 'mirroringEndpointUpdatesBatchPeriod'. If other addresses in the
+same Endpoints resource change in that period, they will be batched to a
+single EndpointSlice update. Default 0 value means that each Endpoints
+update triggers an EndpointSlice update.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `GarbageCollectorControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+GarbageCollectorControllerConfiguration contains elements describing GarbageCollectorController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>EnableGarbageCollector</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   enables the generic garbage collector. MUST be synced with the
+corresponding flag of the kube-apiserver. WARNING: the generic garbage
+collector is an alpha feature.</td>
+</tr>
+    
+  
+<tr><td><code>ConcurrentGCSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentGCSyncs is the number of garbage collector workers that are
+allowed to sync concurrently.</td>
+</tr>
+    
+  
+<tr><td><code>GCIgnoredResources</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GroupResource"><code>[]GroupResource</code></a>
+</td>
+<td>
+   gcIgnoredResources is the list of GroupResources that garbage collection should ignore.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `GroupResource`     {#kubecontrollermanager-config-k8s-io-v1alpha1-GroupResource}
+    
+
+
+
+**Appears in:**
+
+- [GarbageCollectorControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration)
+
+
+GroupResource describes an group resource.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>Group</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   group is the group portion of the GroupResource.</td>
+</tr>
+    
+  
+<tr><td><code>Resource</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   resource is the resource portion of the GroupResource.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `HPAControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-HPAControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+HPAControllerConfiguration contains elements describing HPAController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>HorizontalPodAutoscalerSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   HorizontalPodAutoscalerSyncPeriod is the period for syncing the number of
+pods in horizontal pod autoscaler.</td>
+</tr>
+    
+  
+<tr><td><code>HorizontalPodAutoscalerUpscaleForbiddenWindow</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   HorizontalPodAutoscalerUpscaleForbiddenWindow is a period after which next upscale allowed.</td>
+</tr>
+    
+  
+<tr><td><code>HorizontalPodAutoscalerDownscaleStabilizationWindow</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   HorizontalPodAutoscalerDowncaleStabilizationWindow is a period for which autoscaler will look
+backwards and not scale down below any recommendation it made during that period.</td>
+</tr>
+    
+  
+<tr><td><code>HorizontalPodAutoscalerDownscaleForbiddenWindow</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   HorizontalPodAutoscalerDownscaleForbiddenWindow is a period after which next downscale allowed.</td>
+</tr>
+    
+  
+<tr><td><code>HorizontalPodAutoscalerTolerance</code> <B>[Required]</B><br/>
+<code>float64</code>
+</td>
+<td>
+   HorizontalPodAutoscalerTolerance is the tolerance for when
+resource usage suggests upscaling/downscaling</td>
+</tr>
+    
+  
+<tr><td><code>HorizontalPodAutoscalerUseRESTClients</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   HorizontalPodAutoscalerUseRESTClients causes the HPA controller to use REST clients
+through the kube-aggregator when enabled, instead of using the legacy metrics client
+through the API server proxy.</td>
+</tr>
+    
+  
+<tr><td><code>HorizontalPodAutoscalerCPUInitializationPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   HorizontalPodAutoscalerCPUInitializationPeriod is the period after pod start when CPU samples
+might be skipped.</td>
+</tr>
+    
+  
+<tr><td><code>HorizontalPodAutoscalerInitialReadinessDelay</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   HorizontalPodAutoscalerInitialReadinessDelay is period after pod start during which readiness
+changes are treated as readiness being set for the first time. The only effect of this is that
+HPA will disregard CPU samples from unready pods that had last readiness change during that
+period.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `JobControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-JobControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+JobControllerConfiguration contains elements describing JobController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentJobSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentJobSyncs is the number of job objects that are
+allowed to sync concurrently. Larger number = more responsive jobs,
+but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NamespaceControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NamespaceControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+NamespaceControllerConfiguration contains elements describing NamespaceController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>NamespaceSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   namespaceSyncPeriod is the period for syncing namespace life-cycle
+updates.</td>
+</tr>
+    
+  
+<tr><td><code>ConcurrentNamespaceSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentNamespaceSyncs is the number of namespace objects that are
+allowed to sync concurrently.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeIPAMControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NodeIPAMControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+NodeIPAMControllerConfiguration contains elements describing NodeIpamController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ServiceCIDR</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   serviceCIDR is CIDR Range for Services in cluster.</td>
+</tr>
+    
+  
+<tr><td><code>SecondaryServiceCIDR</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   secondaryServiceCIDR is CIDR Range for Services in cluster. This is used in dual stack clusters. SecondaryServiceCIDR must be of different IP family than ServiceCIDR</td>
+</tr>
+    
+  
+<tr><td><code>NodeCIDRMaskSize</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   NodeCIDRMaskSize is the mask size for node cidr in cluster.</td>
+</tr>
+    
+  
+<tr><td><code>NodeCIDRMaskSizeIPv4</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   NodeCIDRMaskSizeIPv4 is the mask size for node cidr in dual-stack cluster.</td>
+</tr>
+    
+  
+<tr><td><code>NodeCIDRMaskSizeIPv6</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   NodeCIDRMaskSizeIPv6 is the mask size for node cidr in dual-stack cluster.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeLifecycleControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NodeLifecycleControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+NodeLifecycleControllerConfiguration contains elements describing NodeLifecycleController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>EnableTaintManager</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   If set to true enables NoExecute Taints and will evict all not-tolerating
+Pod running on Nodes tainted with this kind of Taints.</td>
+</tr>
+    
+  
+<tr><td><code>NodeEvictionRate</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   nodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is healthy</td>
+</tr>
+    
+  
+<tr><td><code>SecondaryNodeEvictionRate</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   secondaryNodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is unhealthy</td>
+</tr>
+    
+  
+<tr><td><code>NodeStartupGracePeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   nodeStartupGracePeriod is the amount of time which we allow starting a node to
+be unresponsive before marking it unhealthy.</td>
+</tr>
+    
+  
+<tr><td><code>NodeMonitorGracePeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   nodeMontiorGracePeriod is the amount of time which we allow a running node to be
+unresponsive before marking it unhealthy. Must be N times more than kubelet's
+nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet
+to post node status.</td>
+</tr>
+    
+  
+<tr><td><code>PodEvictionTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   podEvictionTimeout is the grace period for deleting pods on failed nodes.</td>
+</tr>
+    
+  
+<tr><td><code>LargeClusterSizeThreshold</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   secondaryNodeEvictionRate is implicitly overridden to 0 for clusters smaller than or equal to largeClusterSizeThreshold</td>
+</tr>
+    
+  
+<tr><td><code>UnhealthyZoneThreshold</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   Zone is treated as unhealthy in nodeEvictionRate and secondaryNodeEvictionRate when at least
+unhealthyZoneThreshold (no less than 3) of Nodes in the zone are NotReady</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PersistentVolumeBinderControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+PersistentVolumeBinderControllerConfiguration contains elements describing
+PersistentVolumeBinderController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>PVClaimBinderSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   pvClaimBinderSyncPeriod is the period for syncing persistent volumes
+and persistent volume claims.</td>
+</tr>
+    
+  
+<tr><td><code>VolumeConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration"><code>VolumeConfiguration</code></a>
+</td>
+<td>
+   volumeConfiguration holds configuration for volume related features.</td>
+</tr>
+    
+  
+<tr><td><code>VolumeHostCIDRDenylist</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   VolumeHostCIDRDenylist is a list of CIDRs that should not be reachable by the
+controller from plugins.</td>
+</tr>
+    
+  
+<tr><td><code>VolumeHostAllowLocalLoopback</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   VolumeHostAllowLocalLoopback indicates if local loopback hosts (127.0.0.1, etc)
+should be allowed from plugins.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PersistentVolumeRecyclerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeRecyclerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [VolumeConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration)
+
+
+PersistentVolumeRecyclerConfiguration contains elements describing persistent volume plugins.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>MaximumRetry</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   maximumRetry is number of retries the PV recycler will execute on failure to recycle
+PV.</td>
+</tr>
+    
+  
+<tr><td><code>MinimumTimeoutNFS</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   minimumTimeoutNFS is the minimum ActiveDeadlineSeconds to use for an NFS Recycler
+pod.</td>
+</tr>
+    
+  
+<tr><td><code>PodTemplateFilePathNFS</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   podTemplateFilePathNFS is the file path to a pod definition used as a template for
+NFS persistent volume recycling</td>
+</tr>
+    
+  
+<tr><td><code>IncrementTimeoutNFS</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   incrementTimeoutNFS is the increment of time added per Gi to ActiveDeadlineSeconds
+for an NFS scrubber pod.</td>
+</tr>
+    
+  
+<tr><td><code>PodTemplateFilePathHostPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   podTemplateFilePathHostPath is the file path to a pod definition used as a template for
+HostPath persistent volume recycling. This is for development and testing only and
+will not work in a multi-node cluster.</td>
+</tr>
+    
+  
+<tr><td><code>MinimumTimeoutHostPath</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   minimumTimeoutHostPath is the minimum ActiveDeadlineSeconds to use for a HostPath
+Recycler pod.  This is for development and testing only and will not work in a multi-node
+cluster.</td>
+</tr>
+    
+  
+<tr><td><code>IncrementTimeoutHostPath</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   incrementTimeoutHostPath is the increment of time added per Gi to ActiveDeadlineSeconds
+for a HostPath scrubber pod.  This is for development and testing only and will not work
+in a multi-node cluster.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PodGCControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PodGCControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+PodGCControllerConfiguration contains elements describing PodGCController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>TerminatedPodGCThreshold</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   terminatedPodGCThreshold is the number of terminated pods that can exist
+before the terminated pod garbage collector starts deleting terminated pods.
+If <= 0, the terminated pod garbage collector is disabled.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ReplicaSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicaSetControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+ReplicaSetControllerConfiguration contains elements describing ReplicaSetController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentRSSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentRSSyncs is the number of replica sets that are  allowed to sync
+concurrently. Larger number = more responsive replica  management, but more
+CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ReplicationControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicationControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+ReplicationControllerConfiguration contains elements describing ReplicationController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentRCSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentRCSyncs is the number of replication controllers that are
+allowed to sync concurrently. Larger number = more responsive replica
+management, but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ResourceQuotaControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceQuotaControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+ResourceQuotaControllerConfiguration contains elements describing ResourceQuotaController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ResourceQuotaSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   resourceQuotaSyncPeriod is the period for syncing quota usage status
+in the system.</td>
+</tr>
+    
+  
+<tr><td><code>ConcurrentResourceQuotaSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentResourceQuotaSyncs is the number of resource quotas that are
+allowed to sync concurrently. Larger number = more responsive quota
+management, but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `SAControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-SAControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+SAControllerConfiguration contains elements describing ServiceAccountController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ServiceAccountKeyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
+used to sign service account tokens.</td>
+</tr>
+    
+  
+<tr><td><code>ConcurrentSATokenSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentSATokenSyncs is the number of service account token syncing operations
+that will be done concurrently.</td>
+</tr>
+    
+  
+<tr><td><code>RootCAFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   rootCAFile is the root certificate authority will be included in service
+account's token secret. This must be a valid PEM-encoded CA bundle.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `StatefulSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-StatefulSetControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+StatefulSetControllerConfiguration contains elements describing StatefulSetController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentStatefulSetSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentStatefulSetSyncs is the number of statefulset objects that are
+allowed to sync concurrently. Larger number = more responsive statefulsets,
+but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `TTLAfterFinishedControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-TTLAfterFinishedControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+TTLAfterFinishedControllerConfiguration contains elements describing TTLAfterFinishedController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentTTLSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentTTLSyncs is the number of TTL-after-finished collector workers that are
+allowed to sync concurrently.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `VolumeConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [PersistentVolumeBinderControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration)
+
+
+VolumeConfiguration contains &lowast;all&lowast; enumerated flags meant to configure all volume
+plugins. From this config, the controller-manager binary will create many instances of
+volume.VolumeConfig, each containing only the configuration needed for that plugin which
+are then passed to the appropriate plugin. The ControllerManager binary is the only part
+of the code which knows what plugins are supported and which flags correspond to each plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>EnableHostPathProvisioning</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   enableHostPathProvisioning enables HostPath PV provisioning when running without a
+cloud provider. This allows testing and development of provisioning features. HostPath
+provisioning is not supported in any way, won't work in a multi-node cluster, and
+should not be used for anything other than testing or development.</td>
+</tr>
+    
+  
+<tr><td><code>EnableDynamicProvisioning</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   enableDynamicProvisioning enables the provisioning of volumes when running within an environment
+that supports dynamic provisioning. Defaults to true.</td>
+</tr>
+    
+  
+<tr><td><code>PersistentVolumeRecyclerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeRecyclerConfiguration"><code>PersistentVolumeRecyclerConfiguration</code></a>
+</td>
+<td>
+   persistentVolumeRecyclerConfiguration holds configuration for persistent volume plugins.</td>
+</tr>
+    
+  
+<tr><td><code>FlexVolumePluginDir</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   volumePluginDir is the full path of the directory in which the flex
+volume plugin should search for additional third party volume plugins</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  
+  
+    
+
+## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+ServiceControllerConfiguration contains elements describing ServiceController.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+  
+    
+
+
+## `CloudControllerManagerConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration}
+    
+
+
+
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>cloudcontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>CloudControllerManagerConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>Generic</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
+</td>
+<td>
+   Generic holds configuration for a generic controller-manager</td>
+</tr>
+    
+  
+<tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
+</td>
+<td>
+   KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.</td>
+</tr>
+    
+  
+<tr><td><code>ServiceController</code> <B>[Required]</B><br/>
+<a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
+</td>
+<td>
+   ServiceControllerConfiguration holds configuration for ServiceController
+related features.</td>
+</tr>
+    
+  
+<tr><td><code>NodeStatusUpdateFrequency</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `CloudProviderConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeCloudSharedConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration)
+
+
+CloudProviderConfiguration contains basically elements about cloud provider.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>Name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name is the provider for cloud services.</td>
+</tr>
+    
+  
+<tr><td><code>CloudConfigFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   cloudConfigFile is the path to the cloud provider configuration file.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeCloudSharedConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
+and cloud-controller manager, but not genericconfig.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>CloudProvider</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration"><code>CloudProviderConfiguration</code></a>
+</td>
+<td>
+   CloudProviderConfiguration holds configuration for CloudProvider related features.</td>
+</tr>
+    
+  
+<tr><td><code>ExternalCloudVolumePlugin</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   externalCloudVolumePlugin specifies the plugin to use when cloudProvider is "external".
+It is currently used by the in repo cloud providers to handle node and volume control in the KCM.</td>
+</tr>
+    
+  
+<tr><td><code>UseServiceAccountCredentials</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   useServiceAccountCredentials indicates whether controllers should be run with
+individual service account credentials.</td>
+</tr>
+    
+  
+<tr><td><code>AllowUntaggedCloud</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   run with untagged cloud instances</td>
+</tr>
+    
+  
+<tr><td><code>RouteReconciliationPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</td>
+</tr>
+    
+  
+<tr><td><code>NodeMonitorPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</td>
+</tr>
+    
+  
+<tr><td><code>ClusterName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   clusterName is the instance prefix for the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>ClusterCIDR</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   clusterCIDR is CIDR Range for Pods in cluster.</td>
+</tr>
+    
+  
+<tr><td><code>AllocateNodeCIDRs</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+ConfigureCloudRoutes is true, to be set on the cloud provider.</td>
+</tr>
+    
+  
+<tr><td><code>CIDRAllocatorType</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   CIDRAllocatorType determines what kind of pod CIDR allocator will be used.</td>
+</tr>
+    
+  
+<tr><td><code>ConfigureCloudRoutes</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
+to be configured on the cloud provider.</td>
+</tr>
+    
+  
+<tr><td><code>NodeSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
+periods will result in fewer calls to cloud provider, but may delay addition
+of new nodes to cluster.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  
+  
+    
+
+
+## `ControllerLeaderConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [LeaderMigrationConfiguration](#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration)
+
+
+ControllerLeaderConfiguration provides the configuration for a migrating leader lock.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name is the name of the controller being migrated
+E.g. service-controller, route-controller, cloud-node-controller, etc</td>
+</tr>
+    
+  
+<tr><td><code>component</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Component is the name of the component in which the controller should be running.
+E.g. kube-controller-manager, cloud-controller-manager, etc</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `GenericControllerManagerConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+GenericControllerManagerConfiguration holds configuration for a generic controller-manager.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>Port</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   port is the port that the controller-manager's http service runs on.</td>
+</tr>
+    
+  
+<tr><td><code>Address</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   address is the IP address to serve on (set to 0.0.0.0 for all interfaces).</td>
+</tr>
+    
+  
+<tr><td><code>MinResyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   minResyncPeriod is the resync period in reflectors; will be random between
+minResyncPeriod and 2&lowast;minResyncPeriod.</td>
+</tr>
+    
+  
+<tr><td><code>ClientConnection</code> <B>[Required]</B><br/>
+<a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
+</td>
+<td>
+   ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.</td>
+</tr>
+    
+  
+<tr><td><code>ControllerStartInterval</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   How long to wait between starting controller managers</td>
+</tr>
+    
+  
+<tr><td><code>LeaderElection</code> <B>[Required]</B><br/>
+<a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
+</td>
+<td>
+   leaderElection defines the configuration of leader election client.</td>
+</tr>
+    
+  
+<tr><td><code>Controllers</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   Controllers is the list of controllers to enable or disable
+'&lowast;' means "all enabled by default controllers"
+'foo' means "enable 'foo'"
+'-foo' means "disable 'foo'"
+first item for a particular name wins</td>
+</tr>
+    
+  
+<tr><td><code>Debugging</code> <B>[Required]</B><br/>
+<a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
+</td>
+<td>
+   DebuggingConfiguration holds configuration for Debugging related features.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LeaderMigrationConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration}
+    
+
+
+
+
+LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+  
+<tr><td><code>leaderName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   LeaderName is the name of the leader election resource that protects the migration
+E.g. 1-20-KCM-to-1-21-CCM</td>
+</tr>
+    
+  
+<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   ResourceLock indicates the resource object type that will be used to lock
+Should be "leases" or "endpoints"</td>
+</tr>
+    
+  
+<tr><td><code>controllerLeaders</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration"><code>[]ControllerLeaderConfiguration</code></a>
+</td>
+<td>
+   ControllerLeaders contains a list of migrating leader lock configurations</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/kube-proxy-config.v1alpha1.md
+++ b/genref/output/md/kube-proxy-config.v1alpha1.md
@@ -1,0 +1,536 @@
+---
+title: kube-proxy Configuration (v1alpha1)
+content_type: tool-reference
+package: kubeproxy.config.k8s.io/v1alpha1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
+  
+    
+
+
+## `KubeProxyConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration}
+    
+
+
+
+
+KubeProxyConfiguration contains everything necessary to configure the
+Kubernetes proxy server.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeproxy.config.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>KubeProxyConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>featureGates</code> <B>[Required]</B><br/>
+<code>map[string]bool</code>
+</td>
+<td>
+   featureGates is a map of feature names to bools that enable or disable alpha/experimental features.</td>
+</tr>
+    
+  
+<tr><td><code>bindAddress</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
+for all interfaces)</td>
+</tr>
+    
+  
+<tr><td><code>healthzBindAddress</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   healthzBindAddress is the IP address and port for the health check server to serve on,
+defaulting to 0.0.0.0:10256</td>
+</tr>
+    
+  
+<tr><td><code>metricsBindAddress</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   metricsBindAddress is the IP address and port for the metrics server to serve on,
+defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)</td>
+</tr>
+    
+  
+<tr><td><code>bindAddressHardFail</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   bindAddressHardFail, if true, kube-proxy will treat failure to bind to a port as fatal and exit</td>
+</tr>
+    
+  
+<tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   enableProfiling enables profiling via web interface on /debug/pprof handler.
+Profiling handlers will be handled by metrics server.</td>
+</tr>
+    
+  
+<tr><td><code>clusterCIDR</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   clusterCIDR is the CIDR range of the pods in the cluster. It is used to
+bridge traffic coming from outside of the cluster. If not provided,
+no off-cluster bridging will be performed.</td>
+</tr>
+    
+  
+<tr><td><code>hostnameOverride</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.</td>
+</tr>
+    
+  
+<tr><td><code>clientConnection</code> <B>[Required]</B><br/>
+<a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
+</td>
+<td>
+   clientConnection specifies the kubeconfig file and client connection settings for the proxy
+server to use when communicating with the apiserver.</td>
+</tr>
+    
+  
+<tr><td><code>iptables</code> <B>[Required]</B><br/>
+<a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPTablesConfiguration"><code>KubeProxyIPTablesConfiguration</code></a>
+</td>
+<td>
+   iptables contains iptables-related configuration options.</td>
+</tr>
+    
+  
+<tr><td><code>ipvs</code> <B>[Required]</B><br/>
+<a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPVSConfiguration"><code>KubeProxyIPVSConfiguration</code></a>
+</td>
+<td>
+   ipvs contains ipvs-related configuration options.</td>
+</tr>
+    
+  
+<tr><td><code>oomScoreAdj</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
+the range [-1000, 1000]</td>
+</tr>
+    
+  
+<tr><td><code>mode</code> <B>[Required]</B><br/>
+<a href="#kubeproxy-config-k8s-io-v1alpha1-ProxyMode"><code>ProxyMode</code></a>
+</td>
+<td>
+   mode specifies which proxy mode to use.</td>
+</tr>
+    
+  
+<tr><td><code>portRange</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
+in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.</td>
+</tr>
+    
+  
+<tr><td><code>udpIdleTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
+Must be greater than 0. Only applicable for proxyMode=userspace.</td>
+</tr>
+    
+  
+<tr><td><code>conntrack</code> <B>[Required]</B><br/>
+<a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConntrackConfiguration"><code>KubeProxyConntrackConfiguration</code></a>
+</td>
+<td>
+   conntrack contains conntrack-related configuration options.</td>
+</tr>
+    
+  
+<tr><td><code>configSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
+than 0.</td>
+</tr>
+    
+  
+<tr><td><code>nodePortAddresses</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   nodePortAddresses is the --nodeport-addresses value for kube-proxy process. Values must be valid
+IP blocks. These values are as a parameter to select the interfaces where nodeport works.
+In case someone would like to expose a service on localhost for local visit and some other interfaces for
+particular purpose, a list of IP blocks would do that.
+If set it to "127.0.0.0/8", kube-proxy will only select the loopback interface for NodePort.
+If set it to a non-zero IP block, kube-proxy will filter that down to just the IPs that applied to the node.
+An empty string slice is meant to select all network interfaces.</td>
+</tr>
+    
+  
+<tr><td><code>winkernel</code> <B>[Required]</B><br/>
+<a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyWinkernelConfiguration"><code>KubeProxyWinkernelConfiguration</code></a>
+</td>
+<td>
+   winkernel contains winkernel-related configuration options.</td>
+</tr>
+    
+  
+<tr><td><code>showHiddenMetricsForVersion</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   ShowHiddenMetricsForVersion is the version for which you want to show hidden metrics.</td>
+</tr>
+    
+  
+<tr><td><code>detectLocalMode</code> <B>[Required]</B><br/>
+<a href="#kubeproxy-config-k8s-io-v1alpha1-LocalMode"><code>LocalMode</code></a>
+</td>
+<td>
+   DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeProxyConntrackConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConntrackConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
+
+
+KubeProxyConntrackConfiguration contains conntrack settings for
+the Kubernetes proxy server.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>maxPerCore</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   maxPerCore is the maximum number of NAT connections to track
+per CPU core (0 to leave the limit as-is and ignore min).</td>
+</tr>
+    
+  
+<tr><td><code>min</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   min is the minimum value of connect-tracking records to allocate,
+regardless of conntrackMaxPerCore (set maxPerCore=0 to leave the limit as-is).</td>
+</tr>
+    
+  
+<tr><td><code>tcpEstablishedTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   tcpEstablishedTimeout is how long an idle TCP connection will be kept open
+(e.g. '2s').  Must be greater than 0 to set.</td>
+</tr>
+    
+  
+<tr><td><code>tcpCloseWaitTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   tcpCloseWaitTimeout is how long an idle conntrack entry
+in CLOSE_WAIT state will remain in the conntrack
+table. (e.g. '60s'). Must be greater than 0 to set.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeProxyIPTablesConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPTablesConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
+
+
+KubeProxyIPTablesConfiguration contains iptables-related configuration
+details for the Kubernetes proxy server.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>masqueradeBit</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
+the pure iptables proxy mode. Values must be within the range [0, 31].</td>
+</tr>
+    
+  
+<tr><td><code>masqueradeAll</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.</td>
+</tr>
+    
+  
+<tr><td><code>syncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
+'2h22m').  Must be greater than 0.</td>
+</tr>
+    
+  
+<tr><td><code>minSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
+'2h22m').</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeProxyIPVSConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPVSConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
+
+
+KubeProxyIPVSConfiguration contains ipvs-related configuration
+details for the Kubernetes proxy server.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>syncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
+'2h22m').  Must be greater than 0.</td>
+</tr>
+    
+  
+<tr><td><code>minSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
+'2h22m').</td>
+</tr>
+    
+  
+<tr><td><code>scheduler</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   ipvs scheduler</td>
+</tr>
+    
+  
+<tr><td><code>excludeCIDRs</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
+when cleaning up ipvs services.</td>
+</tr>
+    
+  
+<tr><td><code>strictARP</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
+from kube-ipvs0 interface</td>
+</tr>
+    
+  
+<tr><td><code>tcpTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   tcpTimeout is the timeout value used for idle IPVS TCP sessions.
+The default value is 0, which preserves the current timeout value on the system.</td>
+</tr>
+    
+  
+<tr><td><code>tcpFinTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   tcpFinTimeout is the timeout value used for IPVS TCP sessions after receiving a FIN.
+The default value is 0, which preserves the current timeout value on the system.</td>
+</tr>
+    
+  
+<tr><td><code>udpTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   udpTimeout is the timeout value used for IPVS UDP packets.
+The default value is 0, which preserves the current timeout value on the system.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeProxyWinkernelConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyWinkernelConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
+
+
+KubeProxyWinkernelConfiguration contains Windows/HNS settings for
+the Kubernetes proxy server.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>networkName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   networkName is the name of the network kube-proxy will use
+to create endpoints and policies</td>
+</tr>
+    
+  
+<tr><td><code>sourceVip</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   sourceVip is the IP address of the source VIP endoint used for
+NAT when loadbalancing</td>
+</tr>
+    
+  
+<tr><td><code>enableDSR</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   enableDSR tells kube-proxy whether HNS policies should be created
+with DSR</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LocalMode`     {#kubeproxy-config-k8s-io-v1alpha1-LocalMode}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
+
+
+LocalMode represents modes to detect local traffic from the node
+
+
+    
+
+
+## `ProxyMode`     {#kubeproxy-config-k8s-io-v1alpha1-ProxyMode}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
+
+
+ProxyMode represents modes used by the Kubernetes proxy server.
+
+Currently, three modes of proxy are available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'
+(newer, faster), 'ipvs'(newest, better in performance and scalability).
+
+Two modes of proxy are available in Windows platform: 'userspace'(older, stable) and 'kernelspace' (newer, faster).
+
+In Linux platform, if proxy mode is blank, use the best-available proxy (currently iptables, but may change in the
+future). If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are
+insufficient, this always falls back to the userspace proxy. IPVS mode will be enabled when proxy mode is set to 'ipvs',
+and the fall back path is firstly iptables and then userspace.
+
+In Windows platform, if proxy mode is blank, use the best-available proxy (currently userspace, but may change in the
+future). If winkernel proxy is selected, regardless of how, but the Windows kernel can't support this mode of proxy,
+this always falls back to the userspace proxy.
+
+
+    
+  

--- a/genref/output/md/kube-scheduler-config.v1beta1.md
+++ b/genref/output/md/kube-scheduler-config.v1beta1.md
@@ -1,0 +1,2156 @@
+---
+title: kube-scheduler Configuration (v1beta1)
+content_type: tool-reference
+package: kubescheduler.config.k8s.io/v1beta1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [DefaultPreemptionArgs](#kubescheduler-config-k8s-io-v1beta1-DefaultPreemptionArgs)
+- [InterPodAffinityArgs](#kubescheduler-config-k8s-io-v1beta1-InterPodAffinityArgs)
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration)
+- [NodeAffinityArgs](#kubescheduler-config-k8s-io-v1beta1-NodeAffinityArgs)
+- [NodeLabelArgs](#kubescheduler-config-k8s-io-v1beta1-NodeLabelArgs)
+- [NodeResourcesFitArgs](#kubescheduler-config-k8s-io-v1beta1-NodeResourcesFitArgs)
+- [NodeResourcesLeastAllocatedArgs](#kubescheduler-config-k8s-io-v1beta1-NodeResourcesLeastAllocatedArgs)
+- [NodeResourcesMostAllocatedArgs](#kubescheduler-config-k8s-io-v1beta1-NodeResourcesMostAllocatedArgs)
+- [PodTopologySpreadArgs](#kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadArgs)
+- [RequestedToCapacityRatioArgs](#kubescheduler-config-k8s-io-v1beta1-RequestedToCapacityRatioArgs)
+- [ServiceAffinityArgs](#kubescheduler-config-k8s-io-v1beta1-ServiceAffinityArgs)
+- [VolumeBindingArgs](#kubescheduler-config-k8s-io-v1beta1-VolumeBindingArgs)
+- [Policy](#kubescheduler-config-k8s-io-v1-Policy)
+  
+    
+
+
+## `DefaultPreemptionArgs`     {#kubescheduler-config-k8s-io-v1beta1-DefaultPreemptionArgs}
+    
+
+
+
+
+DefaultPreemptionArgs holds arguments used to configure the
+DefaultPreemption plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>DefaultPreemptionArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>minCandidateNodesPercentage</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   MinCandidateNodesPercentage is the minimum number of candidates to
+shortlist when dry running preemption as a percentage of number of nodes.
+Must be in the range [0, 100]. Defaults to 10% of the cluster size if
+unspecified.</td>
+</tr>
+    
+  
+<tr><td><code>minCandidateNodesAbsolute</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   MinCandidateNodesAbsolute is the absolute minimum number of candidates to
+shortlist. The likely number of candidates enumerated for dry running
+preemption is given by the formula:
+numCandidates = max(numNodes &lowast; minCandidateNodesPercentage, minCandidateNodesAbsolute)
+We say "likely" because there are other factors such as PDB violations
+that play a role in the number of candidates shortlisted. Must be at least
+0 nodes. Defaults to 100 nodes if unspecified.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `InterPodAffinityArgs`     {#kubescheduler-config-k8s-io-v1beta1-InterPodAffinityArgs}
+    
+
+
+
+
+InterPodAffinityArgs holds arguments used to configure the InterPodAffinity plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>InterPodAffinityArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>hardPodAffinityWeight</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   HardPodAffinityWeight is the scoring weight for existing pods with a
+matching hard affinity to the incoming pod.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeSchedulerConfiguration`     {#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration}
+    
+
+
+
+
+KubeSchedulerConfiguration configures a scheduler
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>KubeSchedulerConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>parallelism</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   Parallelism defines the amount of parallelism in algorithms for scheduling a Pods. Must be greater than 0. Defaults to 16</td>
+</tr>
+    
+  
+<tr><td><code>leaderElection</code> <B>[Required]</B><br/>
+<a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
+</td>
+<td>
+   LeaderElection defines the configuration of leader election client.</td>
+</tr>
+    
+  
+<tr><td><code>clientConnection</code> <B>[Required]</B><br/>
+<a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
+</td>
+<td>
+   ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.</td>
+</tr>
+    
+  
+<tr><td><code>healthzBindAddress</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   HealthzBindAddress is the IP address and port for the health check server to serve on,
+defaulting to 0.0.0.0:10251</td>
+</tr>
+    
+  
+<tr><td><code>metricsBindAddress</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   MetricsBindAddress is the IP address and port for the metrics server to
+serve on, defaulting to 0.0.0.0:10251.</td>
+</tr>
+    
+  
+<tr><td><code>DebuggingConfiguration</code> <B>[Required]</B><br/>
+<a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
+</td>
+<td>(Members of <code>DebuggingConfiguration</code> are embedded into this type.)
+   DebuggingConfiguration holds configuration for Debugging related features
+TODO: We might wanna make this a substruct like Debugging componentbaseconfigv1alpha1.DebuggingConfiguration</td>
+</tr>
+    
+  
+<tr><td><code>percentageOfNodesToScore</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   PercentageOfNodesToScore is the percentage of all nodes that once found feasible
+for running a pod, the scheduler stops its search for more feasible nodes in
+the cluster. This helps improve scheduler's performance. Scheduler always tries to find
+at least "minFeasibleNodesToFind" feasible nodes no matter what the value of this flag is.
+Example: if the cluster size is 500 nodes and the value of this flag is 30,
+then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
+When the value is 0, default percentage (5%--50% based on the size of the cluster) of the
+nodes will be scored.</td>
+</tr>
+    
+  
+<tr><td><code>podInitialBackoffSeconds</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
+If specified, it must be greater than 0. If this value is null, the default value (1s)
+will be used.</td>
+</tr>
+    
+  
+<tr><td><code>podMaxBackoffSeconds</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   PodMaxBackoffSeconds is the max backoff for unschedulable pods.
+If specified, it must be greater than podInitialBackoffSeconds. If this value is null,
+the default value (10s) will be used.</td>
+</tr>
+    
+  
+<tr><td><code>profiles</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerProfile"><code>[]KubeSchedulerProfile</code></a>
+</td>
+<td>
+   Profiles are scheduling profiles that kube-scheduler supports. Pods can
+choose to be scheduled under a particular profile by setting its associated
+scheduler name. Pods that don't specify any scheduler name are scheduled
+with the "default-scheduler" profile, if present here.</td>
+</tr>
+    
+  
+<tr><td><code>extenders</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-Extender"><code>[]Extender</code></a>
+</td>
+<td>
+   Extenders are the list of scheduler extenders, each holding the values of how to communicate
+with the extender. These extenders are shared by all scheduler profiles.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeAffinityArgs`     {#kubescheduler-config-k8s-io-v1beta1-NodeAffinityArgs}
+    
+
+
+
+
+NodeAffinityArgs holds arguments to configure the NodeAffinity plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>NodeAffinityArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>addedAffinity</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#nodeaffinity-v1-core"><code>core/v1.NodeAffinity</code></a>
+</td>
+<td>
+   AddedAffinity is applied to all Pods additionally to the NodeAffinity
+specified in the PodSpec. That is, Nodes need to satisfy AddedAffinity
+AND .spec.NodeAffinity. AddedAffinity is empty by default (all Nodes
+match).
+When AddedAffinity is used, some Pods with affinity requirements that match
+a specific Node (such as Daemonset Pods) might remain unschedulable.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeLabelArgs`     {#kubescheduler-config-k8s-io-v1beta1-NodeLabelArgs}
+    
+
+
+
+
+NodeLabelArgs holds arguments used to configure the NodeLabel plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>NodeLabelArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>presentLabels</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   PresentLabels should be present for the node to be considered a fit for hosting the pod</td>
+</tr>
+    
+  
+<tr><td><code>absentLabels</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   AbsentLabels should be absent for the node to be considered a fit for hosting the pod</td>
+</tr>
+    
+  
+<tr><td><code>presentLabelsPreference</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   Nodes that have labels in the list will get a higher score.</td>
+</tr>
+    
+  
+<tr><td><code>absentLabelsPreference</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   Nodes that don't have labels in the list will get a higher score.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeResourcesFitArgs`     {#kubescheduler-config-k8s-io-v1beta1-NodeResourcesFitArgs}
+    
+
+
+
+
+NodeResourcesFitArgs holds arguments used to configure the NodeResourcesFit plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>NodeResourcesFitArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>ignoredResources</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   IgnoredResources is the list of resources that NodeResources fit filter
+should ignore.</td>
+</tr>
+    
+  
+<tr><td><code>ignoredResourceGroups</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   IgnoredResourceGroups defines the list of resource groups that NodeResources fit filter should ignore.
+e.g. if group is ["example.com"], it will ignore all resource names that begin
+with "example.com", such as "example.com/aaa" and "example.com/bbb".
+A resource group name can't contain '/'.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeResourcesLeastAllocatedArgs`     {#kubescheduler-config-k8s-io-v1beta1-NodeResourcesLeastAllocatedArgs}
+    
+
+
+
+
+NodeResourcesLeastAllocatedArgs holds arguments used to configure NodeResourcesLeastAllocated plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>NodeResourcesLeastAllocatedArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-ResourceSpec"><code>[]ResourceSpec</code></a>
+</td>
+<td>
+   Resources to be managed, if no resource is provided, default resource set with both
+the weight of "cpu" and "memory" set to "1" will be applied.
+Resource with "0" weight will not accountable for the final score.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeResourcesMostAllocatedArgs`     {#kubescheduler-config-k8s-io-v1beta1-NodeResourcesMostAllocatedArgs}
+    
+
+
+
+
+NodeResourcesMostAllocatedArgs holds arguments used to configure NodeResourcesMostAllocated plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>NodeResourcesMostAllocatedArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-ResourceSpec"><code>[]ResourceSpec</code></a>
+</td>
+<td>
+   Resources to be managed, if no resource is provided, default resource set with both
+the weight of "cpu" and "memory" set to "1" will be applied.
+Resource with "0" weight will not accountable for the final score.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PodTopologySpreadArgs`     {#kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadArgs}
+    
+
+
+
+
+PodTopologySpreadArgs holds arguments used to configure the PodTopologySpread plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>PodTopologySpreadArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>defaultConstraints</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#topologyspreadconstraint-v1-core"><code>[]core/v1.TopologySpreadConstraint</code></a>
+</td>
+<td>
+   DefaultConstraints defines topology spread constraints to be applied to
+Pods that don't define any in `pod.spec.topologySpreadConstraints`.
+`.defaultConstraints[&lowast;].labelSelectors` must be empty, as they are
+deduced from the Pod's membership to Services, ReplicationControllers,
+ReplicaSets or StatefulSets.
+When not empty, .defaultingType must be "List".</td>
+</tr>
+    
+  
+<tr><td><code>defaultingType</code><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadConstraintsDefaulting"><code>PodTopologySpreadConstraintsDefaulting</code></a>
+</td>
+<td>
+   DefaultingType determines how .defaultConstraints are deduced. Can be one
+of "System" or "List".
+
+- "System": Use kubernetes defined constraints that spread Pods among
+  Nodes and Zones.
+- "List": Use constraints defined in .defaultConstraints.
+
+Defaults to "List" if feature gate DefaultPodTopologySpread is disabled
+and to "System" if enabled.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `RequestedToCapacityRatioArgs`     {#kubescheduler-config-k8s-io-v1beta1-RequestedToCapacityRatioArgs}
+    
+
+
+
+
+RequestedToCapacityRatioArgs holds arguments used to configure RequestedToCapacityRatio plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>RequestedToCapacityRatioArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>shape</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-UtilizationShapePoint"><code>[]UtilizationShapePoint</code></a>
+</td>
+<td>
+   Points defining priority function shape</td>
+</tr>
+    
+  
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-ResourceSpec"><code>[]ResourceSpec</code></a>
+</td>
+<td>
+   Resources to be managed</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ServiceAffinityArgs`     {#kubescheduler-config-k8s-io-v1beta1-ServiceAffinityArgs}
+    
+
+
+
+
+ServiceAffinityArgs holds arguments used to configure the ServiceAffinity plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ServiceAffinityArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>affinityLabels</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   AffinityLabels are homogeneous for pods that are scheduled to a node.
+(i.e. it returns true IFF this pod can be added to this node such that all other pods in
+the same service are running on nodes with the exact same values for Labels).</td>
+</tr>
+    
+  
+<tr><td><code>antiAffinityLabelsPreference</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   AntiAffinityLabelsPreference are the labels to consider for service anti affinity scoring.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `VolumeBindingArgs`     {#kubescheduler-config-k8s-io-v1beta1-VolumeBindingArgs}
+    
+
+
+
+
+VolumeBindingArgs holds arguments used to configure the VolumeBinding plugin.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>VolumeBindingArgs</code></td></tr>
+    
+
+  
+  
+<tr><td><code>bindTimeoutSeconds</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   BindTimeoutSeconds is the timeout in seconds in volume binding operation.
+Value must be non-negative integer. The value zero indicates no waiting.
+If this value is nil, the default value (600) will be used.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Extender`     {#kubescheduler-config-k8s-io-v1beta1-Extender}
+    
+
+
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration)
+
+
+Extender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
+it is assumed that the extender chose not to provide that extension.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>urlPrefix</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   URLPrefix at which the extender is available</td>
+</tr>
+    
+  
+<tr><td><code>filterVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>preemptVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>prioritizeVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   The numeric multiplier for the node scores that the prioritize call generates.
+The weight should be a positive integer</td>
+</tr>
+    
+  
+<tr><td><code>bindVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
+can implement this function.</td>
+</tr>
+    
+  
+<tr><td><code>enableHTTPS</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   EnableHTTPS specifies whether https should be used to communicate with the extender</td>
+</tr>
+    
+  
+<tr><td><code>tlsConfig</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ExtenderTLSConfig"><code>ExtenderTLSConfig</code></a>
+</td>
+<td>
+   TLSConfig specifies the transport layer security config</td>
+</tr>
+    
+  
+<tr><td><code>httpTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
+timeout is ignored, k8s/other extenders priorities are used to select the node.</td>
+</tr>
+    
+  
+<tr><td><code>nodeCacheCapable</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   NodeCacheCapable specifies that the extender is capable of caching node information,
+so the scheduler should only send minimal information about the eligible nodes
+assuming that the extender already cached full details of all nodes in the cluster</td>
+</tr>
+    
+  
+<tr><td><code>managedResources</code><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ExtenderManagedResource"><code>[]ExtenderManagedResource</code></a>
+</td>
+<td>
+   ManagedResources is a list of extended resources that are managed by
+this extender.
+- A pod will be sent to the extender on the Filter, Prioritize and Bind
+  (if the extender is the binder) phases iff the pod requests at least
+  one of the extended resources in this list. If empty or unspecified,
+  all pods will be sent to this extender.
+- If IgnoredByScheduler is set to true for a resource, kube-scheduler
+  will skip checking the resource in predicates.</td>
+</tr>
+    
+  
+<tr><td><code>ignorable</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+fail when the extender returns an error or is not reachable.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeSchedulerProfile`     {#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerProfile}
+    
+
+
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration)
+
+
+KubeSchedulerProfile is a scheduling profile.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>schedulerName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   SchedulerName is the name of the scheduler associated to this profile.
+If SchedulerName matches with the pod's "spec.schedulerName", then the pod
+is scheduled with this profile.</td>
+</tr>
+    
+  
+<tr><td><code>plugins</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-Plugins"><code>Plugins</code></a>
+</td>
+<td>
+   Plugins specify the set of plugins that should be enabled or disabled.
+Enabled plugins are the ones that should be enabled in addition to the
+default plugins. Disabled plugins are any of the default plugins that
+should be disabled.
+When no enabled or disabled plugin is specified for an extension point,
+default plugins for that extension point will be used if there is any.
+If a QueueSort plugin is specified, the same QueueSort Plugin and
+PluginConfig must be specified for all profiles.</td>
+</tr>
+    
+  
+<tr><td><code>pluginConfig</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginConfig"><code>[]PluginConfig</code></a>
+</td>
+<td>
+   PluginConfig is an optional set of custom plugin arguments for each plugin.
+Omitting config args for a plugin is equivalent to using the default config
+for that plugin.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Plugin`     {#kubescheduler-config-k8s-io-v1beta1-Plugin}
+    
+
+
+
+**Appears in:**
+
+- [PluginSet](#kubescheduler-config-k8s-io-v1beta1-PluginSet)
+
+
+Plugin specifies a plugin name and its weight when applicable. Weight is used only for Score plugins.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name defines the name of plugin</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   Weight defines the weight of plugin, only used for Score plugins.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PluginConfig`     {#kubescheduler-config-k8s-io-v1beta1-PluginConfig}
+    
+
+
+
+**Appears in:**
+
+- [KubeSchedulerProfile](#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerProfile)
+
+
+PluginConfig specifies arguments that should be passed to a plugin at the time of initialization.
+A plugin that is invoked at multiple extension points is initialized once. Args can have arbitrary structure.
+It is up to the plugin to process these Args.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name defines the name of plugin being configured</td>
+</tr>
+    
+  
+<tr><td><code>args</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+</td>
+<td>
+   Args defines the arguments passed to the plugins at the time of initialization. Args can have arbitrary structure.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PluginSet`     {#kubescheduler-config-k8s-io-v1beta1-PluginSet}
+    
+
+
+
+**Appears in:**
+
+- [Plugins](#kubescheduler-config-k8s-io-v1beta1-Plugins)
+
+
+PluginSet specifies enabled and disabled plugins for an extension point.
+If an array is empty, missing, or nil, default plugins at that extension point will be used.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>enabled</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-Plugin"><code>[]Plugin</code></a>
+</td>
+<td>
+   Enabled specifies plugins that should be enabled in addition to default plugins.
+These are called after default plugins and in the same order specified here.</td>
+</tr>
+    
+  
+<tr><td><code>disabled</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-Plugin"><code>[]Plugin</code></a>
+</td>
+<td>
+   Disabled specifies default plugins that should be disabled.
+When all default plugins need to be disabled, an array containing only one "&lowast;" should be provided.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Plugins`     {#kubescheduler-config-k8s-io-v1beta1-Plugins}
+    
+
+
+
+**Appears in:**
+
+- [KubeSchedulerProfile](#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerProfile)
+
+
+Plugins include multiple extension points. When specified, the list of plugins for
+a particular extension point are the only ones enabled. If an extension point is
+omitted from the config, then the default set of plugins is used for that extension point.
+Enabled plugins are called in the order specified here, after default plugins. If they need to
+be invoked before default plugins, default plugins must be disabled and re-enabled here in desired order.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>queueSort</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   QueueSort is a list of plugins that should be invoked when sorting pods in the scheduling queue.</td>
+</tr>
+    
+  
+<tr><td><code>preFilter</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   PreFilter is a list of plugins that should be invoked at "PreFilter" extension point of the scheduling framework.</td>
+</tr>
+    
+  
+<tr><td><code>filter</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.</td>
+</tr>
+    
+  
+<tr><td><code>postFilter</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   PostFilter is a list of plugins that are invoked after filtering phase, no matter whether filtering succeeds or not.</td>
+</tr>
+    
+  
+<tr><td><code>preScore</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   PreScore is a list of plugins that are invoked before scoring.</td>
+</tr>
+    
+  
+<tr><td><code>score</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   Score is a list of plugins that should be invoked when ranking nodes that have passed the filtering phase.</td>
+</tr>
+    
+  
+<tr><td><code>reserve</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   Reserve is a list of plugins invoked when reserving/unreserving resources
+after a node is assigned to run the pod.</td>
+</tr>
+    
+  
+<tr><td><code>permit</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   Permit is a list of plugins that control binding of a Pod. These plugins can prevent or delay binding of a Pod.</td>
+</tr>
+    
+  
+<tr><td><code>preBind</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   PreBind is a list of plugins that should be invoked before a pod is bound.</td>
+</tr>
+    
+  
+<tr><td><code>bind</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   Bind is a list of plugins that should be invoked at "Bind" extension point of the scheduling framework.
+The scheduler call these plugins in order. Scheduler skips the rest of these plugins as soon as one returns success.</td>
+</tr>
+    
+  
+<tr><td><code>postBind</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1beta1-PluginSet"><code>PluginSet</code></a>
+</td>
+<td>
+   PostBind is a list of plugins that should be invoked after a pod is successfully bound.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PodTopologySpreadConstraintsDefaulting`     {#kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadConstraintsDefaulting}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [PodTopologySpreadArgs](#kubescheduler-config-k8s-io-v1beta1-PodTopologySpreadArgs)
+
+
+PodTopologySpreadConstraintsDefaulting defines how to set default constraints
+for the PodTopologySpread plugin.
+
+
+    
+
+
+## `ResourceSpec`     {#kubescheduler-config-k8s-io-v1beta1-ResourceSpec}
+    
+
+
+
+**Appears in:**
+
+- [NodeResourcesLeastAllocatedArgs](#kubescheduler-config-k8s-io-v1beta1-NodeResourcesLeastAllocatedArgs)
+
+- [NodeResourcesMostAllocatedArgs](#kubescheduler-config-k8s-io-v1beta1-NodeResourcesMostAllocatedArgs)
+
+- [RequestedToCapacityRatioArgs](#kubescheduler-config-k8s-io-v1beta1-RequestedToCapacityRatioArgs)
+
+
+ResourceSpec represents single resource and weight for bin packing of priority RequestedToCapacityRatioArguments.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name of the resource to be managed by RequestedToCapacityRatio function.</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   Weight of the resource.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `UtilizationShapePoint`     {#kubescheduler-config-k8s-io-v1beta1-UtilizationShapePoint}
+    
+
+
+
+**Appears in:**
+
+- [RequestedToCapacityRatioArgs](#kubescheduler-config-k8s-io-v1beta1-RequestedToCapacityRatioArgs)
+
+
+UtilizationShapePoint represents single point of priority function shape.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>utilization</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.</td>
+</tr>
+    
+  
+<tr><td><code>score</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   Score assigned to given utilization (y axis). Valid values are 0 to 10.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  
+  
+    
+
+
+## `Policy`     {#kubescheduler-config-k8s-io-v1-Policy}
+    
+
+
+
+
+Policy describes a struct for a policy resource used in api.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Policy</code></td></tr>
+    
+
+  
+  
+<tr><td><code>predicates</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PredicatePolicy"><code>[]PredicatePolicy</code></a>
+</td>
+<td>
+   Holds the information to configure the fit predicate functions</td>
+</tr>
+    
+  
+<tr><td><code>priorities</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PriorityPolicy"><code>[]PriorityPolicy</code></a>
+</td>
+<td>
+   Holds the information to configure the priority functions</td>
+</tr>
+    
+  
+<tr><td><code>extenders</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-LegacyExtender"><code>[]LegacyExtender</code></a>
+</td>
+<td>
+   Holds the information to communicate with the extender(s)</td>
+</tr>
+    
+  
+<tr><td><code>hardPodAffinitySymmetricWeight</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
+corresponding to every RequiredDuringScheduling affinity rule.
+HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.</td>
+</tr>
+    
+  
+<tr><td><code>alwaysCheckAllPredicates</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   When AlwaysCheckAllPredicates is set to true, scheduler checks all
+the configured predicates even after one or more of them fails.
+When the flag is set to false, scheduler skips checking the rest
+of the predicates after it finds one predicate that failed.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExtenderManagedResource`     {#kubescheduler-config-k8s-io-v1-ExtenderManagedResource}
+    
+
+
+
+**Appears in:**
+
+- [Extender](#kubescheduler-config-k8s-io-v1beta1-Extender)
+
+- [LegacyExtender](#kubescheduler-config-k8s-io-v1-LegacyExtender)
+
+
+ExtenderManagedResource describes the arguments of extended resources
+managed by an extender.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name is the extended resource name.</td>
+</tr>
+    
+  
+<tr><td><code>ignoredByScheduler</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   IgnoredByScheduler indicates whether kube-scheduler should ignore this
+resource when applying predicates.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExtenderTLSConfig`     {#kubescheduler-config-k8s-io-v1-ExtenderTLSConfig}
+    
+
+
+
+**Appears in:**
+
+- [Extender](#kubescheduler-config-k8s-io-v1beta1-Extender)
+
+- [LegacyExtender](#kubescheduler-config-k8s-io-v1-LegacyExtender)
+
+
+ExtenderTLSConfig contains settings to enable TLS with extender
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>insecure</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   Server should be accessed without verifying the TLS certificate. For testing only.</td>
+</tr>
+    
+  
+<tr><td><code>serverName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   ServerName is passed to the server for SNI and is used in the client to check server
+certificates against. If ServerName is empty, the hostname used to contact the
+server is used.</td>
+</tr>
+    
+  
+<tr><td><code>certFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Server requires TLS client certificate authentication</td>
+</tr>
+    
+  
+<tr><td><code>keyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Server requires TLS client certificate authentication</td>
+</tr>
+    
+  
+<tr><td><code>caFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Trusted root certificates for server</td>
+</tr>
+    
+  
+<tr><td><code>certData</code> <B>[Required]</B><br/>
+<code>[]byte</code>
+</td>
+<td>
+   CertData holds PEM-encoded bytes (typically read from a client certificate file).
+CertData takes precedence over CertFile</td>
+</tr>
+    
+  
+<tr><td><code>keyData</code> <B>[Required]</B><br/>
+<code>[]byte</code>
+</td>
+<td>
+   KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
+KeyData takes precedence over KeyFile</td>
+</tr>
+    
+  
+<tr><td><code>caData</code> <B>[Required]</B><br/>
+<code>[]byte</code>
+</td>
+<td>
+   CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
+CAData takes precedence over CAFile</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LabelPreference`     {#kubescheduler-config-k8s-io-v1-LabelPreference}
+    
+
+
+
+**Appears in:**
+
+- [PriorityArgument](#kubescheduler-config-k8s-io-v1-PriorityArgument)
+
+
+LabelPreference holds the parameters that are used to configure the corresponding priority function
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>label</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Used to identify node "groups"</td>
+</tr>
+    
+  
+<tr><td><code>presence</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   This is a boolean flag
+If true, higher priority is given to nodes that have the label
+If false, higher priority is given to nodes that do not have the label</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LabelsPresence`     {#kubescheduler-config-k8s-io-v1-LabelsPresence}
+    
+
+
+
+**Appears in:**
+
+- [PredicateArgument](#kubescheduler-config-k8s-io-v1-PredicateArgument)
+
+
+LabelsPresence holds the parameters that are used to configure the corresponding predicate in scheduler policy configuration.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>labels</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   The list of labels that identify node "groups"
+All of the labels should be either present (or absent) for the node to be considered a fit for hosting the pod</td>
+</tr>
+    
+  
+<tr><td><code>presence</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   The boolean flag that indicates whether the labels should be present or absent from the node</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LegacyExtender`     {#kubescheduler-config-k8s-io-v1-LegacyExtender}
+    
+
+
+
+**Appears in:**
+
+- [Policy](#kubescheduler-config-k8s-io-v1-Policy)
+
+
+LegacyExtender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
+it is assumed that the extender chose not to provide that extension.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>urlPrefix</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   URLPrefix at which the extender is available</td>
+</tr>
+    
+  
+<tr><td><code>filterVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>preemptVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>prioritizeVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   The numeric multiplier for the node scores that the prioritize call generates.
+The weight should be a positive integer</td>
+</tr>
+    
+  
+<tr><td><code>bindVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
+can implement this function.</td>
+</tr>
+    
+  
+<tr><td><code>enableHttps</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   EnableHTTPS specifies whether https should be used to communicate with the extender</td>
+</tr>
+    
+  
+<tr><td><code>tlsConfig</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ExtenderTLSConfig"><code>ExtenderTLSConfig</code></a>
+</td>
+<td>
+   TLSConfig specifies the transport layer security config</td>
+</tr>
+    
+  
+<tr><td><code>httpTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/time#Duration"><code>time.Duration</code></a>
+</td>
+<td>
+   HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
+timeout is ignored, k8s/other extenders priorities are used to select the node.</td>
+</tr>
+    
+  
+<tr><td><code>nodeCacheCapable</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   NodeCacheCapable specifies that the extender is capable of caching node information,
+so the scheduler should only send minimal information about the eligible nodes
+assuming that the extender already cached full details of all nodes in the cluster</td>
+</tr>
+    
+  
+<tr><td><code>managedResources</code><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ExtenderManagedResource"><code>[]ExtenderManagedResource</code></a>
+</td>
+<td>
+   ManagedResources is a list of extended resources that are managed by
+this extender.
+- A pod will be sent to the extender on the Filter, Prioritize and Bind
+  (if the extender is the binder) phases iff the pod requests at least
+  one of the extended resources in this list. If empty or unspecified,
+  all pods will be sent to this extender.
+- If IgnoredByScheduler is set to true for a resource, kube-scheduler
+  will skip checking the resource in predicates.</td>
+</tr>
+    
+  
+<tr><td><code>ignorable</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+fail when the extender returns an error or is not reachable.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PredicateArgument`     {#kubescheduler-config-k8s-io-v1-PredicateArgument}
+    
+
+
+
+**Appears in:**
+
+- [PredicatePolicy](#kubescheduler-config-k8s-io-v1-PredicatePolicy)
+
+
+PredicateArgument represents the arguments to configure predicate functions in scheduler policy configuration.
+Only one of its members may be specified
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>serviceAffinity</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ServiceAffinity"><code>ServiceAffinity</code></a>
+</td>
+<td>
+   The predicate that provides affinity for pods belonging to a service
+It uses a label to identify nodes that belong to the same "group"</td>
+</tr>
+    
+  
+<tr><td><code>labelsPresence</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-LabelsPresence"><code>LabelsPresence</code></a>
+</td>
+<td>
+   The predicate that checks whether a particular node has a certain label
+defined or not, regardless of value</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PredicatePolicy`     {#kubescheduler-config-k8s-io-v1-PredicatePolicy}
+    
+
+
+
+**Appears in:**
+
+- [Policy](#kubescheduler-config-k8s-io-v1-Policy)
+
+
+PredicatePolicy describes a struct of a predicate policy.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Identifier of the predicate policy
+For a custom predicate, the name can be user-defined
+For the Kubernetes provided predicates, the name is the identifier of the pre-defined predicate</td>
+</tr>
+    
+  
+<tr><td><code>argument</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PredicateArgument"><code>PredicateArgument</code></a>
+</td>
+<td>
+   Holds the parameters to configure the given predicate</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PriorityArgument`     {#kubescheduler-config-k8s-io-v1-PriorityArgument}
+    
+
+
+
+**Appears in:**
+
+- [PriorityPolicy](#kubescheduler-config-k8s-io-v1-PriorityPolicy)
+
+
+PriorityArgument represents the arguments to configure priority functions in scheduler policy configuration.
+Only one of its members may be specified
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>serviceAntiAffinity</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ServiceAntiAffinity"><code>ServiceAntiAffinity</code></a>
+</td>
+<td>
+   The priority function that ensures a good spread (anti-affinity) for pods belonging to a service
+It uses a label to identify nodes that belong to the same "group"</td>
+</tr>
+    
+  
+<tr><td><code>labelPreference</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-LabelPreference"><code>LabelPreference</code></a>
+</td>
+<td>
+   The priority function that checks whether a particular node has a certain label
+defined or not, regardless of value</td>
+</tr>
+    
+  
+<tr><td><code>requestedToCapacityRatioArguments</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments"><code>RequestedToCapacityRatioArguments</code></a>
+</td>
+<td>
+   The RequestedToCapacityRatio priority function is parametrized with function shape.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PriorityPolicy`     {#kubescheduler-config-k8s-io-v1-PriorityPolicy}
+    
+
+
+
+**Appears in:**
+
+- [Policy](#kubescheduler-config-k8s-io-v1-Policy)
+
+
+PriorityPolicy describes a struct of a priority policy.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Identifier of the priority policy
+For a custom priority, the name can be user-defined
+For the Kubernetes provided priority functions, the name is the identifier of the pre-defined priority function</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   The numeric multiplier for the node scores that the priority function generates
+The weight should be non-zero and can be a positive or a negative integer</td>
+</tr>
+    
+  
+<tr><td><code>argument</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PriorityArgument"><code>PriorityArgument</code></a>
+</td>
+<td>
+   Holds the parameters to configure the given priority function</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `RequestedToCapacityRatioArguments`     {#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments}
+    
+
+
+
+**Appears in:**
+
+- [PriorityArgument](#kubescheduler-config-k8s-io-v1-PriorityArgument)
+
+
+RequestedToCapacityRatioArguments holds arguments specific to RequestedToCapacityRatio priority function.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>shape</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-UtilizationShapePoint"><code>[]UtilizationShapePoint</code></a>
+</td>
+<td>
+   Array of point defining priority function shape.</td>
+</tr>
+    
+  
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ResourceSpec"><code>[]ResourceSpec</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ResourceSpec`     {#kubescheduler-config-k8s-io-v1-ResourceSpec}
+    
+
+
+
+**Appears in:**
+
+- [RequestedToCapacityRatioArguments](#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments)
+
+
+ResourceSpec represents single resource and weight for bin packing of priority RequestedToCapacityRatioArguments.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name of the resource to be managed by RequestedToCapacityRatio function.</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   Weight of the resource.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ServiceAffinity`     {#kubescheduler-config-k8s-io-v1-ServiceAffinity}
+    
+
+
+
+**Appears in:**
+
+- [PredicateArgument](#kubescheduler-config-k8s-io-v1-PredicateArgument)
+
+
+ServiceAffinity holds the parameters that are used to configure the corresponding predicate in scheduler policy configuration.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>labels</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   The list of labels that identify node "groups"
+All of the labels should match for the node to be considered a fit for hosting the pod</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ServiceAntiAffinity`     {#kubescheduler-config-k8s-io-v1-ServiceAntiAffinity}
+    
+
+
+
+**Appears in:**
+
+- [PriorityArgument](#kubescheduler-config-k8s-io-v1-PriorityArgument)
+
+
+ServiceAntiAffinity holds the parameters that are used to configure the corresponding priority function
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>label</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Used to identify node "groups"</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `UtilizationShapePoint`     {#kubescheduler-config-k8s-io-v1-UtilizationShapePoint}
+    
+
+
+
+**Appears in:**
+
+- [RequestedToCapacityRatioArguments](#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments)
+
+
+UtilizationShapePoint represents single point of priority function shape.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>utilization</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.</td>
+</tr>
+    
+  
+<tr><td><code>score</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   Score assigned to given utilization (y axis). Valid values are 0 to 10.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  
+  
+    
+
+## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration)
+
+
+ClientConnectionConfiguration contains details for constructing a client.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>kubeconfig</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   kubeconfig is the path to a KubeConfig file.</td>
+</tr>
+    
+  
+<tr><td><code>acceptContentTypes</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
+default value of 'application/json'. This field will control all connections to the server used by a particular
+client.</td>
+</tr>
+    
+  
+<tr><td><code>contentType</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   contentType is the content type used when sending data to the server from this client.</td>
+</tr>
+    
+  
+<tr><td><code>qps</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   qps controls the number of queries per second allowed for this connection.</td>
+</tr>
+    
+  
+<tr><td><code>burst</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   burst allows extra queries to accumulate when a client is exceeding its rate.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+
+## `DebuggingConfiguration`     {#DebuggingConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration)
+
+
+DebuggingConfiguration holds configuration for Debugging related features.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   enableProfiling enables profiling via web interface host:port/debug/pprof/</td>
+</tr>
+    
+  
+<tr><td><code>enableContentionProfiling</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   enableContentionProfiling enables lock contention profiling, if
+enableProfiling is true.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+
+## `LeaderElectionConfiguration`     {#LeaderElectionConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta1-KubeSchedulerConfiguration)
+
+
+LeaderElectionConfiguration defines the configuration of leader election
+clients for components that can run with leader election enabled.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>leaderElect</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   leaderElect enables a leader election client to gain leadership
+before executing the main loop. Enable this when running replicated
+components for high availability.</td>
+</tr>
+    
+  
+<tr><td><code>leaseDuration</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   leaseDuration is the duration that non-leader candidates will wait
+after observing a leadership renewal until attempting to acquire
+leadership of a led but unrenewed leader slot. This is effectively the
+maximum duration that a leader can be stopped before it is replaced
+by another candidate. This is only applicable if leader election is
+enabled.</td>
+</tr>
+    
+  
+<tr><td><code>renewDeadline</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   renewDeadline is the interval between attempts by the acting master to
+renew a leadership slot before it stops leading. This must be less
+than or equal to the lease duration. This is only applicable if leader
+election is enabled.</td>
+</tr>
+    
+  
+<tr><td><code>retryPeriod</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   retryPeriod is the duration the clients should wait between attempting
+acquisition and renewal of a leadership. This is only applicable if
+leader election is enabled.</td>
+</tr>
+    
+  
+<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   resourceLock indicates the resource object type that will be used to lock
+during leader election cycles.</td>
+</tr>
+    
+  
+<tr><td><code>resourceName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   resourceName indicates the name of resource object that will be used to lock
+during leader election cycles.</td>
+</tr>
+    
+  
+<tr><td><code>resourceNamespace</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   resourceName indicates the namespace of resource object that will be used to lock
+during leader election cycles.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+
+## `LoggingConfiguration`     {#LoggingConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+LoggingConfiguration contains logging options
+Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>format</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Format Flag specifies the structure of log messages.
+default value of format is `text`</td>
+</tr>
+    
+  
+<tr><td><code>sanitization</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</td>
+</tr>
+    
+  
+</tbody>
+</table>

--- a/genref/output/md/kube-scheduler-policy-config.v1.md
+++ b/genref/output/md/kube-scheduler-policy-config.v1.md
@@ -1,0 +1,799 @@
+---
+title: kube-scheduler Policy Configuration (v1)
+content_type: tool-reference
+package: kubescheduler.config.k8s.io/v1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [Policy](#kubescheduler-config-k8s-io-v1-Policy)
+  
+    
+
+
+## `Policy`     {#kubescheduler-config-k8s-io-v1-Policy}
+    
+
+
+
+
+Policy describes a struct for a policy resource used in api.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Policy</code></td></tr>
+    
+
+  
+  
+<tr><td><code>predicates</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PredicatePolicy"><code>[]PredicatePolicy</code></a>
+</td>
+<td>
+   Holds the information to configure the fit predicate functions</td>
+</tr>
+    
+  
+<tr><td><code>priorities</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PriorityPolicy"><code>[]PriorityPolicy</code></a>
+</td>
+<td>
+   Holds the information to configure the priority functions</td>
+</tr>
+    
+  
+<tr><td><code>extenders</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-LegacyExtender"><code>[]LegacyExtender</code></a>
+</td>
+<td>
+   Holds the information to communicate with the extender(s)</td>
+</tr>
+    
+  
+<tr><td><code>hardPodAffinitySymmetricWeight</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
+corresponding to every RequiredDuringScheduling affinity rule.
+HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.</td>
+</tr>
+    
+  
+<tr><td><code>alwaysCheckAllPredicates</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   When AlwaysCheckAllPredicates is set to true, scheduler checks all
+the configured predicates even after one or more of them fails.
+When the flag is set to false, scheduler skips checking the rest
+of the predicates after it finds one predicate that failed.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExtenderManagedResource`     {#kubescheduler-config-k8s-io-v1-ExtenderManagedResource}
+    
+
+
+
+**Appears in:**
+
+- [Extender](#kubescheduler-config-k8s-io-v1beta1-Extender)
+
+- [LegacyExtender](#kubescheduler-config-k8s-io-v1-LegacyExtender)
+
+
+ExtenderManagedResource describes the arguments of extended resources
+managed by an extender.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name is the extended resource name.</td>
+</tr>
+    
+  
+<tr><td><code>ignoredByScheduler</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   IgnoredByScheduler indicates whether kube-scheduler should ignore this
+resource when applying predicates.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExtenderTLSConfig`     {#kubescheduler-config-k8s-io-v1-ExtenderTLSConfig}
+    
+
+
+
+**Appears in:**
+
+- [Extender](#kubescheduler-config-k8s-io-v1beta1-Extender)
+
+- [LegacyExtender](#kubescheduler-config-k8s-io-v1-LegacyExtender)
+
+
+ExtenderTLSConfig contains settings to enable TLS with extender
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>insecure</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   Server should be accessed without verifying the TLS certificate. For testing only.</td>
+</tr>
+    
+  
+<tr><td><code>serverName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   ServerName is passed to the server for SNI and is used in the client to check server
+certificates against. If ServerName is empty, the hostname used to contact the
+server is used.</td>
+</tr>
+    
+  
+<tr><td><code>certFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Server requires TLS client certificate authentication</td>
+</tr>
+    
+  
+<tr><td><code>keyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Server requires TLS client certificate authentication</td>
+</tr>
+    
+  
+<tr><td><code>caFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Trusted root certificates for server</td>
+</tr>
+    
+  
+<tr><td><code>certData</code> <B>[Required]</B><br/>
+<code>[]byte</code>
+</td>
+<td>
+   CertData holds PEM-encoded bytes (typically read from a client certificate file).
+CertData takes precedence over CertFile</td>
+</tr>
+    
+  
+<tr><td><code>keyData</code> <B>[Required]</B><br/>
+<code>[]byte</code>
+</td>
+<td>
+   KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
+KeyData takes precedence over KeyFile</td>
+</tr>
+    
+  
+<tr><td><code>caData</code> <B>[Required]</B><br/>
+<code>[]byte</code>
+</td>
+<td>
+   CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
+CAData takes precedence over CAFile</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LabelPreference`     {#kubescheduler-config-k8s-io-v1-LabelPreference}
+    
+
+
+
+**Appears in:**
+
+- [PriorityArgument](#kubescheduler-config-k8s-io-v1-PriorityArgument)
+
+
+LabelPreference holds the parameters that are used to configure the corresponding priority function
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>label</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Used to identify node "groups"</td>
+</tr>
+    
+  
+<tr><td><code>presence</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   This is a boolean flag
+If true, higher priority is given to nodes that have the label
+If false, higher priority is given to nodes that do not have the label</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LabelsPresence`     {#kubescheduler-config-k8s-io-v1-LabelsPresence}
+    
+
+
+
+**Appears in:**
+
+- [PredicateArgument](#kubescheduler-config-k8s-io-v1-PredicateArgument)
+
+
+LabelsPresence holds the parameters that are used to configure the corresponding predicate in scheduler policy configuration.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>labels</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   The list of labels that identify node "groups"
+All of the labels should be either present (or absent) for the node to be considered a fit for hosting the pod</td>
+</tr>
+    
+  
+<tr><td><code>presence</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   The boolean flag that indicates whether the labels should be present or absent from the node</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LegacyExtender`     {#kubescheduler-config-k8s-io-v1-LegacyExtender}
+    
+
+
+
+**Appears in:**
+
+- [Policy](#kubescheduler-config-k8s-io-v1-Policy)
+
+
+LegacyExtender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
+it is assumed that the extender chose not to provide that extension.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>urlPrefix</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   URLPrefix at which the extender is available</td>
+</tr>
+    
+  
+<tr><td><code>filterVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>preemptVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>prioritizeVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   The numeric multiplier for the node scores that the prioritize call generates.
+The weight should be a positive integer</td>
+</tr>
+    
+  
+<tr><td><code>bindVerb</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
+can implement this function.</td>
+</tr>
+    
+  
+<tr><td><code>enableHttps</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   EnableHTTPS specifies whether https should be used to communicate with the extender</td>
+</tr>
+    
+  
+<tr><td><code>tlsConfig</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ExtenderTLSConfig"><code>ExtenderTLSConfig</code></a>
+</td>
+<td>
+   TLSConfig specifies the transport layer security config</td>
+</tr>
+    
+  
+<tr><td><code>httpTimeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/time#Duration"><code>time.Duration</code></a>
+</td>
+<td>
+   HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
+timeout is ignored, k8s/other extenders priorities are used to select the node.</td>
+</tr>
+    
+  
+<tr><td><code>nodeCacheCapable</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   NodeCacheCapable specifies that the extender is capable of caching node information,
+so the scheduler should only send minimal information about the eligible nodes
+assuming that the extender already cached full details of all nodes in the cluster</td>
+</tr>
+    
+  
+<tr><td><code>managedResources</code><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ExtenderManagedResource"><code>[]ExtenderManagedResource</code></a>
+</td>
+<td>
+   ManagedResources is a list of extended resources that are managed by
+this extender.
+- A pod will be sent to the extender on the Filter, Prioritize and Bind
+  (if the extender is the binder) phases iff the pod requests at least
+  one of the extended resources in this list. If empty or unspecified,
+  all pods will be sent to this extender.
+- If IgnoredByScheduler is set to true for a resource, kube-scheduler
+  will skip checking the resource in predicates.</td>
+</tr>
+    
+  
+<tr><td><code>ignorable</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+fail when the extender returns an error or is not reachable.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PredicateArgument`     {#kubescheduler-config-k8s-io-v1-PredicateArgument}
+    
+
+
+
+**Appears in:**
+
+- [PredicatePolicy](#kubescheduler-config-k8s-io-v1-PredicatePolicy)
+
+
+PredicateArgument represents the arguments to configure predicate functions in scheduler policy configuration.
+Only one of its members may be specified
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>serviceAffinity</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ServiceAffinity"><code>ServiceAffinity</code></a>
+</td>
+<td>
+   The predicate that provides affinity for pods belonging to a service
+It uses a label to identify nodes that belong to the same "group"</td>
+</tr>
+    
+  
+<tr><td><code>labelsPresence</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-LabelsPresence"><code>LabelsPresence</code></a>
+</td>
+<td>
+   The predicate that checks whether a particular node has a certain label
+defined or not, regardless of value</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PredicatePolicy`     {#kubescheduler-config-k8s-io-v1-PredicatePolicy}
+    
+
+
+
+**Appears in:**
+
+- [Policy](#kubescheduler-config-k8s-io-v1-Policy)
+
+
+PredicatePolicy describes a struct of a predicate policy.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Identifier of the predicate policy
+For a custom predicate, the name can be user-defined
+For the Kubernetes provided predicates, the name is the identifier of the pre-defined predicate</td>
+</tr>
+    
+  
+<tr><td><code>argument</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PredicateArgument"><code>PredicateArgument</code></a>
+</td>
+<td>
+   Holds the parameters to configure the given predicate</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PriorityArgument`     {#kubescheduler-config-k8s-io-v1-PriorityArgument}
+    
+
+
+
+**Appears in:**
+
+- [PriorityPolicy](#kubescheduler-config-k8s-io-v1-PriorityPolicy)
+
+
+PriorityArgument represents the arguments to configure priority functions in scheduler policy configuration.
+Only one of its members may be specified
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>serviceAntiAffinity</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ServiceAntiAffinity"><code>ServiceAntiAffinity</code></a>
+</td>
+<td>
+   The priority function that ensures a good spread (anti-affinity) for pods belonging to a service
+It uses a label to identify nodes that belong to the same "group"</td>
+</tr>
+    
+  
+<tr><td><code>labelPreference</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-LabelPreference"><code>LabelPreference</code></a>
+</td>
+<td>
+   The priority function that checks whether a particular node has a certain label
+defined or not, regardless of value</td>
+</tr>
+    
+  
+<tr><td><code>requestedToCapacityRatioArguments</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments"><code>RequestedToCapacityRatioArguments</code></a>
+</td>
+<td>
+   The RequestedToCapacityRatio priority function is parametrized with function shape.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PriorityPolicy`     {#kubescheduler-config-k8s-io-v1-PriorityPolicy}
+    
+
+
+
+**Appears in:**
+
+- [Policy](#kubescheduler-config-k8s-io-v1-Policy)
+
+
+PriorityPolicy describes a struct of a priority policy.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Identifier of the priority policy
+For a custom priority, the name can be user-defined
+For the Kubernetes provided priority functions, the name is the identifier of the pre-defined priority function</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   The numeric multiplier for the node scores that the priority function generates
+The weight should be non-zero and can be a positive or a negative integer</td>
+</tr>
+    
+  
+<tr><td><code>argument</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-PriorityArgument"><code>PriorityArgument</code></a>
+</td>
+<td>
+   Holds the parameters to configure the given priority function</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `RequestedToCapacityRatioArguments`     {#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments}
+    
+
+
+
+**Appears in:**
+
+- [PriorityArgument](#kubescheduler-config-k8s-io-v1-PriorityArgument)
+
+
+RequestedToCapacityRatioArguments holds arguments specific to RequestedToCapacityRatio priority function.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>shape</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-UtilizationShapePoint"><code>[]UtilizationShapePoint</code></a>
+</td>
+<td>
+   Array of point defining priority function shape.</td>
+</tr>
+    
+  
+<tr><td><code>resources</code> <B>[Required]</B><br/>
+<a href="#kubescheduler-config-k8s-io-v1-ResourceSpec"><code>[]ResourceSpec</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ResourceSpec`     {#kubescheduler-config-k8s-io-v1-ResourceSpec}
+    
+
+
+
+**Appears in:**
+
+- [RequestedToCapacityRatioArguments](#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments)
+
+
+ResourceSpec represents single resource and weight for bin packing of priority RequestedToCapacityRatioArguments.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Name of the resource to be managed by RequestedToCapacityRatio function.</td>
+</tr>
+    
+  
+<tr><td><code>weight</code> <B>[Required]</B><br/>
+<code>int64</code>
+</td>
+<td>
+   Weight of the resource.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ServiceAffinity`     {#kubescheduler-config-k8s-io-v1-ServiceAffinity}
+    
+
+
+
+**Appears in:**
+
+- [PredicateArgument](#kubescheduler-config-k8s-io-v1-PredicateArgument)
+
+
+ServiceAffinity holds the parameters that are used to configure the corresponding predicate in scheduler policy configuration.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>labels</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   The list of labels that identify node "groups"
+All of the labels should match for the node to be considered a fit for hosting the pod</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ServiceAntiAffinity`     {#kubescheduler-config-k8s-io-v1-ServiceAntiAffinity}
+    
+
+
+
+**Appears in:**
+
+- [PriorityArgument](#kubescheduler-config-k8s-io-v1-PriorityArgument)
+
+
+ServiceAntiAffinity holds the parameters that are used to configure the corresponding priority function
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>label</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Used to identify node "groups"</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `UtilizationShapePoint`     {#kubescheduler-config-k8s-io-v1-UtilizationShapePoint}
+    
+
+
+
+**Appears in:**
+
+- [RequestedToCapacityRatioArguments](#kubescheduler-config-k8s-io-v1-RequestedToCapacityRatioArguments)
+
+
+UtilizationShapePoint represents single point of priority function shape.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>utilization</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.</td>
+</tr>
+    
+  
+<tr><td><code>score</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   Score assigned to given utilization (y axis). Valid values are 0 to 10.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/kubeadm-config.v1beta1.md
+++ b/genref/output/md/kubeadm-config.v1beta1.md
@@ -1,0 +1,1478 @@
+---
+title: kubeadm Configuration (v1beta1)
+content_type: tool-reference
+package: kubeadm.k8s.io/v1beta1
+auto_generated: true
+---
+&lowast;&lowast;Package v1beta1 has been deprecated by v1beta2&lowast;&lowast;
+
+Package v1beta1 defines the v1beta1 version of the kubeadm configuration file format.
+This version graduates the configuration format to BETA and is a big step towards GA.
+
+A list of changes since v1alpha3:
+
+- `apiServerEndpoint` in `InitConfiguration` was renamed to `localAPIEndpoint` for better clarity of what the field
+  represents.
+- Common fields in ClusterConfiguration such as `&lowast;extraArgs` and `&lowast;extraVolumes` for control plane components are now moved
+  under component structs - i.e. `apiServer`, `controllerManager`, `scheduler`.
+- `auditPolicy` was removed from ClusterConfiguration. Use `extraArgs` in `apiServer` to configure this feature instead.
+- `unifiedControlPlaneImage` in ClusterConfiguration was changed to a boolean field called `useHyperKubeImage`.
+- ClusterConfiguration now has a `dns` field which can be used to select and configure the cluster DNS addon.
+- `featureGates` still exists under ClusterConfiguration, but there are no supported feature gates in 1.13.
+  See the Kubernetes 1.13 changelog for further details.
+- Both `localEtcd` and `dns` configurations now support custom image repositories.
+- The `controlPlane&lowast;`-related fields in JoinConfiguration were refactored into a sub-structure.
+- `clusterName` was removed from JoinConfiguration and the name is now fetched from the existing cluster.
+
+&lowast;&lowast;Migration from old kubeadm config versions&lowast;&lowast;
+
+Please convert your v1alpha3 configuration files to v1beta1 using the `kubeadm config migrate` command of kubeadm v1.13.x
+
+&lowast;&lowast;Basics&lowast;&lowast;
+
+The preferred way to configure kubeadm is to pass an YAML configuration file with the `--config` option. Some of the
+configuration options defined in the kubeadm config file are also available as command line flags, but only
+the most common/simple use case are supported with this approach.
+
+A kubeadm config file could contain multiple configuration types separated using three dashes (`---`).
+
+kubeadm supports the following configuration types:
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+```
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+```
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+```
+```yaml
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+```
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: JoinConfiguration
+```
+
+To print the defaults for `init` and `join` actions use the following commands:
+
+```shell
+kubeadm config print init-defaults
+kubeadm config print join-defaults
+```
+
+The list of configuration types that must be included in a configuration file depends by the action you are
+performing (init or join) and by the configuration options you are going to use (defaults or advanced customization).
+
+If some configuration types are not provided, or provided only partially, kubeadm will use default values.
+Defaults provided by kubeadm help enforce consistency of values across components when required (e.g.
+`--cluster-cidr` flag on controller manager and `clusterCIDR` on kube-proxy).
+
+Users are always allowed to override default values, with the exception of a small subset of setting
+related to security (e.g. enforce authorization-mode Node and RBAC on the API server)
+If the user provides a configuration types that is not expected for the action you are performing,
+kubeadm will ignore those types and print a warning.
+
+&lowast;&lowast;Kubeadm init configuration types&lowast;&lowast;
+
+When executing `kubeadm init` with the `--config` option, the following configuration types could be used:
+`InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`, but only one
+between `InitConfiguration` and `ClusterConfiguration` is mandatory.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+bootstrapTokens:
+  # ...
+nodeRegistration:
+  # ...
+```
+
+The `InitConfiguration` type is used to configure runtime settings. In the case of `kubeadm init`,
+it contains the bootstrap token configuration and all the setting specific to the node where kubeadm
+is executed, including:
+
+- `NodeRegistration`: fields related to registering the new node to the cluster.
+  You can use it to customize the node name, the CRI socket to use or any other
+  settings that should apply to this node only (for example. the node IP).
+
+- `LocalAPIEndpoint`: the endpoint of the API server instance to be deployed on this node.
+  You can use it to customize the API server advertise address, for example.
+
+  ```yaml
+  apiVersion: kubeadm.k8s.io/v1beta1
+  kind: ClusterConfiguration
+  networking:
+    # ...
+  etcd:
+    # ...
+  apiServer:
+    extraArgs:
+      # ...
+    extraVolumes:
+      #  ...
+  # ...
+  ```
+
+The `ClusterConfiguration` type is used to configure cluster-wide settings, including:
+
+- Networking, holds configuration for the networking topology of the cluster.
+  For example, you can use it to customize node subnet or services subnet.
+
+- Etcd configurations that can be used to customize the local etcd or to configure
+  the API server for using an external etcd cluster.
+
+- kube-apiserver, kube-scheduler, kube-controller-manager configurations.
+  You can use it to customize control-plane components by adding customized setting
+  or overriding kubeadm default settings.
+
+```yaml
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+# ...
+```
+
+The `KubeProxyConfiguration` type should be used to change the configuration passed to
+kube-proxy instances deployed in the cluster. If this object is not provided or provided
+only partially, kubeadm applies defaults.
+See [kube-proxy reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) or
+[kube-proxy source code](https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration)
+for more information.
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# ...
+```
+
+The `KubeletConfiguration` type is used to change the configurations passed to all kubelet instances
+deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
+See [kubelet reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) or
+[kubelet source code](https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration)
+for more information.
+
+Here is a fully populated example of a single YAML file containing multiple
+configuration types to be used during a `kubeadm init` run.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+bootstrapTokens:
+- token: "9a08jv.c0izixklcxtmnze7"
+  description: "kubeadm bootstrap token"
+  ttl: "24h"
+- token: "783bde.3f89s0fje9f38fhf"
+  description: "another bootstrap token"
+  usages:
+  - authentication
+  - signing
+  groups:
+  - system:bootstrappers:kubeadm:default-node-token
+nodeRegistration:
+  name: "ec2-10-100-0-1"
+  criSocket: "/var/run/dockershim.sock"
+  taints:
+  - key: "kubeadmNode"
+    value: "master"
+    effect: "NoSchedule"
+  kubeletExtraArgs:
+    cgroup-driver: "cgroupfs"
+localAPIEndpoint:
+  advertiseAddress: "10.100.0.1"
+  bindPort: 6443
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+etcd:
+  # one of local or external
+  local:
+    imageRepository: "k8s.gcr.io"
+    imageTag: "3.2.24"
+    dataDir: "/var/lib/etcd"
+    extraArgs:
+      listen-client-urls: "http://10.100.0.1:2379"
+    serverCertSANs:
+    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
+    peerCertSANs:
+    - "10.100.0.1"
+  # external:
+    # endpoints:
+    # - "10.100.0.1:2379"
+    # - "10.100.0.2:2379"
+    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
+    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
+    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
+networking:
+  serviceSubnet: "10.96.0.0/12"
+  podSubnet: "10.100.0.1/24"
+  dnsDomain: "cluster.local"
+kubernetesVersion: "v1.12.0"
+controlPlaneEndpoint: "10.100.0.1:6443"
+apiServer:
+  extraArgs:
+    authorization-mode: "Node,RBAC"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+  certSANs:
+  - "10.100.1.1"
+  - "ec2-10-100-0-1.compute-1.amazonaws.com"
+  timeoutForControlPlane: 4m0s
+controllerManager:
+  extraArgs:
+    "node-cidr-mask-size": "20"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+scheduler:
+  extraArgs:
+    address: "10.100.0.1"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+certificatesDir: "/etc/kubernetes/pki"
+imageRepository: "k8s.gcr.io"
+useHyperKubeImage: false
+clusterName: "example-cluster"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# kubelet specific options here
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+# kube-proxy specific options here
+```
+
+&lowast;&lowast;Kubeadm join configuration types&lowast;&lowast;
+
+When executing `kubeadm join` with the `--config` option, the `JoinConfiguration` type should be provided.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: JoinConfiguration
+# ...
+```
+
+The `JoinConfiguration` type is used to configure runtime settings. In the case of `kubeadm join`,
+it contains the discovery method used for accessing the cluster info and all the setting which are specific
+to the node where kubeadm is executed, including:
+
+- `NodeRegistration`: fields related to registering the new node to the cluster.
+  You can use it to customize the node name, the CRI socket to use or any other
+  settings that should apply to this node only (e.g. the node ip).
+
+- `APIEndpoint`: the endpoint of the API server instance to be eventually deployed on this node.
+
+## Resource Types 
+
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta1-ClusterConfiguration)
+- [ClusterStatus](#kubeadm-k8s-io-v1beta1-ClusterStatus)
+- [InitConfiguration](#kubeadm-k8s-io-v1beta1-InitConfiguration)
+- [JoinConfiguration](#kubeadm-k8s-io-v1beta1-JoinConfiguration)
+  
+    
+
+
+## `ClusterConfiguration`     {#kubeadm-k8s-io-v1beta1-ClusterConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta1-InitConfiguration)
+
+
+DEPRECATED - This group version of ClusterConfiguration is deprecated by apis/kubeadm/v1beta2.ClusterConfiguration.
+ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ClusterConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>etcd</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-Etcd"><code>Etcd</code></a>
+</td>
+<td>
+   `etcd` holds configuration for etcd.</td>
+</tr>
+    
+  
+<tr><td><code>networking</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-Networking"><code>Networking</code></a>
+</td>
+<td>
+   `networking` holds configuration for the networking topology of the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>kubernetesVersion</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `kubernetesVersion` is the target version of the control plane.</td>
+</tr>
+    
+  
+<tr><td><code>controlPlaneEndpoint</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `controlPlaneEndpoint` sets a stable IP address or DNS name for the control plane.
+It can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+If `controlPlaneEndpoint` is not specified, the `advertiseAddress` + `bindPort`
+are used. If `controlPlaneEndpoint` is specified without a TCP port, the `bindPort` is used.
+Possible usages are:
+
+- In a cluster with more than one control plane nodes, this field should be
+  assigned the address of the external load balancer in front of the
+  control plane nodes.
+- In environments with enforced node recycling, the `controlPlaneEndpoint`
+  could be used for assigning a stable DNS to the control plane.</td>
+</tr>
+    
+  
+<tr><td><code>apiServer</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-APIServer"><code>APIServer</code></a>
+</td>
+<td>
+   `apiServer` contains extra settings for the API server.</td>
+</tr>
+    
+  
+<tr><td><code>controllerManager</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
+</td>
+<td>
+   `controllerManager` contains extra settings for the controller manager.</td>
+</tr>
+    
+  
+<tr><td><code>scheduler</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
+</td>
+<td>
+   `scheduler` contains extra settings for the scheduler.</td>
+</tr>
+    
+  
+<tr><td><code>dns</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-DNS"><code>DNS</code></a>
+</td>
+<td>
+   `dns` defines the options for the DNS add-on installed in the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>certificatesDir</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `certificatesDir` specifies where to store or look for all required certificates.</td>
+</tr>
+    
+  
+<tr><td><code>imageRepository</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `imageRepository` specifies the container registry from which images are pulled.
+If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
+`gcr.io/kubernetes-ci-images` will be used for control plane components and
+kube-proxy, while `k8s.gcr.io` will be used for all the other images.</td>
+</tr>
+    
+  
+<tr><td><code>useHyperKubeImage</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   `useHyperKubeImage` controls if hyperkube should be used for Kubernetes components
+instead of their respective separate images.
+DEPRECATED: As hyperkube is deprecated, this field is deprecated too.
+It will be removed in future kubeadm config versions. Kubeadm may print multiple
+warnings or ignore it when this is set to true.</td>
+</tr>
+    
+  
+<tr><td><code>featureGates</code> <B>[Required]</B><br/>
+<code>map[string]bool</code>
+</td>
+<td>
+   `featureGates` is a map containing the feature gates to be enabled.</td>
+</tr>
+    
+  
+<tr><td><code>clusterName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `clusterName` contains the cluster name.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ClusterStatus`     {#kubeadm-k8s-io-v1beta1-ClusterStatus}
+    
+
+
+
+
+ClusterStatus contains the cluster status. The ClusterStatus will be stored in the `kubeadm-config` ConfigMap in the
+cluster, and then updated by kubeadm when additional control plane nodes joins or leaves the cluster.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ClusterStatus</code></td></tr>
+    
+
+  
+  
+<tr><td><code>apiEndpoints</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-APIEndpoint"><code>map[string]github.com/tengqm/kubeconfig/config/kubeadm/v1beta1.APIEndpoint</code></a>
+</td>
+<td>
+   `apiEndpoints` contains a list of API endpoints currently available in the cluster,
+one for each control-plane or API server instance. The key of the map is the IP
+of the node's default interface.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `InitConfiguration`     {#kubeadm-k8s-io-v1beta1-InitConfiguration}
+    
+
+
+
+
+DEPRECATED - This group version of InitConfiguration is deprecated by apis/kubeadm/v1beta2.InitConfiguration.
+InitConfiguration contains runtime information that are specific to "kubeadm init".
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>InitConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-ClusterConfiguration"><code>ClusterConfiguration</code></a>
+</td>
+<td>
+   This field holds the cluster-wide information, and embeds that struct (which can be (un)marshalled separately as well)
+When InitConfiguration is marshalled to bytes in the external version, this information IS NOT preserved (which can be seen from
+the `json:"-"` tag. This is due to that when InitConfiguration is (un)marshalled, it turns into two YAML documents, one for the
+InitConfiguration and ClusterConfiguration. Hence, the information must not be duplicated, and is therefore omitted here.</td>
+</tr>
+    
+  
+<tr><td><code>bootstrapTokens</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-BootstrapToken"><code>[]BootstrapToken</code></a>
+</td>
+<td>
+   `bootstrapTokens` describes a set of Bootstrap Tokens to create during `kubeadm init`.
+This information is NOT uploaded to the `kubeadm-config` ConfigMap, partly because of its sensitive nature</td>
+</tr>
+    
+  
+<tr><td><code>nodeRegistration</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-NodeRegistrationOptions"><code>NodeRegistrationOptions</code></a>
+</td>
+<td>
+   `nodeRegistration` holds fields related to registering the new control-plane node to the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>localAPIEndpoint</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-APIEndpoint"><code>APIEndpoint</code></a>
+</td>
+<td>
+   `localAPIEndpoint` represents the endpoint of the API server instance that's deployed on this control plane
+instance.  In HA setups, this differs from `ClusterConfiguration.controlPlaneEndpoint` in the sense that
+`controlPlaneEndpoint` is the global endpoint for the cluster, which loadbalances the requests to each individual
+API server. This configuration object lets you customize what IP/DNS name and port on which the local API server
+is accessible. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in
+case that process fails you may set the desired value here.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `JoinConfiguration`     {#kubeadm-k8s-io-v1beta1-JoinConfiguration}
+    
+
+
+
+
+DEPRECATED - This group version of JoinConfiguration is deprecated by apis/kubeadm/v1beta2.JoinConfiguration.
+JoinConfiguration contains elements describing a particular node.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>JoinConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>nodeRegistration</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-NodeRegistrationOptions"><code>NodeRegistrationOptions</code></a>
+</td>
+<td>
+   `nodeRegistration` holds fields related to registering a new control-plane node to the cluster</td>
+</tr>
+    
+  
+<tr><td><code>caCertPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `caCertPath` is the path to the SSL certificate authority (CA) used to
+secure comunications between the node and the control-plane.
+Defaults to "/etc/kubernetes/pki/ca.crt".</td>
+</tr>
+    
+  
+<tr><td><code>discovery</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-Discovery"><code>Discovery</code></a>
+</td>
+<td>
+   `discovery` specifies the options for the kubelet to use during the TLS Bootstrap process.</td>
+</tr>
+    
+  
+<tr><td><code>controlPlane</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-JoinControlPlane"><code>JoinControlPlane</code></a>
+</td>
+<td>
+   `controlPlane` defines the additional control plane instance to be deployed on the joining node.
+If not specified, no additional control plane instance will be deployed.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `APIEndpoint`     {#kubeadm-k8s-io-v1beta1-APIEndpoint}
+    
+
+
+
+**Appears in:**
+
+- [ClusterStatus](#kubeadm-k8s-io-v1beta1-ClusterStatus)
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta1-InitConfiguration)
+
+- [JoinControlPlane](#kubeadm-k8s-io-v1beta1-JoinControlPlane)
+
+
+APIEndpoint struct contains elements of API server instance deployed on a node.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>advertiseAddress</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `advertiseAddress` sets the IP address for the API server to advertise.</td>
+</tr>
+    
+  
+<tr><td><code>bindPort</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   `bindPort` sets the secure port for the API Server to bind to. Defaults to 6443.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `APIServer`     {#kubeadm-k8s-io-v1beta1-APIServer}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta1-ClusterConfiguration)
+
+
+APIServer holds settings necessary for API server instances in the cluster
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ControlPlaneComponent</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
+</td>
+<td>(Members of <code>ControlPlaneComponent</code> are embedded into this type.)
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>certSANs</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `certSANs` sets extra Subject Alternative Names (SANs) for the API Server signing cert.</td>
+</tr>
+    
+  
+<tr><td><code>timeoutForControlPlane</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   `timeoutForControlPlane` controls the timeout that kubeadm waits for the API server to appear.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `BootstrapToken`     {#kubeadm-k8s-io-v1beta1-BootstrapToken}
+    
+
+
+
+**Appears in:**
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta1-InitConfiguration)
+
+
+BootstrapToken describes one bootstrap token, stored as a Secret in the cluster
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-BootstrapTokenString"><code>BootstrapTokenString</code></a>
+</td>
+<td>
+   `token` is used for establishing bidirectional trust between nodes and control-planes.
+Used for joining nodes in the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>description</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `description` contains a human-friendly message why this token exists and what it's used
+for, so other administrators can know its purpose.</td>
+</tr>
+    
+  
+<tr><td><code>ttl</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   `ttl`  defines the time to live (TTL) for this token. Defaults to `24h`.
+The `expires` field and the `ttl` field are mutually exclusive.</td>
+</tr>
+    
+  
+<tr><td><code>expires</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   `expires` specifies the timestamp when this token expires. Defaults to being set
+dynamically at runtime based on the `ttl`. The `expires` field and the `ttl` field are
+mutually exclusive.</td>
+</tr>
+    
+  
+<tr><td><code>usages</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `usages` describes the ways in which this token can be used. Can by default be used
+for establishing bidirectional trust, but that can be changed here.</td>
+</tr>
+    
+  
+<tr><td><code>groups</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `groups` specifies the extra groups that this token will authenticate as when/if
+used for authentication.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `BootstrapTokenDiscovery`     {#kubeadm-k8s-io-v1beta1-BootstrapTokenDiscovery}
+    
+
+
+
+**Appears in:**
+
+- [Discovery](#kubeadm-k8s-io-v1beta1-Discovery)
+
+
+BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `token` is a token used to validate cluster information fetched from the control-plane.</td>
+</tr>
+    
+  
+<tr><td><code>apiServerEndpoint</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `apiServerEndpoint` is an IP or domain name for the API server from which info will be fetched.</td>
+</tr>
+    
+  
+<tr><td><code>caCertHashes</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `caCertHashes` specifies a set of public key pins to verify when token-based discovery is used.
+The root CA found during discovery must match one of these values. Specifying an empty set disables
+root CA pinning, which can be unsafe. Each hash is specified as `<type>:<value>`, where the only
+type currently supported is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key
+Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL.</td>
+</tr>
+    
+  
+<tr><td><code>unsafeSkipCAVerification</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   `unsafeSkipCAVerification` allows token-based discovery without CA verification via `caCertHashes`.
+This can weaken the kubeadm security since other nodes can impersonate the control-plane.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `BootstrapTokenString`     {#kubeadm-k8s-io-v1beta1-BootstrapTokenString}
+    
+
+
+
+**Appears in:**
+
+- [BootstrapToken](#kubeadm-k8s-io-v1beta1-BootstrapToken)
+
+
+DEPRECATED - This group version of BootstrapTokenString is deprecated by apis/kubeadm/v1beta2/BootstrapTokenString.
+BootstrapTokenString is a token of the format abcdef.abcdef0123456789 that is used
+for both validation of the practically of the API server from a joining node's point
+of view and as an authentication method for the node in the bootstrap phase of
+"kubeadm join". This token is and should be short-lived
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ControlPlaneComponent`     {#kubeadm-k8s-io-v1beta1-ControlPlaneComponent}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta1-ClusterConfiguration)
+
+- [APIServer](#kubeadm-k8s-io-v1beta1-APIServer)
+
+
+ControlPlaneComponent holds settings common to control plane component of the cluster
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>extraArgs</code> <B>[Required]</B><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   `extraArgs` is an extra set of flags to pass to the control plane components.
+TODO: This is temporary and ideally we would like to switch all components to
+use ComponentConfig + ConfigMaps.</td>
+</tr>
+    
+  
+<tr><td><code>extraVolumes</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-HostPathMount"><code>[]HostPathMount</code></a>
+</td>
+<td>
+   `extraVolumes` is an extra set of HostPath volumes to be mounted by the control plane component.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `DNS`     {#kubeadm-k8s-io-v1beta1-DNS}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta1-ClusterConfiguration)
+
+
+DNS defines the DNS add-on that should be used in the cluster
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>type</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-DNSAddOnType"><code>DNSAddOnType</code></a>
+</td>
+<td>
+   `type` defines the DNS add-on to be used. Can be one of "CoreDNS" or "kube-dns".</td>
+</tr>
+    
+  
+<tr><td><code>ImageMeta</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-ImageMeta"><code>ImageMeta</code></a>
+</td>
+<td>(Members of <code>ImageMeta</code> are embedded into this type.)
+   `imageMeta` is used to customize the image used for the DNS add-on.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `DNSAddOnType`     {#kubeadm-k8s-io-v1beta1-DNSAddOnType}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [DNS](#kubeadm-k8s-io-v1beta1-DNS)
+
+
+DNSAddOnType defines string identifying DNS add-on types.
+
+
+    
+
+
+## `Discovery`     {#kubeadm-k8s-io-v1beta1-Discovery}
+    
+
+
+
+**Appears in:**
+
+- [JoinConfiguration](#kubeadm-k8s-io-v1beta1-JoinConfiguration)
+
+
+Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>bootstrapToken</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-BootstrapTokenDiscovery"><code>BootstrapTokenDiscovery</code></a>
+</td>
+<td>
+   `bootstrapToken` is used to set the options for bootstrap token based discovery.
+The `bootstrapToken` field and the `file` field are mutually exclusive.</td>
+</tr>
+    
+  
+<tr><td><code>file</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-FileDiscovery"><code>FileDiscovery</code></a>
+</td>
+<td>
+   `file` is used to specify a file or URL to a kubeconfig file from which to load cluster information.
+The `bootstrapToken` field and the `file` field are mutually exclusive.</td>
+</tr>
+    
+  
+<tr><td><code>tlsBootstrapToken</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `tlsBootstrapToken` is a token used for TLS bootstrapping.
+If `bootstrapToken` is set, this field is defaulted to `.bootstrapToken.token`, but can be overridden.
+If `file` is set, this field &lowast;&lowast;must be set&lowast;&lowast; in case the KubeConfigFile does not contain any other
+authentication information.</td>
+</tr>
+    
+  
+<tr><td><code>timeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   `timeout` is used to customize timeout period for the discovery.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Etcd`     {#kubeadm-k8s-io-v1beta1-Etcd}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta1-ClusterConfiguration)
+
+
+Etcd contains elements describing Etcd configuration.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>local</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-LocalEtcd"><code>LocalEtcd</code></a>
+</td>
+<td>
+   `local` provides configurations for the local etcd instance.
+The `local` field and the `external` field are mutually exclusive.</td>
+</tr>
+    
+  
+<tr><td><code>external</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-ExternalEtcd"><code>ExternalEtcd</code></a>
+</td>
+<td>
+   `external` describes how to connect to an external etcd service.
+The `local` field and the `external` field are mutually exclusive.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExternalEtcd`     {#kubeadm-k8s-io-v1beta1-ExternalEtcd}
+    
+
+
+
+**Appears in:**
+
+- [Etcd](#kubeadm-k8s-io-v1beta1-Etcd)
+
+
+ExternalEtcd describes an external etcd cluster.
+Kubeadm has no knowledge of where certificate files live and they must be supplied.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>endpoints</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `endpoints` contains a list of etcd members. This field is required.</td>
+</tr>
+    
+  
+<tr><td><code>caFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `caFile` is an SSL Certificate Authority (CA) file used to secure etcd communication.
+Required if using a TLS connection.</td>
+</tr>
+    
+  
+<tr><td><code>certFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `certFile` is an SSL certification file used to secure etcd communication.
+Required if using a TLS connection.</td>
+</tr>
+    
+  
+<tr><td><code>keyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `keyFile` is an SSL key file used to secure etcd communication.
+Required if using a TLS connection.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `FileDiscovery`     {#kubeadm-k8s-io-v1beta1-FileDiscovery}
+    
+
+
+
+**Appears in:**
+
+- [Discovery](#kubeadm-k8s-io-v1beta1-Discovery)
+
+
+FileDiscovery is used to specify a file or a URL to a kubeconfig file from which to load cluster information.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>kubeConfigPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `kubeConfigPath` is used to specify the file path or a URL to the kubeconfig file from which
+to load cluster information</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `HostPathMount`     {#kubeadm-k8s-io-v1beta1-HostPathMount}
+    
+
+
+
+**Appears in:**
+
+- [ControlPlaneComponent](#kubeadm-k8s-io-v1beta1-ControlPlaneComponent)
+
+
+HostPathMount contains elements describing volumes that are mounted from the host.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `name` is the name of the volume inside the Pod template.</td>
+</tr>
+    
+  
+<tr><td><code>hostPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `hostPath` is the path on the host that will be mounted inside the Pod.</td>
+</tr>
+    
+  
+<tr><td><code>mountPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `mountPath` is the path inside the Pod where `hostPath` will be mounted.</td>
+</tr>
+    
+  
+<tr><td><code>readOnly</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   `readOnly` indicates whether the volume is mounted in read-only mode.</td>
+</tr>
+    
+  
+<tr><td><code>pathType</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
+</td>
+<td>
+   `pathType` is the type of the HostPath, for example, "DirectoryOrCreate", "File", etc.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ImageMeta`     {#kubeadm-k8s-io-v1beta1-ImageMeta}
+    
+
+
+
+**Appears in:**
+
+- [DNS](#kubeadm-k8s-io-v1beta1-DNS)
+
+- [LocalEtcd](#kubeadm-k8s-io-v1beta1-LocalEtcd)
+
+
+ImageMeta allows to customize the image used for components that are not
+originated from the Kubernetes/Kubernetes release process
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>imageRepository</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `imageRepository` sets the container registry to pull images from.
+If not set, the `imageRepository` defined in ClusterConfiguration will be used instead.</td>
+</tr>
+    
+  
+<tr><td><code>imageTag</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `imageTag` allows for specifying a tag for the image.
+When this value is set, kubeadm does not automatically change the version
+of the above components during upgrades.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `JoinControlPlane`     {#kubeadm-k8s-io-v1beta1-JoinControlPlane}
+    
+
+
+
+**Appears in:**
+
+- [JoinConfiguration](#kubeadm-k8s-io-v1beta1-JoinConfiguration)
+
+
+JoinControlPlane contains elements describing an additional control plane instance to be deployed on the joining node.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>localAPIEndpoint</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-APIEndpoint"><code>APIEndpoint</code></a>
+</td>
+<td>
+   `localAPIEndpoint` represents the endpoint of the API server instance to be deployed on this node.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LocalEtcd`     {#kubeadm-k8s-io-v1beta1-LocalEtcd}
+    
+
+
+
+**Appears in:**
+
+- [Etcd](#kubeadm-k8s-io-v1beta1-Etcd)
+
+
+LocalEtcd describes that kubeadm should run an etcd cluster locally
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ImageMeta</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta1-ImageMeta"><code>ImageMeta</code></a>
+</td>
+<td>(Members of <code>ImageMeta</code> are embedded into this type.)
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>dataDir</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `dataDir` is the directory for etcd to place its data. Defaults to "/var/lib/etcd".</td>
+</tr>
+    
+  
+<tr><td><code>extraArgs</code> <B>[Required]</B><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   `extraArgs` are extra arguments provided to the etcd binary when run inside a static pod.</td>
+</tr>
+    
+  
+<tr><td><code>serverCertSANs</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `serverCertSANs` sets extra Subject Alternative Names (SANs) for the etcd server signing cert.</td>
+</tr>
+    
+  
+<tr><td><code>peerCertSANs</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `peerCertSANs` sets extra Subject Alternative Names (SANs) for the etcd peer signing cert.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Networking`     {#kubeadm-k8s-io-v1beta1-Networking}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta1-ClusterConfiguration)
+
+
+Networking contains elements describing cluster's networking configuration
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>serviceSubnet</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `serviceSubnet` is the subnet used by Services. Defaults to "10.96.0.0/12".</td>
+</tr>
+    
+  
+<tr><td><code>podSubnet</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `podSubnet` is the subnet used by Pods.</td>
+</tr>
+    
+  
+<tr><td><code>dnsDomain</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `dnsDomain` is the DNS domain used by Services. Defaults to "cluster.local".</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeRegistrationOptions`     {#kubeadm-k8s-io-v1beta1-NodeRegistrationOptions}
+    
+
+
+
+**Appears in:**
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta1-InitConfiguration)
+
+- [JoinConfiguration](#kubeadm-k8s-io-v1beta1-JoinConfiguration)
+
+
+NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either via "kubeadm init" or "kubeadm join"
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `name` is the `.metadata.name` field of the Node API object that will be created in this `kubeadm init` or
+`kubeadm join` operation. This field is also used in the CommonName field of the kubelet's
+client certificate to the API server. Defaults to the hostname of the node.</td>
+</tr>
+    
+  
+<tr><td><code>criSocket</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `criSocket` is used to retrieve container runtime information. This information will be
+annotated to the Node API object, for later re-use.</td>
+</tr>
+    
+  
+<tr><td><code>taints</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#taint-v1-core"><code>[]core/v1.Taint</code></a>
+</td>
+<td>
+   `taints` specifies the taints the Node API object should be registered with. If this field is not set, i.e. nil,
+it will be defaulted to `['node-role.kubernetes.io/master=""']` during `kubeadm init`.
+If you don't want to taint your control-plane node, set this field to an empty list (`[]`).
+This field is only used for node registration.</td>
+</tr>
+    
+  
+<tr><td><code>kubeletExtraArgs</code> <B>[Required]</B><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   `kubeletExtraArgs` contains extra arguments to pass to the kubelet. Kubeadm writes these arguments into an
+environment file for the kubelet to source.
+This overrides the generic base-level configuration in the `kubelet-config-1.x` ConfigMap
+Command line flags have higher priority when parsing.
+These values are local and specific to the node kubeadm is executing on.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/kubeadm-config.v1beta2.md
+++ b/genref/output/md/kubeadm-config.v1beta2.md
@@ -1,0 +1,1509 @@
+---
+title: kubeadm Configuration (v1beta2)
+content_type: tool-reference
+package: kubeadm.k8s.io/v1beta2
+auto_generated: true
+---
+Package v1beta2 defines the v1beta2 version of the kubeadm configuration file format.
+This version improves on the v1beta1 format by fixing some minor issues and adding a few new fields.
+
+A list of changes since v1beta1:
+
+- `certificateKey` field is added to `InitConfiguration` and `JoinConfiguration`.
+- `ignorePreflightErrors` field is added to the `NodeRegistrationOptions`.
+- The JSON `omitempty` tag is used in more places where appropriate.
+- The JSON `omitempty` tag of the "taints" field (in `NodeRegistrationOptions`) is removed.
+
+See the Kubernetes 1.15 changelog for further details.
+
+&lowast;&lowast;Migration from old kubeadm config versions&lowast;&lowast;
+
+Please convert your v1beta1 configuration files to v1beta2 using the `kubeadm config migrate` command of kubeadm
+v1.15.x. kubeadm v1.15.x supports reading from v1beta1 version of the kubeadm config file format.
+
+&lowast;&lowast;Basics&lowast;&lowast;
+
+The preferred way to configure kubeadm is to pass an YAML configuration file with the `--config` option. Some of the
+configuration options defined in the kubeadm config file are also available as command line flags, but only
+the most common/simple use case are supported with this approach.
+
+A kubeadm config file could contain multiple configuration types separated using three dashes (`---`).
+
+kubeadm supports the following configuration types:
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+```
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+```
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+```
+```yaml
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+```
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+```
+
+To print the defaults for `init` and `join` actions use the following commands:
+
+```shell
+kubeadm config print init-defaults
+kubeadm config print join-defaults
+```
+
+The list of configuration types that must be included in a configuration file depends by the action you are
+performing (`init` or `join`) and by the configuration options you are going to use (defaults or advanced customization).
+
+If some configuration types are not provided, or provided only partially, kubeadm will use default values.
+Defaults provided by kubeadm help enforce consistency of values across components when required (e.g.
+`--cluster-cidr` flag on controller manager and `clusterCIDR` on kube-proxy).
+
+Users are always allowed to override default values, with the only exception of a small subset of setting
+related to security (e.g. enforce authorization-mode Node and RBAC on the API server)
+If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
+ignore those types and print a warning.
+
+&lowast;&lowast;Kubeadm init configuration types&lowast;&lowast;
+
+When executing kubeadm init with the `--config` option, the following configuration types could be used:
+`InitConfiguration`, `ClusterConfiguration`, `KubeProxyConfiguration`, `KubeletConfiguration`, but only one
+between `InitConfiguration` and `ClusterConfiguration` is mandatory.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+bootstrapTokens:
+  # ...
+nodeRegistration:
+  # ...
+```
+
+The `InitConfiguration` type is used to configure runtime settings. In the case of `kubeadm init`,
+it includes the configuration of the bootstrap token and all the setting specific to the node
+where kubeadm is executed, including:
+
+- `nodeRegistration`: fields that relate to registering the new node to the cluster.
+  You can use it to customize the node name, the CRI socket to use or any other
+  settings that should apply to this node only (for example. the node IP).
+
+- `localAPIEndpoint`: the endpoint of the API server instance to be deployed on this node.
+  For example, you can use it to customize the API server advertise address.
+
+  ```yaml
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: ClusterConfiguration
+  networking:
+    # ...
+  etcd:
+    # ...
+  apiServer:
+    extraArgs:
+      # ...
+    extraVolumes:
+      # ...
+  # ...
+  ```
+
+The `ClusterConfiguration` type can be used to configure cluster-wide settings, including:
+
+- Networking, that holds configuration for the networking topology of the cluster;
+  For example, uou can use it to customize node subnet or services subnet.
+
+- Etcd configurations that can be used for customizing the local etcd or to configure
+  the API server for using an external etcd cluster.
+
+- kube-apiserver, kube-scheduler, kube-controller-manager configurations.
+  You can use it to customize control-plane components by adding customized setting
+  or overriding kubeadm default settings.
+
+```yaml
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+# ...
+```
+
+The `KubeProxyConfiguration` type is used to change the configurations passed to the kube-proxy
+instances deployed in the cluster. If this object is not provided or provided only partially,
+kubeadm applies defaults.
+See [kube-proxy reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)
+or [kube-proxy source code](https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration)
+for the official documentation.
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# ...
+```
+
+The `KubeletConfiguration` type is used to change the configurations passed to all kubelet instances
+deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
+See [kubelet reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) or
+[kubelet source code](https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration)
+for the official documentation.
+
+Here is a fully populated example of a single YAML file containing multiple
+configuration types to be used during a `kubeadm init` run.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+bootstrapTokens:
+- token: "9a08jv.c0izixklcxtmnze7"
+  description: "kubeadm bootstrap token"
+  ttl: "24h"
+- token: "783bde.3f89s0fje9f38fhf"
+  description: "another bootstrap token"
+  usages:
+  - authentication
+  - signing
+  groups:
+  - system:bootstrappers:kubeadm:default-node-token
+nodeRegistration:
+  name: "ec2-10-100-0-1"
+  criSocket: "/var/run/dockershim.sock"
+  taints:
+  - key: "kubeadmNode"
+    value: "master"
+    effect: "NoSchedule"
+  kubeletExtraArgs:
+    cgroup-driver: "cgroupfs"
+  ignorePreflightErrors:
+  - IsPrivilegedUser
+localAPIEndpoint:
+  advertiseAddress: "10.100.0.1"
+  bindPort: 6443
+certificateKey: "e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204"
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+etcd:
+  # one of local or external
+  local:
+    imageRepository: "k8s.gcr.io"
+    imageTag: "3.2.24"
+    dataDir: "/var/lib/etcd"
+    extraArgs:
+      listen-client-urls: "http://10.100.0.1:2379"
+    serverCertSANs:
+    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
+    peerCertSANs:
+    - "10.100.0.1"
+  # external:
+    # endpoints:
+    # - "10.100.0.1:2379"
+    # - "10.100.0.2:2379"
+    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
+    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
+    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
+networking:
+  serviceSubnet: "10.96.0.0/12"
+  podSubnet: "10.100.0.1/24"
+  dnsDomain: "cluster.local"
+kubernetesVersion: "v1.12.0"
+controlPlaneEndpoint: "10.100.0.1:6443"
+apiServer:
+  extraArgs:
+    authorization-mode: "Node,RBAC"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+  certSANs:
+  - "10.100.1.1"
+  - "ec2-10-100-0-1.compute-1.amazonaws.com"
+  timeoutForControlPlane: 4m0s
+controllerManager:
+  extraArgs:
+    "node-cidr-mask-size": "20"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+scheduler:
+  extraArgs:
+    address: "10.100.0.1"
+  extraVolumes:
+  - name: "some-volume"
+    hostPath: "/etc/some-path"
+    mountPath: "/etc/some-pod-path"
+    readOnly: false
+    pathType: File
+certificatesDir: "/etc/kubernetes/pki"
+imageRepository: "k8s.gcr.io"
+useHyperKubeImage: false
+clusterName: "example-cluster"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# kubelet specific options here
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+# kube-proxy specific options here
+```
+
+&lowast;&lowast;Kubeadm join configuration types&lowast;&lowast;
+
+When executing `kubeadm join` with the `--config` option, the `JoinConfiguration` type should be provided.
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: JoinConfiguration
+# ...
+```
+
+The `JoinConfiguration` type is used to configure runtime settings. In the case of `kubeadm join`,
+it contains the discovery method used for accessing the cluster info and all the setting which are specific
+to the node where kubeadm is executed, including:
+
+- `nodeRegistration`: fields related to registering the new node to the cluster.
+  You can use it to customize the node name, the CRI socket to use or any other settings that should
+  apply to this node only (e.g. the node ip).
+
+- `apiEndpoint`: the endpoint of the API server instance to be eventually deployed on this node.
+
+## Resource Types 
+
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
+- [ClusterStatus](#kubeadm-k8s-io-v1beta2-ClusterStatus)
+- [InitConfiguration](#kubeadm-k8s-io-v1beta2-InitConfiguration)
+- [JoinConfiguration](#kubeadm-k8s-io-v1beta2-JoinConfiguration)
+  
+    
+
+
+## `ClusterConfiguration`     {#kubeadm-k8s-io-v1beta2-ClusterConfiguration}
+    
+
+
+
+
+ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ClusterConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>etcd</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-Etcd"><code>Etcd</code></a>
+</td>
+<td>
+   `etcd` holds configuration for etcd.</td>
+</tr>
+    
+  
+<tr><td><code>networking</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-Networking"><code>Networking</code></a>
+</td>
+<td>
+   `networking` holds configuration for the networking topology of the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>kubernetesVersion</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `kubernetesVersion` is the target version of the control plane.</td>
+</tr>
+    
+  
+<tr><td><code>controlPlaneEndpoint</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `controlPlaneEndpoint` sets a stable IP address or DNS name for the control plane.
+It can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+If `controlPlaneEndpoint` is not specified, the `advertiseAddress` + `bindPort`
+are used. If `controlPlaneEndpoint` is specified without a TCP port, the `bindPort` is used.
+Possible usages are:
+
+- In a cluster with more than one control plane nodes, this field should be
+  assigned the address of the external load balancer in front of the
+  control plane nodes.
+- In environments with enforced node recycling, the `controlPlaneEndpoint`
+  could be used for assigning a stable DNS to the control plane.</td>
+</tr>
+    
+  
+<tr><td><code>apiServer</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-APIServer"><code>APIServer</code></a>
+</td>
+<td>
+   `apiServer` contains extra settings for the API server.</td>
+</tr>
+    
+  
+<tr><td><code>controllerManager</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
+</td>
+<td>
+   `controllerManager` contains extra settings for the controller manager.</td>
+</tr>
+    
+  
+<tr><td><code>scheduler</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
+</td>
+<td>
+   `scheduler` contains extra settings for the scheduler.</td>
+</tr>
+    
+  
+<tr><td><code>dns</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-DNS"><code>DNS</code></a>
+</td>
+<td>
+   `dns` defines the options for the DNS add-on installed in the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>certificatesDir</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `certificatesDir` specifies where to store or look for all required certificates.
+The value must be an absolute path.</td>
+</tr>
+    
+  
+<tr><td><code>imageRepository</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `imageRepository` specifies the container registry from which images are pulled.
+If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
+`gcr.io/kubernetes-ci-images` will be used for control plane components and
+kube-proxy, while `k8s.gcr.io` will be used for all the other images.</td>
+</tr>
+    
+  
+<tr><td><code>useHyperKubeImage</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   `useHyperKubeImage` controls if hyperkube should be used for Kubernetes components
+instead of their respective separate images.
+DEPRECATED: As hyperkube is deprecated, this field is deprecated too.
+It will be removed in future kubeadm config versions. Kubeadm may print multiple
+warnings or ignore it when this is set to true.</td>
+</tr>
+    
+  
+<tr><td><code>featureGates</code> <B>[Required]</B><br/>
+<code>map[string]bool</code>
+</td>
+<td>
+   `featureGates` is a map containing the feature gates to be enabled.</td>
+</tr>
+    
+  
+<tr><td><code>clusterName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `clusterName` contains the cluster name.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ClusterStatus`     {#kubeadm-k8s-io-v1beta2-ClusterStatus}
+    
+
+
+
+
+ClusterStatus contains the cluster status. The ClusterStatus will be stored in the `kubeadm-config` ConfigMap in the
+cluster, and then updated by kubeadm when additional control plane nodes joins or leaves the cluster.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ClusterStatus</code></td></tr>
+    
+
+  
+  
+<tr><td><code>apiEndpoints</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-APIEndpoint"><code>map[string]github.com/tengqm/kubeconfig/config/kubeadm/v1beta2.APIEndpoint</code></a>
+</td>
+<td>
+   `apiEndpoints` contains a list of API endpoints currently available in the cluster,
+one for each control-plane or API server instance. The key of the map is the IP
+of the node's default interface.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `InitConfiguration`     {#kubeadm-k8s-io-v1beta2-InitConfiguration}
+    
+
+
+
+
+InitConfiguration contains runtime information that are specific to "kubeadm init".
+These information are only used the first time `kubeadm init` runs.
+After that, the information in the fields IS NOT uploaded to the `kubeadm-config` ConfigMap
+that is used by `kubeadm upgrade` for instance. These fields must be optional.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>InitConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>bootstrapTokens</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-BootstrapToken"><code>[]BootstrapToken</code></a>
+</td>
+<td>
+   `bootstrapTokens` describes a set of Bootstrap Tokens to create during `kubeadm init`.
+This information is NOT uploaded to the `kubeadm-config` ConfigMap, partly because of its sensitive nature.</td>
+</tr>
+    
+  
+<tr><td><code>nodeRegistration</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-NodeRegistrationOptions"><code>NodeRegistrationOptions</code></a>
+</td>
+<td>
+   `nodeRegistration` holds fields related to registering the new control-plane node to the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>localAPIEndpoint</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-APIEndpoint"><code>APIEndpoint</code></a>
+</td>
+<td>
+   `localAPIEndpoint` represents the endpoint of the API server instance that's deployed on this control plane node.
+In HA setups, this differs from `ClusterConfiguration.controlPlaneEndpoint` in the sense that
+`controlPlaneEndpoint` is the global endpoint for the cluster, which loadbalances the requests to each individual
+API server. This configuration object lets you customize what IP/DNS name and port on which the local API server
+is accessible.  By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in
+case that process fails you may set the desired value here.</td>
+</tr>
+    
+  
+<tr><td><code>certificateKey</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `certificateKey` sets the key with which certificates and keys are encrypted prior to being uploaded in
+a secret in the cluster during the uploadcerts init phase.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `JoinConfiguration`     {#kubeadm-k8s-io-v1beta2-JoinConfiguration}
+    
+
+
+
+
+JoinConfiguration contains elements describing a particular node.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta2</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>JoinConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>nodeRegistration</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-NodeRegistrationOptions"><code>NodeRegistrationOptions</code></a>
+</td>
+<td>
+   `nodeRegistration` holds fields related to registering a new control-plane node to the cluster</td>
+</tr>
+    
+  
+<tr><td><code>caCertPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `caCertPath` is the path to the SSL certificate authority (CA) used to
+secure comunications between the node and the control-plane.
+Defaults to "/etc/kubernetes/pki/ca.crt".</td>
+</tr>
+    
+  
+<tr><td><code>discovery</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-Discovery"><code>Discovery</code></a>
+</td>
+<td>
+   `discovery` specifies the options for the kubelet to use during the TLS Bootstrap process.</td>
+</tr>
+    
+  
+<tr><td><code>controlPlane</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-JoinControlPlane"><code>JoinControlPlane</code></a>
+</td>
+<td>
+   `controlPlane` defines the additional control plane instance to be deployed on the joining node.
+If not specified, no additional control plane instance will be deployed.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `APIEndpoint`     {#kubeadm-k8s-io-v1beta2-APIEndpoint}
+    
+
+
+
+**Appears in:**
+
+- [ClusterStatus](#kubeadm-k8s-io-v1beta2-ClusterStatus)
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta2-InitConfiguration)
+
+- [JoinControlPlane](#kubeadm-k8s-io-v1beta2-JoinControlPlane)
+
+
+APIEndpoint struct contains elements of API server instance deployed on a node.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>advertiseAddress</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `advertiseAddress` sets the IP address for the API server to advertise.</td>
+</tr>
+    
+  
+<tr><td><code>bindPort</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   `bindPort` sets the secure port for the API Server to bind to. Defaults to 6443.
+The value must be greater or equal to 1, while less than or equal to 65535.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `APIServer`     {#kubeadm-k8s-io-v1beta2-APIServer}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
+
+
+APIServer holds settings necessary for API server instances in the cluster.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ControlPlaneComponent</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
+</td>
+<td>(Members of <code>ControlPlaneComponent</code> are embedded into this type.)
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>certSANs</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `certSANs` sets extra Subject Alternative Names (SANs) for the API Server signing cert.</td>
+</tr>
+    
+  
+<tr><td><code>timeoutForControlPlane</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   `timeoutForControlPlane` controls the timeout that kubeadm waits for the API server to appear.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `BootstrapToken`     {#kubeadm-k8s-io-v1beta2-BootstrapToken}
+    
+
+
+
+**Appears in:**
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta2-InitConfiguration)
+
+
+BootstrapToken describes a bootstrap token that is stored as a Secret in the cluster
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-BootstrapTokenString"><code>BootstrapTokenString</code></a>
+</td>
+<td>
+   `token` is used for establishing bidirectional trust between nodes and control-planes.
+Used for joining nodes in the cluster.</td>
+</tr>
+    
+  
+<tr><td><code>description</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `description` contains a human-friendly message why this token exists and what it's used
+for, so other administrators can know its purpose.</td>
+</tr>
+    
+  
+<tr><td><code>ttl</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   `ttl`  defines the time to live (TTL) for this token. Defaults to `24h`.
+The `expires` field and the `ttl` field are mutually exclusive.</td>
+</tr>
+    
+  
+<tr><td><code>expires</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   `expires` specifies the timestamp when this token expires. Defaults to being set
+dynamically at runtime based on the `ttl`. The `expires` field and the `ttl` field are
+mutually exclusive.</td>
+</tr>
+    
+  
+<tr><td><code>usages</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `usages` describes the ways in which this token can be used. Can by default be used
+for establishing bidirectional trust, but that can be changed here.</td>
+</tr>
+    
+  
+<tr><td><code>groups</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `groups` specifies the extra groups that this token will authenticate as when/if
+used for authentication. This field can be specified only when `usages` contains
+"authentication".</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `BootstrapTokenDiscovery`     {#kubeadm-k8s-io-v1beta2-BootstrapTokenDiscovery}
+    
+
+
+
+**Appears in:**
+
+- [Discovery](#kubeadm-k8s-io-v1beta2-Discovery)
+
+
+BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `token` is a token used to validate cluster information fetched from the control-plane.</td>
+</tr>
+    
+  
+<tr><td><code>apiServerEndpoint</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `apiServerEndpoint` is an IP or domain name for the API server from which info will be fetched.
+This field is required.</td>
+</tr>
+    
+  
+<tr><td><code>caCertHashes</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `caCertHashes` specifies a set of public key pins to verify when token-based discovery is used.
+The root CA found during discovery must match one of these values. Specifying an empty set disables
+root CA pinning, which can be unsafe. Each hash is specified as `<type>:<value>`, where the only
+type currently supported is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key
+Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL.</td>
+</tr>
+    
+  
+<tr><td><code>unsafeSkipCAVerification</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   `unsafeSkipCAVerification` allows token-based discovery without CA verification via `caCertHashes`.
+This can weaken the kubeadm security since other nodes can impersonate the control-plane.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `BootstrapTokenString`     {#kubeadm-k8s-io-v1beta2-BootstrapTokenString}
+    
+
+
+
+**Appears in:**
+
+- [BootstrapToken](#kubeadm-k8s-io-v1beta2-BootstrapToken)
+
+
+BootstrapTokenString is a token of the format abcdef.abcdef0123456789 that is used
+for both validation of the practically of the API server from a joining node's point
+of view and as an authentication method for the node in the bootstrap phase of
+"kubeadm join". This token is and should be short-lived
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>-</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ControlPlaneComponent`     {#kubeadm-k8s-io-v1beta2-ControlPlaneComponent}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
+
+- [APIServer](#kubeadm-k8s-io-v1beta2-APIServer)
+
+
+ControlPlaneComponent holds settings common to control plane component for the cluster
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>extraArgs</code> <B>[Required]</B><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   `extraArgs` is an extra set of flags to pass to the control plane components.
+TODO: This is temporary and ideally we would like to switch all components to
+use ComponentConfig + ConfigMaps.</td>
+</tr>
+    
+  
+<tr><td><code>extraVolumes</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-HostPathMount"><code>[]HostPathMount</code></a>
+</td>
+<td>
+   `extraVolumes` is an extra set of HostPath volumes to be mounted by the control plane component.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `DNS`     {#kubeadm-k8s-io-v1beta2-DNS}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
+
+
+DNS defines the DNS add-on that should be used in the cluster
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>type</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-DNSAddOnType"><code>DNSAddOnType</code></a>
+</td>
+<td>
+   `type` defines the DNS add-on to be used. Can be one of "CoreDNS" or "kube-dns".</td>
+</tr>
+    
+  
+<tr><td><code>ImageMeta</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-ImageMeta"><code>ImageMeta</code></a>
+</td>
+<td>(Members of <code>ImageMeta</code> are embedded into this type.)
+   `imageMeta` is used to customize the image used for the DNS add-on.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `DNSAddOnType`     {#kubeadm-k8s-io-v1beta2-DNSAddOnType}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [DNS](#kubeadm-k8s-io-v1beta2-DNS)
+
+
+DNSAddOnType defines string identifying DNS add-on types.
+
+
+    
+
+
+## `Discovery`     {#kubeadm-k8s-io-v1beta2-Discovery}
+    
+
+
+
+**Appears in:**
+
+- [JoinConfiguration](#kubeadm-k8s-io-v1beta2-JoinConfiguration)
+
+
+Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>bootstrapToken</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-BootstrapTokenDiscovery"><code>BootstrapTokenDiscovery</code></a>
+</td>
+<td>
+   `bootstrapToken` is used to set the options for bootstrap token based discovery.
+One and only one of the `bootstrapToken` field and the `file` field must be set.</td>
+</tr>
+    
+  
+<tr><td><code>file</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-FileDiscovery"><code>FileDiscovery</code></a>
+</td>
+<td>
+   `file` is used to specify a file or URL to a kubeconfig file from which to load cluster information.
+One and only one of the `bootstrapToken` field and the `file` field must be set.</td>
+</tr>
+    
+  
+<tr><td><code>tlsBootstrapToken</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `tlsBootstrapToken` is a token used for TLS bootstrapping.
+If `bootstrapToken` is set, this field is defaulted to `.bootstrapToken.token`, but can be overridden.
+If `file` is set, this field &lowast;&lowast;must be set&lowast;&lowast; in case the KubeConfigFile does not contain any other
+authentication information.</td>
+</tr>
+    
+  
+<tr><td><code>timeout</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   `timeout` is used to customize timeout period for the discovery.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Etcd`     {#kubeadm-k8s-io-v1beta2-Etcd}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
+
+
+Etcd contains elements describing Etcd configuration.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>local</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-LocalEtcd"><code>LocalEtcd</code></a>
+</td>
+<td>
+   `local` provides configurations for the local etcd instance.
+One and only one of the `local` field and the `external` field must be specified.</td>
+</tr>
+    
+  
+<tr><td><code>external</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-ExternalEtcd"><code>ExternalEtcd</code></a>
+</td>
+<td>
+   `external` describes how to connect to an external etcd service.
+One and only one of the `local` field and the `external` field must be specified.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ExternalEtcd`     {#kubeadm-k8s-io-v1beta2-ExternalEtcd}
+    
+
+
+
+**Appears in:**
+
+- [Etcd](#kubeadm-k8s-io-v1beta2-Etcd)
+
+
+ExternalEtcd describes an external etcd cluster.
+Kubeadm has no knowledge of where certificate files live and they must be supplied.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>endpoints</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `endpoints` contains a list of etcd members. This field is required.
+When TLS connection is used, `caFile`, `certFile` and `keyFile` are all specified,
+the endpoints listed must use the HTTPS scheme.</td>
+</tr>
+    
+  
+<tr><td><code>caFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `caFile` is an SSL Certificate Authority (CA) file used to secure etcd communication.
+Required if using a TLS connection.
+The value must be an absolute path.</td>
+</tr>
+    
+  
+<tr><td><code>certFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `certFile` is an SSL certification file used to secure etcd communication.
+Required if using a TLS connection.
+When this is specified, the `keyFile` field cannot be left unset.
+When either 'certFile` or `keyFile` are provided, the `caFile` cannot be empty.
+The value must be an absolute path.</td>
+</tr>
+    
+  
+<tr><td><code>keyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `keyFile` is an SSL key file used to secure etcd communication.
+Required if using a TLS connection.
+When this is specified, the `certFile` field cannot be left unset.
+When either 'certFile` or `keyFile` are provided, the `caFile` cannot be empty.
+The value must be an absolute path.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `FileDiscovery`     {#kubeadm-k8s-io-v1beta2-FileDiscovery}
+    
+
+
+
+**Appears in:**
+
+- [Discovery](#kubeadm-k8s-io-v1beta2-Discovery)
+
+
+FileDiscovery is used to specify a file or a URL to a kubeconfig file from which to load cluster information.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>kubeConfigPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `kubeConfigPath` is used to specify the file path or a URL to the kubeconfig file from which
+to load cluster information. If the path is a URL, its scheme must be HTTPS.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `HostPathMount`     {#kubeadm-k8s-io-v1beta2-HostPathMount}
+    
+
+
+
+**Appears in:**
+
+- [ControlPlaneComponent](#kubeadm-k8s-io-v1beta2-ControlPlaneComponent)
+
+
+HostPathMount contains elements describing volumes that are mounted from the host.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `name` is the name of the volume inside the Pod template.</td>
+</tr>
+    
+  
+<tr><td><code>hostPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `hostPath` is the path on the host that will be mounted inside the Pod.</td>
+</tr>
+    
+  
+<tr><td><code>mountPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `mountPath` is the path inside the Pod where `hostPath` will be mounted.</td>
+</tr>
+    
+  
+<tr><td><code>readOnly</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   `readOnly` indicates whether the volume is mounted in read-only mode.</td>
+</tr>
+    
+  
+<tr><td><code>pathType</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
+</td>
+<td>
+   `pathType` is the type of the HostPath, for example, "DirectoryOrCreate", "File", etc.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ImageMeta`     {#kubeadm-k8s-io-v1beta2-ImageMeta}
+    
+
+
+
+**Appears in:**
+
+- [DNS](#kubeadm-k8s-io-v1beta2-DNS)
+
+- [LocalEtcd](#kubeadm-k8s-io-v1beta2-LocalEtcd)
+
+
+ImageMeta allows to customize the image used for components that are not
+originated from the Kubernetes/Kubernetes release process
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>imageRepository</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `imageRepository` sets the container registry to pull images from.
+If not set, the `imageRepository` defined in ClusterConfiguration will be used instead.</td>
+</tr>
+    
+  
+<tr><td><code>imageTag</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `imageTag` allows for specifying a tag for the image.
+When this value is set, kubeadm does not automatically change the version
+of the above components during upgrades.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `JoinControlPlane`     {#kubeadm-k8s-io-v1beta2-JoinControlPlane}
+    
+
+
+
+**Appears in:**
+
+- [JoinConfiguration](#kubeadm-k8s-io-v1beta2-JoinConfiguration)
+
+
+JoinControlPlane contains elements describing an additional control plane instance to be deployed on the joining node.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>localAPIEndpoint</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-APIEndpoint"><code>APIEndpoint</code></a>
+</td>
+<td>
+   `localAPIEndpoint` represents the endpoint of the API server instance to be deployed on this node.</td>
+</tr>
+    
+  
+<tr><td><code>certificateKey</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `certificateKey` is the key for decrypting certificates after they are downloaded from the Secret
+upon joining a new control plane node. The corresponding encryption key is in the `initConfiguration`.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `LocalEtcd`     {#kubeadm-k8s-io-v1beta2-LocalEtcd}
+    
+
+
+
+**Appears in:**
+
+- [Etcd](#kubeadm-k8s-io-v1beta2-Etcd)
+
+
+LocalEtcd describes that kubeadm should run an etcd cluster locally
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>ImageMeta</code> <B>[Required]</B><br/>
+<a href="#kubeadm-k8s-io-v1beta2-ImageMeta"><code>ImageMeta</code></a>
+</td>
+<td>(Members of <code>ImageMeta</code> are embedded into this type.)
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>dataDir</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `dataDir` is the directory for etcd to place its data. Defaults to "/var/lib/etcd".
+The path must be an absolute path.</td>
+</tr>
+    
+  
+<tr><td><code>extraArgs</code> <B>[Required]</B><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   `extraArgs` are extra arguments provided to the etcd binary when run inside a static pod.</td>
+</tr>
+    
+  
+<tr><td><code>serverCertSANs</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `serverCertSANs` sets extra Subject Alternative Names (SANs) for the etcd server signing cert.</td>
+</tr>
+    
+  
+<tr><td><code>peerCertSANs</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `peerCertSANs` sets extra Subject Alternative Names (SANs) for the etcd peer signing cert.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `Networking`     {#kubeadm-k8s-io-v1beta2-Networking}
+    
+
+
+
+**Appears in:**
+
+- [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
+
+
+Networking contains elements describing cluster's networking configuration
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>serviceSubnet</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `serviceSubnet` is the subnet used by Services. Defaults to "10.96.0.0/12".
+When DualStack is enabled, you can specify two CIDRs separated by a comma,
+one CIDR for IPv4 and the other for IPv6.
+If DualStack is not enabled, only one CIDR can be specified.
+The service subnet can be at most 20 bits, so the largest supported Service subnet is `/12` for IPv4
+and `/108` for IPv6.
+Also, the subnet defined must have at least 10 nodes.</td>
+</tr>
+    
+  
+<tr><td><code>podSubnet</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `podSubnet` is the subnet used by Pods.
+When DualStack is enabled, you can specify two CIDRs separated by a comma,
+one CIDR for IPv4 and the other for IPv6.
+If DualStack is not enabled, only one CIDR can be specified.</td>
+</tr>
+    
+  
+<tr><td><code>dnsDomain</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `dnsDomain` is the DNS domain used by Services. Defaults to "cluster.local".</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeRegistrationOptions`     {#kubeadm-k8s-io-v1beta2-NodeRegistrationOptions}
+    
+
+
+
+**Appears in:**
+
+- [InitConfiguration](#kubeadm-k8s-io-v1beta2-InitConfiguration)
+
+- [JoinConfiguration](#kubeadm-k8s-io-v1beta2-JoinConfiguration)
+
+
+NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either
+via "kubeadm init" or "kubeadm join".
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `name` is the `.metadata.name` field of the Node API object that will be created in this `kubeadm init` or
+`kubeadm join` operation. This field is also used in the CommonName field of the kubelet's
+client certificate to the API server. Defaults to the hostname of the node.</td>
+</tr>
+    
+  
+<tr><td><code>criSocket</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   `criSocket` is used to retrieve container runtime information. This information will be
+annotated to the Node API object, for later re-use.</td>
+</tr>
+    
+  
+<tr><td><code>taints</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#taint-v1-core"><code>[]core/v1.Taint</code></a>
+</td>
+<td>
+   `taints` specifies the taints the Node API object should be registered with. If this field is not set, i.e. nil,
+it will be defaulted to `['node-role.kubernetes.io/master=""']` during `kubeadm init`.
+If you don't want to taint your control-plane node, set this field to an empty list (`[]`).
+This field is only used for node registration.</td>
+</tr>
+    
+  
+<tr><td><code>kubeletExtraArgs</code> <B>[Required]</B><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   `kubeletExtraArgs` contains extra arguments to pass to the kubelet. Kubeadm writes these arguments into an
+environment file for the kubelet to source.
+This overrides the generic base-level configuration in the `kubelet-config-1.x` ConfigMap
+Command line flags have higher priority when parsing.
+These values are local and specific to the node kubeadm is executing on.</td>
+</tr>
+    
+  
+<tr><td><code>ignorePreflightErrors</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   `ignorePreflightErrors` provides a list of pre-flight errors that are ignored during node registration.
+This list cannot contain "all".</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/output/md/kubelet-config.v1beta1.md
+++ b/genref/output/md/kubelet-config.v1beta1.md
@@ -1,0 +1,1604 @@
+---
+title: Kubelet Configuration (v1beta1)
+content_type: tool-reference
+package: kubelet.config.k8s.io/v1beta1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+- [SerializedNodeConfigSource](#kubelet-config-k8s-io-v1beta1-SerializedNodeConfigSource)
+  
+    
+
+
+## `KubeletConfiguration`     {#kubelet-config-k8s-io-v1beta1-KubeletConfiguration}
+    
+
+
+
+
+KubeletConfiguration contains the configuration for the Kubelet
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubelet.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>KubeletConfiguration</code></td></tr>
+    
+
+  
+  
+<tr><td><code>enableServer</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   enableServer enables Kubelet's secured server.
+Note: Kubelet's insecure port is controlled by the readOnlyPort option.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>staticPodPath</code><br/>
+<code>string</code>
+</td>
+<td>
+   staticPodPath is the path to the directory containing local (static) pods to
+run, or the path to a single static pod file.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+the set of static pods specified at the new path may be different than the
+ones the Kubelet initially started with, and this may disrupt your node.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>syncFrequency</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   syncFrequency is the max period between synchronizing running
+containers and config.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening this duration may have a negative performance impact, especially
+as the number of Pods on the node increases. Alternatively, increasing this
+duration will result in longer refresh times for ConfigMaps and Secrets.
+Default: "1m"</td>
+</tr>
+    
+  
+<tr><td><code>fileCheckFrequency</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   fileCheckFrequency is the duration between checking config files for
+new data
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the duration will cause the Kubelet to reload local Static Pod
+configurations more frequently, which may have a negative performance impact.
+Default: "20s"</td>
+</tr>
+    
+  
+<tr><td><code>httpCheckFrequency</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   httpCheckFrequency is the duration between checking http for new data
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the duration will cause the Kubelet to poll staticPodURL more
+frequently, which may have a negative performance impact.
+Default: "20s"</td>
+</tr>
+    
+  
+<tr><td><code>staticPodURL</code><br/>
+<code>string</code>
+</td>
+<td>
+   staticPodURL is the URL for accessing static pods to run
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+the set of static pods specified at the new URL may be different than the
+ones the Kubelet initially started with, and this may disrupt your node.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>staticPodURLHeader</code><br/>
+<code>map[string][]string</code>
+</td>
+<td>
+   staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt the ability to read the latest set of static pods from StaticPodURL.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>address</code><br/>
+<code>string</code>
+</td>
+<td>
+   address is the IP address for the Kubelet to serve on (set to 0.0.0.0
+for all interfaces).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: "0.0.0.0"</td>
+</tr>
+    
+  
+<tr><td><code>port</code><br/>
+<code>int32</code>
+</td>
+<td>
+   port is the port for the Kubelet to serve on.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: 10250</td>
+</tr>
+    
+  
+<tr><td><code>readOnlyPort</code><br/>
+<code>int32</code>
+</td>
+<td>
+   readOnlyPort is the read-only port for the Kubelet to serve on with
+no authentication/authorization.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: 0 (disabled)</td>
+</tr>
+    
+  
+<tr><td><code>tlsCertFile</code><br/>
+<code>string</code>
+</td>
+<td>
+   tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,
+if any, concatenated after server cert). If tlsCertFile and
+tlsPrivateKeyFile are not provided, a self-signed certificate
+and key are generated for the public address and saved to the directory
+passed to the Kubelet's --cert-dir flag.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>tlsPrivateKeyFile</code><br/>
+<code>string</code>
+</td>
+<td>
+   tlsPrivateKeyFile is the file containing x509 private key matching tlsCertFile
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>tlsCipherSuites</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   TLSCipherSuites is the list of allowed cipher suites for the server.
+Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>tlsMinVersion</code><br/>
+<code>string</code>
+</td>
+<td>
+   TLSMinVersion is the minimum TLS version supported.
+Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>rotateCertificates</code><br/>
+<code>bool</code>
+</td>
+<td>
+   rotateCertificates enables client certificate rotation. The Kubelet will request a
+new certificate from the certificates.k8s.io API. This requires an approver to approve the
+certificate signing requests.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may disrupt the Kubelet's ability to authenticate with the API server
+after the current certificate expires.
+Default: false</td>
+</tr>
+    
+  
+<tr><td><code>serverTLSBootstrap</code><br/>
+<code>bool</code>
+</td>
+<td>
+   serverTLSBootstrap enables server certificate bootstrap. Instead of self
+signing a serving certificate, the Kubelet will request a certificate from
+the certificates.k8s.io API. This requires an approver to approve the
+certificate signing requests. The RotateKubeletServerCertificate feature
+must be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it will stop the renewal of Kubelet server certificates, which can
+disrupt components that interact with the Kubelet server in the long term,
+due to certificate expiration.
+Default: false</td>
+</tr>
+    
+  
+<tr><td><code>authentication</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthentication"><code>KubeletAuthentication</code></a>
+</td>
+<td>
+   authentication specifies how requests to the Kubelet's server are authenticated
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Defaults:
+  anonymous:
+    enabled: false
+  webhook:
+    enabled: true
+    cacheTTL: "2m"</td>
+</tr>
+    
+  
+<tr><td><code>authorization</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorization"><code>KubeletAuthorization</code></a>
+</td>
+<td>
+   authorization specifies how requests to the Kubelet's server are authorized
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Defaults:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: "5m"
+    cacheUnauthorizedTTL: "30s"</td>
+</tr>
+    
+  
+<tr><td><code>registryPullQPS</code><br/>
+<code>int32</code>
+</td>
+<td>
+   registryPullQPS is the limit of registry pulls per second.
+Set to 0 for no limit.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced
+by image pulls.
+Default: 5</td>
+</tr>
+    
+  
+<tr><td><code>registryBurst</code><br/>
+<code>int32</code>
+</td>
+<td>
+   registryBurst is the maximum size of bursty pulls, temporarily allows
+pulls to burst to this number, while still not exceeding registryPullQPS.
+Only used if registryPullQPS > 0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced
+by image pulls.
+Default: 10</td>
+</tr>
+    
+  
+<tr><td><code>eventRecordQPS</code><br/>
+<code>int32</code>
+</td>
+<td>
+   eventRecordQPS is the maximum event creations per second. If 0, there
+is no limit enforced.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced by
+event creations.
+Default: 5</td>
+</tr>
+    
+  
+<tr><td><code>eventBurst</code><br/>
+<code>int32</code>
+</td>
+<td>
+   eventBurst is the maximum size of a burst of event creations, temporarily
+allows event creations to burst to this number, while still not exceeding
+eventRecordQPS. Only used if eventRecordQPS > 0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic produced by
+event creations.
+Default: 10</td>
+</tr>
+    
+  
+<tr><td><code>enableDebuggingHandlers</code><br/>
+<code>bool</code>
+</td>
+<td>
+   enableDebuggingHandlers enables server endpoints for log access
+and local running of containers and commands, including the exec,
+attach, logs, and portforward features.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may disrupt components that interact with the Kubelet server.
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>enableContentionProfiling</code><br/>
+<code>bool</code>
+</td>
+<td>
+   enableContentionProfiling enables lock contention profiling, if enableDebuggingHandlers is true.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+enabling it may carry a performance impact.
+Default: false</td>
+</tr>
+    
+  
+<tr><td><code>healthzPort</code><br/>
+<code>int32</code>
+</td>
+<td>
+   healthzPort is the port of the localhost healthz endpoint (set to 0 to disable)
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that monitor Kubelet health.
+Default: 10248</td>
+</tr>
+    
+  
+<tr><td><code>healthzBindAddress</code><br/>
+<code>string</code>
+</td>
+<td>
+   healthzBindAddress is the IP address for the healthz server to serve on
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that monitor Kubelet health.
+Default: "127.0.0.1"</td>
+</tr>
+    
+  
+<tr><td><code>oomScoreAdj</code><br/>
+<code>int32</code>
+</td>
+<td>
+   oomScoreAdj is The oom-score-adj value for kubelet process. Values
+must be within the range [-1000, 1000].
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the stability of nodes under memory pressure.
+Default: -999</td>
+</tr>
+    
+  
+<tr><td><code>clusterDomain</code><br/>
+<code>string</code>
+</td>
+<td>
+   clusterDomain is the DNS domain for this cluster. If set, kubelet will
+configure all containers to search this domain in addition to the
+host's search domains.
+Dynamic Kubelet Config (beta): Dynamically updating this field is not recommended,
+as it should be kept in sync with the rest of the cluster.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>clusterDNS</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   clusterDNS is a list of IP addresses for the cluster DNS server. If set,
+kubelet will configure all containers to use this for DNS resolution
+instead of the host's DNS servers.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes will only take effect on Pods created after the update. Draining
+the node is recommended before changing this field.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>streamingConnectionIdleTimeout</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   streamingConnectionIdleTimeout is the maximum time a streaming connection
+can be idle before the connection is automatically closed.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact components that rely on infrequent updates over streaming
+connections to the Kubelet server.
+Default: "4h"</td>
+</tr>
+    
+  
+<tr><td><code>nodeStatusUpdateFrequency</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   nodeStatusUpdateFrequency is the frequency that kubelet computes node
+status. If node lease feature is not enabled, it is also the frequency that
+kubelet posts node status to master.
+Note: When node lease feature is not enabled, be cautious when changing the
+constant, it must work with nodeMonitorGracePeriod in nodecontroller.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact node scalability, and also that the node controller's
+nodeMonitorGracePeriod must be set to N&lowast;NodeStatusUpdateFrequency,
+where N is the number of retries before the node controller marks
+the node unhealthy.
+Default: "10s"</td>
+</tr>
+    
+  
+<tr><td><code>nodeStatusReportFrequency</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   nodeStatusReportFrequency is the frequency that kubelet posts node
+status to master if node status does not change. Kubelet will ignore this
+frequency and post node status immediately if any change is detected. It is
+only used when node lease feature is enabled. nodeStatusReportFrequency's
+default value is 1m. But if nodeStatusUpdateFrequency is set explicitly,
+nodeStatusReportFrequency's default value will be set to
+nodeStatusUpdateFrequency for backward compatibility.
+Default: "1m"</td>
+</tr>
+    
+  
+<tr><td><code>nodeLeaseDurationSeconds</code><br/>
+<code>int32</code>
+</td>
+<td>
+   nodeLeaseDurationSeconds is the duration the Kubelet will set on its corresponding Lease,
+when the NodeLease feature is enabled. This feature provides an indicator of node
+health by having the Kubelet create and periodically renew a lease, named after the node,
+in the kube-node-lease namespace. If the lease expires, the node can be considered unhealthy.
+The lease is currently renewed every 10s, per KEP-0009. In the future, the lease renewal interval
+may be set based on the lease duration.
+Requires the NodeLease feature gate to be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+decreasing the duration may reduce tolerance for issues that temporarily prevent
+the Kubelet from renewing the lease (e.g. a short-lived network issue).
+Default: 40</td>
+</tr>
+    
+  
+<tr><td><code>imageMinimumGCAge</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   imageMinimumGCAge is the minimum age for an unused image before it is
+garbage collected.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: "2m"</td>
+</tr>
+    
+  
+<tr><td><code>imageGCHighThresholdPercent</code><br/>
+<code>int32</code>
+</td>
+<td>
+   imageGCHighThresholdPercent is the percent of disk usage after which
+image garbage collection is always run. The percent is calculated as
+this field value out of 100.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: 85</td>
+</tr>
+    
+  
+<tr><td><code>imageGCLowThresholdPercent</code><br/>
+<code>int32</code>
+</td>
+<td>
+   imageGCLowThresholdPercent is the percent of disk usage before which
+image garbage collection is never run. Lowest disk usage to garbage
+collect to. The percent is calculated as this field value out of 100.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay garbage collection, and may change the image overhead
+on the node.
+Default: 80</td>
+</tr>
+    
+  
+<tr><td><code>volumeStatsAggPeriod</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   How frequently to calculate and cache volume disk usage for all pods
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the period may carry a performance impact.
+Default: "1m"</td>
+</tr>
+    
+  
+<tr><td><code>kubeletCgroups</code><br/>
+<code>string</code>
+</td>
+<td>
+   kubeletCgroups is the absolute name of cgroups to isolate the kubelet in
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>systemCgroups</code><br/>
+<code>string</code>
+</td>
+<td>
+   systemCgroups is absolute name of cgroups in which to place
+all non-kernel processes that are not already in a container. Empty
+for no container. Rolling back the flag requires a reboot.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>cgroupRoot</code><br/>
+<code>string</code>
+</td>
+<td>
+   cgroupRoot is the root cgroup to use for pods. This is handled by the
+container runtime on a best effort basis.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>cgroupsPerQOS</code><br/>
+<code>bool</code>
+</td>
+<td>
+   Enable QoS based Cgroup hierarchy: top level cgroups for QoS Classes
+And all Burstable and BestEffort pods are brought up under their
+specific top level QoS cgroup.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>cgroupDriver</code><br/>
+<code>string</code>
+</td>
+<td>
+   driver that the kubelet uses to manipulate cgroups on the host (cgroupfs or systemd)
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: "cgroupfs"</td>
+</tr>
+    
+  
+<tr><td><code>cpuManagerPolicy</code><br/>
+<code>string</code>
+</td>
+<td>
+   CPUManagerPolicy is the name of the policy to use.
+Requires the CPUManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: "none"</td>
+</tr>
+    
+  
+<tr><td><code>cpuManagerReconcilePeriod</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   CPU Manager reconciliation period.
+Requires the CPUManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+shortening the period may carry a performance impact.
+Default: "10s"</td>
+</tr>
+    
+  
+<tr><td><code>topologyManagerPolicy</code><br/>
+<code>string</code>
+</td>
+<td>
+   TopologyManagerPolicy is the name of the policy to use.
+Policies other than "none" require the TopologyManager feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: "none"</td>
+</tr>
+    
+  
+<tr><td><code>topologyManagerScope</code><br/>
+<code>string</code>
+</td>
+<td>
+   TopologyManagerScope represents the scope of topology hint generation
+that topology manager requests and hint providers generate.
+"pod" scope requires the TopologyManager feature gate to be enabled.
+Default: "container"</td>
+</tr>
+    
+  
+<tr><td><code>qosReserved</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   qosReserved is a set of resource name to percentage pairs that specify
+the minimum percentage of a resource reserved for exclusive use by the
+guaranteed QoS tier.
+Currently supported resources: "memory"
+Requires the QOSReserved feature gate to be enabled.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>runtimeRequestTimeout</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   runtimeRequestTimeout is the timeout for all runtime requests except long running
+requests - pull, logs, exec and attach.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may disrupt components that interact with the Kubelet server.
+Default: "2m"</td>
+</tr>
+    
+  
+<tr><td><code>hairpinMode</code><br/>
+<code>string</code>
+</td>
+<td>
+   hairpinMode specifies how the Kubelet should configure the container
+bridge for hairpin packets.
+Setting this flag allows endpoints in a Service to loadbalance back to
+themselves if they should try to access their own Service. Values:
+  "promiscuous-bridge": make the container bridge promiscuous.
+  "hairpin-veth":       set the hairpin flag on container veth interfaces.
+  "none":               do nothing.
+Generally, one must set --hairpin-mode=hairpin-veth to achieve hairpin NAT,
+because promiscuous-bridge assumes the existence of a container bridge named cbr0.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may require a node reboot, depending on the network plugin.
+Default: "promiscuous-bridge"</td>
+</tr>
+    
+  
+<tr><td><code>maxPods</code><br/>
+<code>int32</code>
+</td>
+<td>
+   maxPods is the number of pods that can run on this Kubelet.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes may cause Pods to fail admission on Kubelet restart, and may change
+the value reported in Node.Status.Capacity[v1.ResourcePods], thus affecting
+future scheduling decisions. Increasing this value may also decrease performance,
+as more Pods can be packed into a single node.
+Default: 110</td>
+</tr>
+    
+  
+<tr><td><code>podCIDR</code><br/>
+<code>string</code>
+</td>
+<td>
+   The CIDR to use for pod IP addresses, only used in standalone mode.
+In cluster mode, this is obtained from the master.
+Dynamic Kubelet Config (beta): This field should always be set to the empty default.
+It should only set for standalone Kubelets, which cannot use Dynamic Kubelet Config.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>podPidsLimit</code><br/>
+<code>int64</code>
+</td>
+<td>
+   PodPidsLimit is the maximum number of pids in any pod.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may prevent container processes from forking after the change.
+Default: -1</td>
+</tr>
+    
+  
+<tr><td><code>resolvConf</code><br/>
+<code>string</code>
+</td>
+<td>
+   ResolverConfig is the resolver configuration file used as the basis
+for the container DNS resolution configuration.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes will only take effect on Pods created after the update. Draining
+the node is recommended before changing this field.
+Default: "/etc/resolv.conf"</td>
+</tr>
+    
+  
+<tr><td><code>runOnce</code><br/>
+<code>bool</code>
+</td>
+<td>
+   RunOnce causes the Kubelet to check the API server once for pods,
+run those in addition to the pods specified by static pod files, and exit.
+Default: false</td>
+</tr>
+    
+  
+<tr><td><code>cpuCFSQuota</code><br/>
+<code>bool</code>
+</td>
+<td>
+   cpuCFSQuota enables CPU CFS quota enforcement for containers that
+specify CPU limits.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it may reduce node stability.
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>cpuCFSQuotaPeriod</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   CPUCFSQuotaPeriod is the CPU CFS quota period value, cpu.cfs_period_us.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+limits set for containers will result in different cpu.cfs_quota settings. This
+will trigger container restarts on the node being reconfigured.
+Default: "100ms"</td>
+</tr>
+    
+  
+<tr><td><code>nodeStatusMaxImages</code><br/>
+<code>int32</code>
+</td>
+<td>
+   nodeStatusMaxImages caps the number of images reported in Node.Status.Images.
+Note: If -1 is specified, no cap will be applied. If 0 is specified, no image is returned.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+different values can be reported on node status.
+Default: 50</td>
+</tr>
+    
+  
+<tr><td><code>maxOpenFiles</code><br/>
+<code>int64</code>
+</td>
+<td>
+   maxOpenFiles is Number of files that can be opened by Kubelet process.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability of the Kubelet to interact with the node's filesystem.
+Default: 1000000</td>
+</tr>
+    
+  
+<tr><td><code>contentType</code><br/>
+<code>string</code>
+</td>
+<td>
+   contentType is contentType of requests sent to apiserver.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability for the Kubelet to communicate with the API server.
+If the Kubelet loses contact with the API server due to a change to this field,
+the change cannot be reverted via dynamic Kubelet config.
+Default: "application/vnd.kubernetes.protobuf"</td>
+</tr>
+    
+  
+<tr><td><code>kubeAPIQPS</code><br/>
+<code>int32</code>
+</td>
+<td>
+   kubeAPIQPS is the QPS to use while talking with kubernetes apiserver
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic the Kubelet
+sends to the API server.
+Default: 5</td>
+</tr>
+    
+  
+<tr><td><code>kubeAPIBurst</code><br/>
+<code>int32</code>
+</td>
+<td>
+   kubeAPIBurst is the burst to allow while talking with kubernetes apiserver
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact scalability by changing the amount of traffic the Kubelet
+sends to the API server.
+Default: 10</td>
+</tr>
+    
+  
+<tr><td><code>serializeImagePulls</code><br/>
+<code>bool</code>
+</td>
+<td>
+   serializeImagePulls when enabled, tells the Kubelet to pull images one
+at a time. We recommend &lowast;not&lowast; changing the default value on nodes that
+run docker daemon with version  < 1.9 or an Aufs storage backend.
+Issue #10959 has more details.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the performance of image pulls.
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>evictionHard</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   Map of signal names to quantities that defines hard eviction thresholds. For example: {"memory.available": "300Mi"}.
+To explicitly disable, pass a 0% or 100% threshold on an arbitrary resource.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions.
+Default:
+  memory.available:  "100Mi"
+  nodefs.available:  "10%"
+  nodefs.inodesFree: "5%"
+  imagefs.available: "15%"</td>
+</tr>
+    
+  
+<tr><td><code>evictionSoft</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   Map of signal names to quantities that defines soft eviction thresholds.
+For example: {"memory.available": "300Mi"}.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions, and may change the allocatable reported
+by the node.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>evictionSoftGracePeriod</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   Map of signal names to quantities that defines grace periods for each soft eviction signal.
+For example: {"memory.available": "30s"}.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger or delay Pod evictions.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>evictionPressureTransitionPeriod</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may decrease the stability of the node when the node is overcommitted.
+Default: "5m"</td>
+</tr>
+    
+  
+<tr><td><code>evictionMaxPodGracePeriod</code><br/>
+<code>int32</code>
+</td>
+<td>
+   Maximum allowed grace period (in seconds) to use when terminating pods in
+response to a soft eviction threshold being met. This value effectively caps
+the Pod's TerminationGracePeriodSeconds value during soft evictions.
+Note: Due to issue #64530, the behavior has a bug where this value currently just
+overrides the grace period during soft eviction, which can increase the grace
+period from what is set on the Pod. This bug will be fixed in a future release.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it decreases the amount of time Pods will have to gracefully clean
+up before being killed during a soft eviction.
+Default: 0</td>
+</tr>
+    
+  
+<tr><td><code>evictionMinimumReclaim</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   Map of signal names to quantities that defines minimum reclaims, which describe the minimum
+amount of a given resource the kubelet will reclaim when performing a pod eviction while
+that resource is under pressure. For example: {"imagefs.available": "2Gi"}
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may change how well eviction can manage resource pressure.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>podsPerCore</code><br/>
+<code>int32</code>
+</td>
+<td>
+   podsPerCore is the maximum number of pods per core. Cannot exceed MaxPods.
+If 0, this field is ignored.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changes may cause Pods to fail admission on Kubelet restart, and may change
+the value reported in Node.Status.Capacity[v1.ResourcePods], thus affecting
+future scheduling decisions. Increasing this value may also decrease performance,
+as more Pods can be packed into a single node.
+Default: 0</td>
+</tr>
+    
+  
+<tr><td><code>enableControllerAttachDetach</code><br/>
+<code>bool</code>
+</td>
+<td>
+   enableControllerAttachDetach enables the Attach/Detach controller to
+manage attachment/detachment of volumes scheduled to this node, and
+disables kubelet from executing any attach/detach operations
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+changing which component is responsible for volume management on a live node
+may result in volumes refusing to detach if the node is not drained prior to
+the update, and if Pods are scheduled to the node before the
+volumes.kubernetes.io/controller-managed-attach-detach annotation is updated by the
+Kubelet. In general, it is safest to leave this value set the same as local config.
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>protectKernelDefaults</code><br/>
+<code>bool</code>
+</td>
+<td>
+   protectKernelDefaults, if true, causes the Kubelet to error if kernel
+flags are not as it expects. Otherwise the Kubelet will attempt to modify
+kernel flags to match its expectation.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+enabling it may cause the Kubelet to crash-loop if the Kernel is not configured as
+Kubelet expects.
+Default: false</td>
+</tr>
+    
+  
+<tr><td><code>makeIPTablesUtilChains</code><br/>
+<code>bool</code>
+</td>
+<td>
+   If true, Kubelet ensures a set of iptables rules are present on host.
+These rules will serve as utility rules for various components, e.g. KubeProxy.
+The rules will be created based on IPTablesMasqueradeBit and IPTablesDropBit.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+disabling it will prevent the Kubelet from healing locally misconfigured iptables rules.
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>iptablesMasqueradeBit</code><br/>
+<code>int32</code>
+</td>
+<td>
+   iptablesMasqueradeBit is the bit of the iptables fwmark space to mark for SNAT
+Values must be within the range [0, 31]. Must be different from other mark bits.
+Warning: Please match the value of the corresponding parameter in kube-proxy.
+TODO: clean up IPTablesMasqueradeBit in kube-proxy
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it needs to be coordinated with other components, like kube-proxy, and the update
+will only be effective if MakeIPTablesUtilChains is enabled.
+Default: 14</td>
+</tr>
+    
+  
+<tr><td><code>iptablesDropBit</code><br/>
+<code>int32</code>
+</td>
+<td>
+   iptablesDropBit is the bit of the iptables fwmark space to mark for dropping packets.
+Values must be within the range [0, 31]. Must be different from other mark bits.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it needs to be coordinated with other components, like kube-proxy, and the update
+will only be effective if MakeIPTablesUtilChains is enabled.
+Default: 15</td>
+</tr>
+    
+  
+<tr><td><code>featureGates</code><br/>
+<code>map[string]bool</code>
+</td>
+<td>
+   featureGates is a map of feature names to bools that enable or disable alpha/experimental
+features. This field modifies piecemeal the built-in default values from
+"k8s.io/kubernetes/pkg/features/kube_features.go".
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider the
+documentation for the features you are enabling or disabling. While we
+encourage feature developers to make it possible to dynamically enable
+and disable features, some changes may require node reboots, and some
+features may require careful coordination to retroactively disable.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>failSwapOn</code><br/>
+<code>bool</code>
+</td>
+<td>
+   failSwapOn tells the Kubelet to fail to start if swap is enabled on the node.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+setting it to true will cause the Kubelet to crash-loop if swap is enabled.
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>containerLogMaxSize</code><br/>
+<code>string</code>
+</td>
+<td>
+   A quantity defines the maximum size of the container log file before it is rotated.
+For example: "5Mi" or "256Ki".
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may trigger log rotation.
+Default: "10Mi"</td>
+</tr>
+    
+  
+<tr><td><code>containerLogMaxFiles</code><br/>
+<code>int32</code>
+</td>
+<td>
+   Maximum number of container log files that can be present for a container.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+lowering it may cause log files to be deleted.
+Default: 5</td>
+</tr>
+    
+  
+<tr><td><code>configMapAndSecretChangeDetectionStrategy</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-ResourceChangeDetectionStrategy"><code>ResourceChangeDetectionStrategy</code></a>
+</td>
+<td>
+   ConfigMapAndSecretChangeDetectionStrategy is a mode in which
+config map and secret managers are running.
+Default: "Watch"</td>
+</tr>
+    
+  
+<tr><td><code>systemReserved</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   systemReserved is a set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G)
+pairs that describe resources reserved for non-kubernetes components.
+Currently only cpu and memory are supported.
+See http://kubernetes.io/docs/user-guide/compute-resources for more detail.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may not be possible to increase the reserved resources, because this
+requires resizing cgroups. Always look for a NodeAllocatableEnforced event
+after updating this field to ensure that the update was successful.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>kubeReserved</code><br/>
+<code>map[string]string</code>
+</td>
+<td>
+   A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs
+that describe resources reserved for kubernetes system components.
+Currently cpu, memory and local storage for root file system are supported.
+See http://kubernetes.io/docs/user-guide/compute-resources for more detail.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may not be possible to increase the reserved resources, because this
+requires resizing cgroups. Always look for a NodeAllocatableEnforced event
+after updating this field to ensure that the update was successful.
+Default: nil</td>
+</tr>
+    
+  
+<tr><td><code>reservedSystemCPUs</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   This ReservedSystemCPUs option specifies the cpu list reserved for the host level system threads and kubernetes related threads.
+This provide a "static" CPU list rather than the "dynamic" list by system-reserved and kube-reserved.
+This option overwrites CPUs provided by system-reserved and kube-reserved.</td>
+</tr>
+    
+  
+<tr><td><code>showHiddenMetricsForVersion</code><br/>
+<code>string</code>
+</td>
+<td>
+   The previous version for which you want to show hidden metrics.
+Only the previous minor version is meaningful, other values will not be allowed.
+The format is <major>.<minor>, e.g.: '1.16'.
+The purpose of this format is make sure you have the opportunity to notice if the next release hides additional metrics,
+rather than being surprised when they are permanently removed in the release after that.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>systemReservedCgroup</code><br/>
+<code>string</code>
+</td>
+<td>
+   This flag helps kubelet identify absolute name of top level cgroup used to enforce `SystemReserved` compute resource reservation for OS system daemons.
+Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>kubeReservedCgroup</code><br/>
+<code>string</code>
+</td>
+<td>
+   This flag helps kubelet identify absolute name of top level cgroup used to enforce `KubeReserved` compute resource reservation for Kubernetes node system daemons.
+Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
+Dynamic Kubelet Config (beta): This field should not be updated without a full node
+reboot. It is safest to keep this value the same as the local config.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>enforceNodeAllocatable</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   This flag specifies the various Node Allocatable enforcements that Kubelet needs to perform.
+This flag accepts a list of options. Acceptable options are `none`, `pods`, `system-reserved` & `kube-reserved`.
+If `none` is specified, no other options may be specified.
+Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+removing enforcements may reduce the stability of the node. Alternatively, adding
+enforcements may reduce the stability of components which were using more than
+the reserved amount of resources; for example, enforcing kube-reserved may cause
+Kubelets to OOM if it uses more than the reserved resources, and enforcing system-reserved
+may cause system daemons to OOM if they use more than the reserved resources.
+Default: ["pods"]</td>
+</tr>
+    
+  
+<tr><td><code>allowedUnsafeSysctls</code><br/>
+<code>[]string</code>
+</td>
+<td>
+   A comma separated whitelist of unsafe sysctls or sysctl patterns (ending in &lowast;).
+Unsafe sysctl groups are kernel.shm&lowast;, kernel.msg&lowast;, kernel.sem, fs.mqueue.&lowast;, and net.&lowast;.
+These sysctls are namespaced but not allowed by default.  For example: "kernel.msg&lowast;,net.ipv4.route.min_pmtu"
+Default: []</td>
+</tr>
+    
+  
+<tr><td><code>volumePluginDir</code><br/>
+<code>string</code>
+</td>
+<td>
+   volumePluginDir is the full path of the directory in which to search
+for additional third party volume plugins.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that changing
+the volumePluginDir may disrupt workloads relying on third party volume plugins.
+Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"</td>
+</tr>
+    
+  
+<tr><td><code>providerID</code><br/>
+<code>string</code>
+</td>
+<td>
+   providerID, if set, sets the unique id of the instance that an external provider (i.e. cloudprovider)
+can use to identify a specific node.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the ability of the Kubelet to interact with cloud providers.
+Default: ""</td>
+</tr>
+    
+  
+<tr><td><code>kernelMemcgNotification</code><br/>
+<code>bool</code>
+</td>
+<td>
+   kernelMemcgNotification, if set, the kubelet will integrate with the kernel memcg notification
+to determine if memory eviction thresholds are crossed rather than polling.
+Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+it may impact the way Kubelet interacts with the kernel.
+Default: false</td>
+</tr>
+    
+  
+<tr><td><code>logging</code> <B>[Required]</B><br/>
+<a href="#LoggingConfiguration"><code>LoggingConfiguration</code></a>
+</td>
+<td>
+   Logging specifies the options of logging.
+Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
+Defaults:
+  Format: text</td>
+</tr>
+    
+  
+<tr><td><code>enableSystemLogHandler</code><br/>
+<code>bool</code>
+</td>
+<td>
+   enableSystemLogHandler enables system logs via web interface host:port/logs/
+Default: true</td>
+</tr>
+    
+  
+<tr><td><code>shutdownGracePeriod</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   ShutdownGracePeriod specifies the total duration that the node should delay the shutdown and total grace period for pod termination during a node shutdown.
+Default: "30s"</td>
+</tr>
+    
+  
+<tr><td><code>shutdownGracePeriodCriticalPods</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   ShutdownGracePeriodCriticalPods specifies the duration used to terminate critical pods during a node shutdown. This should be less than ShutdownGracePeriod.
+For example, if ShutdownGracePeriod=30s, and ShutdownGracePeriodCriticalPods=10s, during a node shutdown the first 20 seconds would be reserved for gracefully terminating normal pods, and the last 10 seconds would be reserved for terminating critical pods.
+Default: "10s"</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `SerializedNodeConfigSource`     {#kubelet-config-k8s-io-v1beta1-SerializedNodeConfigSource}
+    
+
+
+
+
+SerializedNodeConfigSource allows us to serialize v1.NodeConfigSource.
+This type is used internally by the Kubelet for tracking checkpointed dynamic configs.
+It exists in the kubeletconfig API group because it is classified as a versioned input to the Kubelet.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubelet.config.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>SerializedNodeConfigSource</code></td></tr>
+    
+
+  
+  
+<tr><td><code>source</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#nodeconfigsource-v1-core"><code>core/v1.NodeConfigSource</code></a>
+</td>
+<td>
+   Source is the source that we are serializing</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `HairpinMode`     {#kubelet-config-k8s-io-v1beta1-HairpinMode}
+    
+(Alias of `string`)
+
+
+
+HairpinMode denotes how the kubelet should configure networking to handle
+hairpin packets.
+
+
+    
+
+
+## `KubeletAnonymousAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletAnonymousAuthentication}
+    
+
+
+
+**Appears in:**
+
+- [KubeletAuthentication](#kubelet-config-k8s-io-v1beta1-KubeletAuthentication)
+
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>enabled</code><br/>
+<code>bool</code>
+</td>
+<td>
+   enabled allows anonymous requests to the kubelet server.
+Requests that are not rejected by another authentication method are treated as anonymous requests.
+Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeletAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthentication}
+    
+
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>x509</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletX509Authentication"><code>KubeletX509Authentication</code></a>
+</td>
+<td>
+   x509 contains settings related to x509 client certificate authentication</td>
+</tr>
+    
+  
+<tr><td><code>webhook</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthentication"><code>KubeletWebhookAuthentication</code></a>
+</td>
+<td>
+   webhook contains settings related to webhook bearer token authentication</td>
+</tr>
+    
+  
+<tr><td><code>anonymous</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletAnonymousAuthentication"><code>KubeletAnonymousAuthentication</code></a>
+</td>
+<td>
+   anonymous contains settings related to anonymous authentication</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeletAuthorization`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthorization}
+    
+
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>mode</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorizationMode"><code>KubeletAuthorizationMode</code></a>
+</td>
+<td>
+   mode is the authorization mode to apply to requests to the kubelet server.
+Valid values are AlwaysAllow and Webhook.
+Webhook mode uses the SubjectAccessReview API to determine authorization.</td>
+</tr>
+    
+  
+<tr><td><code>webhook</code><br/>
+<a href="#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthorization"><code>KubeletWebhookAuthorization</code></a>
+</td>
+<td>
+   webhook contains settings related to Webhook authorization.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeletAuthorizationMode`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthorizationMode}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [KubeletAuthorization](#kubelet-config-k8s-io-v1beta1-KubeletAuthorization)
+
+
+
+
+
+    
+
+
+## `KubeletWebhookAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthentication}
+    
+
+
+
+**Appears in:**
+
+- [KubeletAuthentication](#kubelet-config-k8s-io-v1beta1-KubeletAuthentication)
+
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>enabled</code><br/>
+<code>bool</code>
+</td>
+<td>
+   enabled allows bearer token authentication backed by the tokenreviews.authentication.k8s.io API</td>
+</tr>
+    
+  
+<tr><td><code>cacheTTL</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   cacheTTL enables caching of authentication results</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeletWebhookAuthorization`     {#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthorization}
+    
+
+
+
+**Appears in:**
+
+- [KubeletAuthorization](#kubelet-config-k8s-io-v1beta1-KubeletAuthorization)
+
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>cacheAuthorizedTTL</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   cacheAuthorizedTTL is the duration to cache 'authorized' responses from the webhook authorizer.</td>
+</tr>
+    
+  
+<tr><td><code>cacheUnauthorizedTTL</code><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   cacheUnauthorizedTTL is the duration to cache 'unauthorized' responses from the webhook authorizer.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `KubeletX509Authentication`     {#kubelet-config-k8s-io-v1beta1-KubeletX509Authentication}
+    
+
+
+
+**Appears in:**
+
+- [KubeletAuthentication](#kubelet-config-k8s-io-v1beta1-KubeletAuthentication)
+
+
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>clientCAFile</code><br/>
+<code>string</code>
+</td>
+<td>
+   clientCAFile is the path to a PEM-encoded certificate bundle. If set, any request presenting a client certificate
+signed by one of the authorities in the bundle is authenticated with a username corresponding to the CommonName,
+and groups corresponding to the Organization in the client certificate.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ResourceChangeDetectionStrategy`     {#kubelet-config-k8s-io-v1beta1-ResourceChangeDetectionStrategy}
+    
+(Alias of `string`)
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+ResourceChangeDetectionStrategy denotes a mode in which internal
+managers (secret, configmap) are discovering object changes.
+
+
+    
+  
+  
+    
+
+## `LoggingConfiguration`     {#LoggingConfiguration}
+    
+
+
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+LoggingConfiguration contains logging options
+Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>format</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Format Flag specifies the structure of log messages.
+default value of format is `text`</td>
+</tr>
+    
+  
+<tr><td><code>sanitization</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</td>
+</tr>
+    
+  
+</tbody>
+</table>

--- a/genref/output/md/metrics.v1beta1.md
+++ b/genref/output/md/metrics.v1beta1.md
@@ -1,0 +1,261 @@
+---
+title: Kubernetes Metrics (v1alpha1)
+content_type: tool-reference
+package: metrics.k8s.io/v1beta1
+auto_generated: true
+---
+Package v1beta1 is the v1beta1 version of the metrics API.
+
+## Resource Types 
+
+
+- [NodeMetrics](#metrics-k8s-io-v1beta1-NodeMetrics)
+- [NodeMetricsList](#metrics-k8s-io-v1beta1-NodeMetricsList)
+- [PodMetrics](#metrics-k8s-io-v1beta1-PodMetrics)
+- [PodMetricsList](#metrics-k8s-io-v1beta1-PodMetricsList)
+  
+    
+
+
+## `NodeMetrics`     {#metrics-k8s-io-v1beta1-NodeMetrics}
+    
+
+
+
+**Appears in:**
+
+- [NodeMetricsList](#metrics-k8s-io-v1beta1-NodeMetricsList)
+
+
+NodeMetrics sets resource usage metrics of a node.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>NodeMetrics</code></td></tr>
+    
+
+  
+  
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
+</tr>
+    
+  
+<tr><td><code>timestamp</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   The following fields define time interval from which metrics were
+collected from the interval [Timestamp-Window, Timestamp].</td>
+</tr>
+    
+  
+<tr><td><code>window</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>usage</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
+</td>
+<td>
+   The memory usage is the memory working set.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `NodeMetricsList`     {#metrics-k8s-io-v1beta1-NodeMetricsList}
+    
+
+
+
+
+NodeMetricsList is a list of NodeMetrics.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>NodeMetricsList</code></td></tr>
+    
+
+  
+  
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+</td>
+<td>
+   Standard list metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</td>
+</tr>
+    
+  
+<tr><td><code>items</code> <B>[Required]</B><br/>
+<a href="#metrics-k8s-io-v1beta1-NodeMetrics"><code>[]NodeMetrics</code></a>
+</td>
+<td>
+   List of node metrics.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PodMetrics`     {#metrics-k8s-io-v1beta1-PodMetrics}
+    
+
+
+
+**Appears in:**
+
+- [PodMetricsList](#metrics-k8s-io-v1beta1-PodMetricsList)
+
+
+PodMetrics sets resource usage metrics of a pod.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>PodMetrics</code></td></tr>
+    
+
+  
+  
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
+</tr>
+    
+  
+<tr><td><code>timestamp</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   The following fields define time interval from which metrics were
+collected from the interval [Timestamp-Window, Timestamp].</td>
+</tr>
+    
+  
+<tr><td><code>window</code> <B>[Required]</B><br/>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+    
+  
+<tr><td><code>containers</code> <B>[Required]</B><br/>
+<a href="#metrics-k8s-io-v1beta1-ContainerMetrics"><code>[]ContainerMetrics</code></a>
+</td>
+<td>
+   Metrics for all containers are collected within the same time window.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `PodMetricsList`     {#metrics-k8s-io-v1beta1-PodMetricsList}
+    
+
+
+
+
+PodMetricsList is a list of PodMetrics.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>PodMetricsList</code></td></tr>
+    
+
+  
+  
+<tr><td><code>metadata</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
+</td>
+<td>
+   Standard list metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</td>
+</tr>
+    
+  
+<tr><td><code>items</code> <B>[Required]</B><br/>
+<a href="#metrics-k8s-io-v1beta1-PodMetrics"><code>[]PodMetrics</code></a>
+</td>
+<td>
+   List of pod metrics.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+
+
+## `ContainerMetrics`     {#metrics-k8s-io-v1beta1-ContainerMetrics}
+    
+
+
+
+**Appears in:**
+
+- [PodMetrics](#metrics-k8s-io-v1beta1-PodMetrics)
+
+
+ContainerMetrics sets resource usage metrics of a container.
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   Container name corresponding to the one from pod.spec.containers.</td>
+</tr>
+    
+  
+<tr><td><code>usage</code> <B>[Required]</B><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
+</td>
+<td>
+   The memory usage is the memory working set.</td>
+</tr>
+    
+  
+</tbody>
+</table>
+    
+  

--- a/genref/types.go
+++ b/genref/types.go
@@ -332,7 +332,15 @@ func (t *apiType) References() []*apiType {
 		}
 	}
 	for k := range m {
-		out = append(out, k)
+		found := false
+		for _, e := range out {
+			if k.DisplayName() == e.DisplayName() && k.Link() == e.Link() {
+				found = true
+			}
+		}
+		if !found {
+			out = append(out, k)
+		}
 	}
 	sortTypes(out)
 	return out


### PR DESCRIPTION
I'm proposing a version control for the config outputs because:

- We want to know how frequent the upstream config structs are changed;
- The config files (HTML plus MD) are not huge assets to manage;
- We can later decide to remove this from version control when we gain
  more confidence about the generator and the workflow.

These files are separated from the PR #176 to ease the PR review.