### PR TITLE
Add resourcequota config

### DIFF
--- a/genref/config.yaml
+++ b/genref/config.yaml
@@ -116,6 +116,11 @@ apis:
     package: k8s.io/apiserver
     path: pkg/apis/audit/v1
 
+  - name: apiserver-resourcequota
+    title: kube-apiserver ResourceQuota Configuration (v1)
+    package: k8s.io/apiserver
+    path: pkg/admission/plugin/resourcequota/apis/resourcequota/v1
+
   - name: apiserver-webhookadmission
     title: WebhookAdmission Configuration (v1alpha1)
     package: k8s.io/apiserver

--- a/genref/markdown/pkg.tpl
+++ b/genref/markdown/pkg.tpl
@@ -1,8 +1,8 @@
 {{ define "packages" -}}
 
-{{- range .packages -}}
+{{- range $idx, $val := .packages -}}
 {{/* Only display package that has a group name */}}
-{{- if ne .GroupName "" -}}
+{{- if and (ne .GroupName "") (eq $idx 0) -}}
 ---
 title: {{ .Title }}
 content_type: tool-reference

--- a/genref/types.go
+++ b/genref/types.go
@@ -341,6 +341,10 @@ func (t *apiType) References() []*apiType {
 // groupName extracts the "//+groupName" meta-comment from the specified
 // package's comments, or returns empty string if it cannot be found.
 func groupName(gopkg *types.Package) string {
+	p := gopkg.Constants["GroupName"]
+	if p != nil {
+		return *p.ConstValue
+	}
 	m := types.ExtractCommentTags("+", gopkg.Comments)
 	v := m["groupName"]
 	if len(v) == 1 {


### PR DESCRIPTION
This adds the support to generate resourcequota configuration reference. We also prefer the GroupName used over the 'groupName' comment which sometimes deviates from the implementation.

related: https://github.com/kubernetes/website/pull/26820
