### PR TITLE
Use code tag instead of samp for config API types

### DIFF
--- a/genref/config.yaml
+++ b/genref/config.yaml
@@ -38,6 +38,8 @@ apis:
     title: Kubelet Stats (v1alpha1)
     package: k8s.io/kubelet
     path: pkg/apis/stats/v1alpha1
+    # Skip this because not referenced anywhere and it has no group name
+    skip: true
 
   - name: kube-scheduler-config
     title: kube-scheduler Configuration (v1beta1)
@@ -69,6 +71,8 @@ apis:
     title: Kubernetes Metrics (v1alpha1)
     package: k8s.io/metrics
     path: pkg/apis/metrics/v1alpha1
+    # superceded by v1beta1 version
+    skip: true
 
   - name: metrics
     title: Kubernetes Metrics (v1alpha1)
@@ -79,6 +83,8 @@ apis:
     title: Client Authentication (v1alpha1)
     package: k8s.io/client-go
     path: pkg/apis/clientauthentication/v1alpha1
+    # superceded by v1beta1
+    skip: true
 
   - name: client-authentication
     title: Client Authentication (v1beta1)

--- a/genref/markdown/members.tpl
+++ b/genref/markdown/members.tpl
@@ -4,21 +4,21 @@
   {{- range .GetMembers -}}
     {{/* . is a apiMember */}}
     {{- if not .Hidden }}
-<tr><td><samp>{{ .FieldName }}</samp>
+<tr><td><code>{{ .FieldName }}</code>
       {{- if not .IsOptional }} <B>[Required]</B>{{- end -}}
 <br/>
 {{/* Link for type reference */}}
       {{- with .GetType -}}
         {{- if .Link -}}
-<a href="{{ .Link }}"><samp>{{ .DisplayName }}</samp></a>
+<a href="{{ .Link }}"><code>{{ .DisplayName }}</code></a>
         {{- else -}}
-<samp>{{ .DisplayName }}</samp>
+<code>{{ .DisplayName }}</code>
         {{- end -}}
       {{- end }}
 </td>
 <td>
    {{- if .IsInline -}}
-(Members of <samp>{{ .FieldName }}</samp> are embedded into this type.)
+(Members of <code>{{ .FieldName }}</code> are embedded into this type.)
    {{- end }}
    {{ if .GetComment -}}
    {{ .GetComment }}
@@ -26,7 +26,7 @@
    <span class="text-muted">No description provided.</span>
    {{ end }}
    {{- if and (eq (.GetType.Name.Name) "ObjectMeta") -}}
-Refer to the Kubernetes API documentation for the fields of the <samp>metadata</samp> field.
+Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.
    {{- end -}}
 </td>
 </tr>

--- a/genref/markdown/pkg.tpl
+++ b/genref/markdown/pkg.tpl
@@ -1,24 +1,25 @@
 {{ define "packages" -}}
 
+{{ $grpname := "" -}}
 {{- range $idx, $val := .packages -}}
-{{/* Only display package that has a group name */}}
-{{- if and (ne .GroupName "") (eq $idx 0) -}}
+{{- if and (ne .GroupName "") (eq $grpname "") -}}
 ---
 title: {{ .Title }}
 content_type: tool-reference
 package: {{ .DisplayName }}
 auto_generated: true
 ---
-{{ .GetComment }}
+{{ .GetComment -}}
+{{ $grpname = .GroupName }}
 {{- end -}}
 {{- end }}
 
 ## Resource Types 
 
-{{ range .packages }}
-  {{ if ne .GroupName "" -}}
+{{ range .packages -}}
+  {{- if ne .GroupName "" -}}
     {{- range .VisibleTypes -}}
-      {{ if .IsExported }}
+      {{- if .IsExported }}
 - [{{ .DisplayName }}]({{ .Link }})
       {{- end -}}
     {{- end -}}

--- a/genref/markdown/type.tpl
+++ b/genref/markdown/type.tpl
@@ -24,8 +24,8 @@
     {{/* . is a apiType */}}
     {{- if .IsExported -}}
 {{/* Add apiVersion and kind rows if deemed necessary */}}
-<tr><td><samp>apiVersion</samp><br/>string</td><td><samp>{{- .APIGroup -}}</samp></td></tr>
-<tr><td><samp>kind</samp><br/>string</td><td><samp>{{- .Name.Name -}}</samp></td></tr>
+<tr><td><code>apiVersion</code><br/>string</td><td><code>{{- .APIGroup -}}</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>{{- .Name.Name -}}</code></td></tr>
     {{ end -}}
 
 {{/* The actual list of members is in the following template */}}

--- a/genref/types.go
+++ b/genref/types.go
@@ -332,7 +332,15 @@ func (t *apiType) References() []*apiType {
 		}
 	}
 	for k := range m {
-		out = append(out, k)
+		found := false
+		for _, e := range out {
+			if k.DisplayName() == e.DisplayName() && k.Link() == e.Link() {
+				found = true
+			}
+		}
+		if !found {
+			out = append(out, k)
+		}
 	}
 	sortTypes(out)
 	return out


### PR DESCRIPTION
This PR optimizes the config API generator and fixed some nits:
    
- Use code tag instead of samp for config API types (team agreed to fix `<code>` style rather than using `<samp>`)
- Skip more packages because they are not used, buggy, or superceded
- Improved `pkg` template logic for testing group name
- Added detection for duplicated entries in references, which was identified during review
