### PR TITLE
Tune Makefile and Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - KUBE_VERSION: 1.21
+    - K8S_RELEASE: 1.21.0
     - BUILD_PATH: /home/travis/gopath
 language: go
 go:
@@ -8,13 +8,13 @@ go:
 
 install:
 - mkdir -p ${BUILD_PATH}/src/k8s.io
-- wget https://github.com/kubernetes/kubernetes/archive/v${KUBE_VERSION}.0.tar.gz -O ${BUILD_PATH}/src/k8s.io/kubernetes-src.tar.gz
-- pushd ${BUILD_PATH}/src/k8s.io && tar xzf kubernetes-src.tar.gz && mv kubernetes-${KUBE_VERSION}.0 kubernetes && popd
+- wget https://github.com/kubernetes/kubernetes/archive/v${K8S_RELEASE}.tar.gz -O ${BUILD_PATH}/src/k8s.io/kubernetes-src.tar.gz
+- pushd ${BUILD_PATH}/src/k8s.io && tar xzf kubernetes-src.tar.gz && mv kubernetes-${K8S_RELEASE} kubernetes && popd
 - pushd ${BUILD_PATH}/src/k8s.io/kubernetes && make generated_files && popd
 
 script:
 - make comp
 - make genresources
-# TODO: uncomment the following to make other docs
-# - make api
+- make api
+- make configapi
 # - make cli

--- a/genref/Makefile
+++ b/genref/Makefile
@@ -1,3 +1,8 @@
 
-all:
+genref:
 	go build -mod mod -o genref
+
+all: genref
+	./genref -o output/md
+
+	


### PR DESCRIPTION
This PR tunes the Makefile by:

- improve detection of K8S_RELEASE environment variable and error/abort if not defined;
- add new targets `configapi` and `copy-configapi`;
- add `configapi`, `genresources` into the target list;
- move constant definition to where they belong;
- remove the `RCNUM` variable which is not used anywhere.

The PR tunes the travis configuration by:

- replace the `KUBE_VERSION` environemnt variable by `K8S_RELEASE` for consistency;
- upgrade go version from 1.15.5 to 1.16.3 which is the default version used by the upstream community/repo;
- add `api`, `configapi` into list of scripts to be executed.