### PR TITLE
Update component reference generator

### DIFF
--- a/gen-compdocs/generators/doc.go
+++ b/gen-compdocs/generators/doc.go
@@ -454,6 +454,8 @@ func unquoteUsage(flag *pflag.Flag) (name string, usage string) {
 func processUsage(usage string) string {
 	var buf bytes.Buffer
 	var result string
+	usage = strings.Replace(usage, "<", "&lt;", -1)
+	usage = strings.Replace(usage, ">", "&gt;", -1)
 	md := goldmark.New(goldmark.WithExtensions(highlighting.Highlighting))
 	if err := md.Convert([]byte(usage), &buf); err != nil {
 		result = usage

--- a/gen-compdocs/go.mod
+++ b/gen-compdocs/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golangplus/testing v1.0.0 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
-	github.com/yuin/goldmark v1.2.1
+	github.com/yuin/goldmark v1.3.5
 	github.com/yuin/goldmark-highlighting v0.0.0-20200307114337-60d527fdb691
 	k8s.io/component-base v0.21.0
 	k8s.io/kubectl v0.0.0

--- a/gen-compdocs/go.sum
+++ b/gen-compdocs/go.sum
@@ -723,8 +723,9 @@ github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6Ut
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.22/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.2.1 h1:ruQGxdhGHe7FWOJPT0mKs5+pD2Xs1Bm/kdGlHO04FmM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5 h1:dPmz1Snjq0kmkz159iL7S6WzdahUTHnHB5M56WFVifs=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark-highlighting v0.0.0-20200307114337-60d527fdb691 h1:VWSxtAiQNh3zgHJpdpkpVYjTPqRE3P6UZCOPa1nRDio=
 github.com/yuin/goldmark-highlighting v0.0.0-20200307114337-60d527fdb691/go.mod h1:YLF3kDffRfUH/bTxOxHhV6lxwIB3Vfj91rEwNMS9MXo=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
The goldmark package we used for parsing markdown text in option usage has some problems processing `>` and `<` characters. These characters are sometimes treated as HTML flags so the parser emits "raw HTML not emited" messages. This PR fixes the parser by adding a preprocessing step. It also upgrades the package dependency.