### PR TITLE
Update latest events API to events.k8s.io

### DIFF
--- a/gen-apidocs/config/config.yaml
+++ b/gen-apidocs/config/config.yaml
@@ -119,7 +119,7 @@ resource_categories:
       group: apiextensions
     - name: Event
       version: v1
-      group: core
+      group: events
     - name: LimitRange
       version: v1
       group: core

--- a/gen-apidocs/config/v1_19/config.yaml
+++ b/gen-apidocs/config/v1_19/config.yaml
@@ -114,7 +114,7 @@ resource_categories:
       group: apiextensions
     - name: Event
       version: v1
-      group: core
+      group: events
     - name: LimitRange
       version: v1
       group: core

--- a/gen-apidocs/config/v1_20/config.yaml
+++ b/gen-apidocs/config/v1_20/config.yaml
@@ -116,7 +116,7 @@ resource_categories:
       group: apiextensions
     - name: Event
       version: v1
-      group: core
+      group: events
     - name: LimitRange
       version: v1
       group: core

--- a/gen-apidocs/config/v1_21/config.yaml
+++ b/gen-apidocs/config/v1_21/config.yaml
@@ -119,7 +119,7 @@ resource_categories:
       group: apiextensions
     - name: Event
       version: v1
-      group: core
+      group: events
     - name: LimitRange
       version: v1
       group: core

--- a/gen-apidocs/generators/api/types.go
+++ b/gen-apidocs/generators/api/types.go
@@ -54,6 +54,14 @@ func (g ApiGroup) LessThan(other ApiGroup) bool {
 		return false
 	}
 
+	// "events" group APIs are newer than "core" group APIs
+	if g.String() == "events" && other.String() == "core" {
+		return true
+	}
+	if other.String() == "events" && g.String() == "core" {
+		return false
+	}
+
 	return strings.Compare(g.String(), other.String()) < 0
 }
 


### PR DESCRIPTION
In Kubernetes v1.19, the new Events API events.k8s.io was promoted to
v1. As such it now supersedes the original core Events API. Since this
wasn't defined in this project, the official kubernetes-api doc was
putting the events.k8s.io API under the list of old APIs and the
recommended API for Events was still the core one. To fix that, we need
to define that the events API group is newer than the core one.

/cc @ehashman 