### PR TITLE
use k8s-staging-images vs kubernetes-ci-images

### DIFF
--- a/genref/output/html/kubeadm-config.v1beta1.html
+++ b/genref/output/html/kubeadm-config.v1beta1.html
@@ -648,7 +648,7 @@ Possible usages are:
 
           `imageRepository` specifies the container registry from which images are pulled.
 If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
-`gcr.io/kubernetes-ci-images` will be used for control plane components and
+`gcr.io/k8s-staging-ci-images` will be used for control plane components and
 kube-proxy, while `k8s.gcr.io` will be used for all the other images.
 
           

--- a/genref/output/html/kubeadm-config.v1beta2.html
+++ b/genref/output/html/kubeadm-config.v1beta2.html
@@ -639,7 +639,7 @@ The value must be an absolute path.
 
           `imageRepository` specifies the container registry from which images are pulled.
 If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
-`gcr.io/kubernetes-ci-images` will be used for control plane components and
+`gcr.io/k8s-staging-ci-images` will be used for control plane components and
 kube-proxy, while `k8s.gcr.io` will be used for all the other images.
 
           


### PR DESCRIPTION
Related:
- This is part of: https://github.com/kubernetes/k8s.io/issues/2318
- Similar PR: https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/pull/300
- The change this is documenting, which landed 2021-01-14: https://github.com/kubernetes/kubernetes/pull/97087

I did this as a straight search-replace because it was unclear to me how exactly the files I changed are used.

I had initially tried using `genref` but it excluded `v1beta1`, and pulled in way more stuff, which is the sort of thing I'd expect a regular contributor to this repo to handle.