### PR TITLE
Makefile: remove bashism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ cleancli:
 	sudo rm -rf $(shell pwd)/gen-kubectldocs/generators/manifest.json
 
 cli: cleancli
-	pushd gen-kubectldocs && go mod download && go run main.go --kubernetes-version v$(K8SRELEASEDIR) && popd
+	cd gen-kubectldocs && go mod download && go run main.go --kubernetes-version v$(K8SRELEASEDIR)
 	mkdir -p $(CLISRC)
 	docker run -v $(shell pwd)/gen-kubectldocs/generators/includes:/source -v $(shell pwd)/gen-kubectldocs/generators/build:/build -v $(shell pwd)/gen-kubectldocs/generators/:/manifest brianpursley/brodocs:latest
 


### PR DESCRIPTION
"pushd/popd" are not part of POSIX and not supported by dash, the default shell
on Debian and Ubuntu.

This causes the following command to fail:
```
$ make cli WEBROOT=/nvme/gopath/src/k8s.io/website K8SROOT=/nvme/gopath/src/k8s.io/kubernetes K8SRELEASE=1.23.0-beta.0
sudo rm -f main
sudo rm -rf /nvme/gopath/src/sigs.k8s.io/reference-docs/gen-kubectldocs/generators/includes
sudo rm -rf /nvme/gopath/src/sigs.k8s.io/reference-docs/gen-kubectldocs/generators/build
sudo rm -rf /nvme/gopath/src/sigs.k8s.io/reference-docs/gen-kubectldocs/generators/manifest.json
pushd gen-kubectldocs && go mod download && go run main.go --kubernetes-version v1_23 && popd
/bin/sh: 1: pushd: not found
```

Changing back to the original directory is unnecessary here because each make
command runs in its own shell.