### PR TITLE
Fix nits in the config API generator

### DIFF
--- a/genref/Makefile
+++ b/genref/Makefile
@@ -1,8 +1,9 @@
 
-genref:
+genref: main.go types.go
 	go build -mod mod -o genref
 
 all: genref
+	rm -fr output/md/*
 	./genref -o output/md
 
-	
+

--- a/genref/config.yaml
+++ b/genref/config.yaml
@@ -3,17 +3,17 @@ hiddenMemberFields:
 
 externalPackages:
   - match: ^k8s\.io/apimachinery/pkg/apis/meta/v1\.Duration$
-    target: https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration
+    target: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration
   - match: ^k8s\.io/apimachinery/pkg/types\.UID$
-    target: https://godoc.org/k8s.io/apimachinery/pkg/types#UID
+    target: https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID
   - match: ^k8s\.io/apimachinery/pkg/runtime\.RawExtension$
-    target: https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension
+    target: https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/#RawExtension
   - match: ^k8s\.io/apimachinery/pkg/api/resource\.QuantityValue$
     target: https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue
   - match: ^k8s\.io/apimachinery/pkg/runtime\.Unknown$
-    target: https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown
+    target: https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Unknown
   - match: ^time\.Duration$
-    target: https://godoc.org/time#Duration
+    target: https://pkg.go.dev/time#Duration
   - match: ^k8s\.io/(api|apimachinery/pkg/apis)/
     target: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#{{- lower .TypeIdentifier -}}-{{- arrIndex .PackageSegments -1 -}}-{{- arrIndex .PackageSegments -2 -}}
 
@@ -105,7 +105,13 @@ apis:
     package: k8s.io/client-go
     path: pkg/apis/clientauthentication/v1
 
-  # v1alpha1 and v1beta1 are skipped
+  # v1alpha1 is skipped
+  # v1beta1 is preserved because it has different types exposed.
+  - name: apiserver-config
+    title: kube-apiserver Configuration (v1beta1)
+    package: k8s.io/apiserver
+    path: pkg/apis/apiserver/v1beta1
+
   - name: apiserver-config
     title: kube-apiserver Configuration (v1)
     package: k8s.io/apiserver

--- a/genref/go.mod
+++ b/genref/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/tengqm/kubeconfig v0.0.0-20211208031044-eeb467b41192 // indirect
+	github.com/tengqm/kubeconfig v0.0.0-20211220002240-61266accc6b7 // indirect
 	github.com/yuin/goldmark v1.4.0
 	github.com/yuin/goldmark-highlighting v0.0.0-20210516132338-9216f9c5aa01
 	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e // indirect

--- a/genref/go.sum
+++ b/genref/go.sum
@@ -425,6 +425,12 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tengqm/kubeconfig v0.0.0-20211208031044-eeb467b41192 h1:k6yierBEpI0WA3J3XoZ3N1N8ymUf1B2dtIvUxxPhckA=
 github.com/tengqm/kubeconfig v0.0.0-20211208031044-eeb467b41192/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
+github.com/tengqm/kubeconfig v0.0.0-20211211121435-c4c77f58ab33 h1:UA0bq2xCYsr37nJXcesK45N1+BnvmjMAbx1TEbmUmpE=
+github.com/tengqm/kubeconfig v0.0.0-20211211121435-c4c77f58ab33/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
+github.com/tengqm/kubeconfig v0.0.0-20211219101435-116361aff6b8 h1:anl9FX6bKUyr8SSDLNaqAno4qulxM3yr8FitdIujYE4=
+github.com/tengqm/kubeconfig v0.0.0-20211219101435-116361aff6b8/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
+github.com/tengqm/kubeconfig v0.0.0-20211220002240-61266accc6b7 h1:5najYSbgJG+Yrh/sdYJfbGkGV+3uHEb11GtIXRVq/TA=
+github.com/tengqm/kubeconfig v0.0.0-20211220002240-61266accc6b7/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/genref/html/pkg.tpl
+++ b/genref/html/pkg.tpl
@@ -16,25 +16,15 @@
     </head>
     <body>
       <div class="container">
-        <!--
-        <H2>Packages:</H2>
-        <ul>
-          {{ range .packages }}
-            {{/* Skip package which doesn't have a group name defined */}}
-            {{ if ne .GroupName ""}}
-              <li>
-                <a href="#{{- .Anchor -}}">{{ .DisplayName }}</a>
-              </li>
-            {{ end }}
-          {{ end }}
-        </ul>
-        -->
         {{ range .packages }}
           {{/* Only display package that has a group name */}}
           {{ if ne .GroupName "" }}
             <H2 id="{{- .Anchor -}}">Package: <span style="font-family: monospace">{{- .DisplayName -}}</span></H2>
             <p>{{ .GetComment }}</p>
-
+          {{ end }}
+        {{ end }}
+        {{ range .packages }}
+          {{ if ne .GroupName "" }}
             {{/* TODO: Make the following line conditional */}}
             <H3>Resource Types:</H3>
             <ul>
@@ -49,23 +39,24 @@
 
             {{/* For package with a group name, list all type definitions in it. */}}
             {{ range .VisibleTypes }}
-              {{ template "type" .  }}
+              {{- if or .Referenced .IsExported -}}
+                {{ template "type" .  }}
+              {{- end -}}
             {{ end }}
           {{ else }}
             {{/* For package without a group name, list only type definitions that are referenced. */}}
             {{ range .VisibleTypes }}
               {{ if .Referenced }}
-                {{ template "type" .  }}
+                {{ template "type" . }}
               {{ end }}
             {{ end }}
           {{ end }}
-
           <HR />
         {{ end }}
       </div>
 
       <div class="container">
-        <p><em>Generated with <code>gendoc</code>{{ with .gitCommit }} on git commit <code>{{ . }}</code>{{end}}</em></p>
+        <p><em>Generated with <code>genref</code>{{ with .gitCommit }} on git commit <code>{{ . }}</code>{{end}}</em></p>
       </div>
     </body>
   </html>

--- a/genref/html/type.tpl
+++ b/genref/html/type.tpl
@@ -9,9 +9,11 @@
       (<em>Appears in:</em>
       {{- $prev := "" -}}
       {{- range . -}}
+        {{- if or .Referenced .IsExported -}}
         {{- if $prev -}}, {{ end -}}
         {{ $prev = . }}
         <a href="{{ .Link }}">{{ .DisplayName }}</a>
+        {{- end }}
       {{- end -}}
       )
     </p>

--- a/genref/markdown/members.tpl
+++ b/genref/markdown/members.tpl
@@ -1,5 +1,4 @@
 {{ define "members" }}
-
   {{/* . is a apiType */}}
   {{- range .GetMembers -}}
     {{/* . is a apiMember */}}
@@ -24,12 +23,12 @@
    {{ .GetComment }}
    {{- else -}}
    <span class="text-muted">No description provided.</span>
-   {{ end }}
+   {{- end }}
    {{- if and (eq (.GetType.Name.Name) "ObjectMeta") -}}
 Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.
    {{- end -}}
 </td>
 </tr>
-    {{ end }}
-  {{ end }}
+    {{- end }}
+  {{- end }}
 {{ end }}

--- a/genref/markdown/pkg.tpl
+++ b/genref/markdown/pkg.tpl
@@ -31,7 +31,9 @@ auto_generated: true
      
     {{/* For package with a group name, list all type definitions in it. */}}
     {{ range .VisibleTypes }}
+      {{- if or .Referenced .IsExported -}}
 {{ template "type" . }}
+      {{- end -}}
     {{ end }}
   {{ else }}
     {{/* For package w/o group name, list only types referenced. */}}

--- a/genref/markdown/type.tpl
+++ b/genref/markdown/type.tpl
@@ -4,19 +4,20 @@
     
 {{ if eq .Kind "Alias" -}}
 (Alias of `{{ .Underlying }}`)
-{{- end }}
+{{ end }}
 
-{{ with .References }}
+{{- with .References }}
 **Appears in:**
 {{ range . }}
+{{ if or .Referenced .IsExported -}}
 - [{{ .DisplayName }}]({{ .Link }})
-{{ end }}
+{{ end -}}
+{{- end -}}
 {{- end }}
 
 {{ if .GetComment -}}
 {{ .GetComment }}
-{{- end }}
-
+{{ end }}
 {{ if .GetMembers -}}
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>

--- a/genref/output/md/apiserver-audit.v1.md
+++ b/genref/output/md/apiserver-audit.v1.md
@@ -16,18 +16,16 @@ auto_generated: true
   
     
 
-
 ## `Event`     {#audit-k8s-io-v1-Event}
     
-
-
 
 **Appears in:**
 
 - [EventList](#audit-k8s-io-v1-EventList)
 
 
-Event captures all the information that can be included in an API audit log.
+<p>Event captures all the information that can be included in an API audit log.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -36,164 +34,143 @@ Event captures all the information that can be included in an API audit log.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>audit.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>Event</code></td></tr>
     
-
-  
   
 <tr><td><code>level</code> <B>[Required]</B><br/>
 <a href="#audit-k8s-io-v1-Level"><code>Level</code></a>
 </td>
 <td>
-   AuditLevel at which event was generated</td>
+   <p>AuditLevel at which event was generated</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>auditID</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
 </td>
 <td>
-   Unique audit ID, generated for each request.</td>
+   <p>Unique audit ID, generated for each request.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>stage</code> <B>[Required]</B><br/>
 <a href="#audit-k8s-io-v1-Stage"><code>Stage</code></a>
 </td>
 <td>
-   Stage of the request handling when this event instance was generated.</td>
+   <p>Stage of the request handling when this event instance was generated.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>requestURI</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   RequestURI is the request URI as sent by the client to a server.</td>
+   <p>RequestURI is the request URI as sent by the client to a server.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>verb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb is the kubernetes verb associated with the request.
-For non-resource requests, this is the lower-cased HTTP method.</td>
+   <p>Verb is the kubernetes verb associated with the request.
+For non-resource requests, this is the lower-cased HTTP method.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>user</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#userinfo-v1-authentication"><code>authentication/v1.UserInfo</code></a>
 </td>
 <td>
-   Authenticated user information.</td>
+   <p>Authenticated user information.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>impersonatedUser</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#userinfo-v1-authentication"><code>authentication/v1.UserInfo</code></a>
 </td>
 <td>
-   Impersonated user information.</td>
+   <p>Impersonated user information.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>sourceIPs</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   Source IPs, from where the request originated and intermediate proxies.</td>
+   <p>Source IPs, from where the request originated and intermediate proxies.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>userAgent</code><br/>
 <code>string</code>
 </td>
 <td>
-   UserAgent records the user agent string reported by the client.
-Note that the UserAgent is provided by the client, and must not be trusted.</td>
+   <p>UserAgent records the user agent string reported by the client.
+Note that the UserAgent is provided by the client, and must not be trusted.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>objectRef</code><br/>
 <a href="#audit-k8s-io-v1-ObjectReference"><code>ObjectReference</code></a>
 </td>
 <td>
-   Object reference this request is targeted at.
-Does not apply for List-type requests, or non-resource requests.</td>
+   <p>Object reference this request is targeted at.
+Does not apply for List-type requests, or non-resource requests.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>responseStatus</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#status-v1-meta"><code>meta/v1.Status</code></a>
 </td>
 <td>
-   The response status, populated even when the ResponseObject is not a Status type.
+   <p>The response status, populated even when the ResponseObject is not a Status type.
 For successful responses, this will only include the Code and StatusSuccess.
-For non-status type error responses, this will be auto-populated with the error Message.</td>
+For non-status type error responses, this will be auto-populated with the error Message.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>requestObject</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
 </td>
 <td>
-   API object from the request, in JSON format. The RequestObject is recorded as-is in the request
+   <p>API object from the request, in JSON format. The RequestObject is recorded as-is in the request
 (possibly re-encoded as JSON), prior to version conversion, defaulting, admission or
 merging. It is an external versioned object type, and may not be a valid object on its own.
-Omitted for non-resource requests.  Only logged at Request Level and higher.</td>
+Omitted for non-resource requests.  Only logged at Request Level and higher.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>responseObject</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
 </td>
 <td>
-   API object returned in the response, in JSON. The ResponseObject is recorded after conversion
+   <p>API object returned in the response, in JSON. The ResponseObject is recorded after conversion
 to the external type, and serialized as JSON.  Omitted for non-resource requests.  Only logged
-at Response Level.</td>
+at Response Level.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>requestReceivedTimestamp</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
 </td>
 <td>
-   Time the request reached the apiserver.</td>
+   <p>Time the request reached the apiserver.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>stageTimestamp</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#microtime-v1-meta"><code>meta/v1.MicroTime</code></a>
 </td>
 <td>
-   Time the request reached current audit stage.</td>
+   <p>Time the request reached current audit stage.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>annotations</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   Annotations is an unstructured key value map stored with an audit event that may be set by
+   <p>Annotations is an unstructured key value map stored with an audit event that may be set by
 plugins invoked in the request serving chain, including authentication, authorization and
 admission plugins. Note that these annotations are for the audit event, and do not correspond
 to the metadata.annotations of the submitted object. Keys should uniquely identify the informing
 component to avoid name collisions (e.g. podsecuritypolicy.admission.k8s.io/policy). Values
-should be short. Annotations are included in the Metadata level.</td>
+should be short. Annotations are included in the Metadata level.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `EventList`     {#audit-k8s-io-v1-EventList}
     
 
 
+<p>EventList is a list of audit Events.</p>
 
-
-EventList is a list of audit Events.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -202,44 +179,33 @@ EventList is a list of audit Events.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>audit.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>EventList</code></td></tr>
     
-
-  
   
 <tr><td><code>metadata</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>items</code> <B>[Required]</B><br/>
 <a href="#audit-k8s-io-v1-Event"><code>[]Event</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Policy`     {#audit-k8s-io-v1-Policy}
     
-
-
 
 **Appears in:**
 
 - [PolicyList](#audit-k8s-io-v1-PolicyList)
 
 
-Policy defines the configuration of audit logging, and the rules for how different request
-categories are logged.
+<p>Policy defines the configuration of audit logging, and the rules for how different request
+categories are logged.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -248,62 +214,53 @@ categories are logged.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>audit.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>Policy</code></td></tr>
     
-
-  
   
 <tr><td><code>metadata</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
 </td>
 <td>
-   ObjectMeta is included for interoperability with API infrastructure.Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
+   <p>ObjectMeta is included for interoperability with API infrastructure.</p>
+Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-    
-  
 <tr><td><code>rules</code> <B>[Required]</B><br/>
 <a href="#audit-k8s-io-v1-PolicyRule"><code>[]PolicyRule</code></a>
 </td>
 <td>
-   Rules specify the audit Level a request should be recorded at.
+   <p>Rules specify the audit Level a request should be recorded at.
 A request may match multiple rules, in which case the FIRST matching rule is used.
 The default audit level is None, but can be overridden by a catch-all rule at the end of the list.
-PolicyRules are strictly ordered.</td>
+PolicyRules are strictly ordered.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>omitStages</code><br/>
 <a href="#audit-k8s-io-v1-Stage"><code>[]Stage</code></a>
 </td>
 <td>
-   OmitStages is a list of stages for which no events are created. Note that this can also
-be specified per rule in which case the union of both are omitted.</td>
+   <p>OmitStages is a list of stages for which no events are created. Note that this can also
+be specified per rule in which case the union of both are omitted.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>omitManagedFields</code><br/>
 <code>bool</code>
 </td>
 <td>
-   OmitManagedFields indicates whether to omit the managed fields of the request
+   <p>OmitManagedFields indicates whether to omit the managed fields of the request
 and response bodies from being written to the API audit log.
 This is used as a global default - a value of 'true' will omit the managed fileds,
 otherwise the managed fields will be included in the API audit log.
 Note that this can also be specified per rule in which case the value specified
-in a rule will override the global default.</td>
+in a rule will override the global default.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PolicyList`     {#audit-k8s-io-v1-PolicyList}
     
 
 
+<p>PolicyList is a list of audit Policies.</p>
 
-
-PolicyList is a list of audit Policies.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -312,99 +269,78 @@ PolicyList is a list of audit Policies.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>audit.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>PolicyList</code></td></tr>
     
-
-  
   
 <tr><td><code>metadata</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>items</code> <B>[Required]</B><br/>
 <a href="#audit-k8s-io-v1-Policy"><code>[]Policy</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `GroupResources`     {#audit-k8s-io-v1-GroupResources}
     
-
-
 
 **Appears in:**
 
 - [PolicyRule](#audit-k8s-io-v1-PolicyRule)
 
 
-GroupResources represents resource kinds in an API group.
+<p>GroupResources represents resource kinds in an API group.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>group</code><br/>
 <code>string</code>
 </td>
 <td>
-   Group is the name of the API group that contains the resources.
-The empty string represents the core API group.</td>
+   <p>Group is the name of the API group that contains the resources.
+The empty string represents the core API group.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resources</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   Resources is a list of resources this rule applies to.
-
-For example:
+   <p>Resources is a list of resources this rule applies to.</p>
+<p>For example:
 'pods' matches pods.
 'pods/log' matches the log subresource of pods.
-'&lowast;' matches all resources and their subresources.
-'pods/&lowast;' matches all subresources of pods.
-'&lowast;/scale' matches all scale subresources.
-
-If wildcard is present, the validation rule will ensure resources do not
-overlap with each other.
-
-An empty list implies all resources and subresources in this API groups apply.</td>
+'<em>' matches all resources and their subresources.
+'pods/</em>' matches all subresources of pods.
+'&lowast;/scale' matches all scale subresources.</p>
+<p>If wildcard is present, the validation rule will ensure resources do not
+overlap with each other.</p>
+<p>An empty list implies all resources and subresources in this API groups apply.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceNames</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   ResourceNames is a list of resource instance names that the policy matches.
+   <p>ResourceNames is a list of resource instance names that the policy matches.
 Using this field requires Resources to be specified.
-An empty list implies that every instance of the resource is matched.</td>
+An empty list implies that every instance of the resource is matched.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Level`     {#audit-k8s-io-v1-Level}
     
 (Alias of `string`)
 
-
 **Appears in:**
 
 - [Event](#audit-k8s-io-v1-Event)
@@ -412,225 +348,188 @@ An empty list implies that every instance of the resource is matched.</td>
 - [PolicyRule](#audit-k8s-io-v1-PolicyRule)
 
 
-Level defines the amount of information logged during auditing
+<p>Level defines the amount of information logged during auditing</p>
 
 
-    
 
 
 ## `ObjectReference`     {#audit-k8s-io-v1-ObjectReference}
     
 
-
-
 **Appears in:**
 
 - [Event](#audit-k8s-io-v1-Event)
 
 
-ObjectReference contains enough information to let you inspect or modify the referred object.
+<p>ObjectReference contains enough information to let you inspect or modify the referred object.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>resource</code><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>namespace</code><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>name</code><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>uid</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/types#UID"><code>k8s.io/apimachinery/pkg/types.UID</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>apiGroup</code><br/>
 <code>string</code>
 </td>
 <td>
-   APIGroup is the name of the API group that contains the referred object.
-The empty string represents the core API group.</td>
+   <p>APIGroup is the name of the API group that contains the referred object.
+The empty string represents the core API group.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>apiVersion</code><br/>
 <code>string</code>
 </td>
 <td>
-   APIVersion is the version of the API group that contains the referred object.</td>
+   <p>APIVersion is the version of the API group that contains the referred object.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceVersion</code><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>subresource</code><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PolicyRule`     {#audit-k8s-io-v1-PolicyRule}
     
-
-
 
 **Appears in:**
 
 - [Policy](#audit-k8s-io-v1-Policy)
 
 
-PolicyRule maps requests based off metadata to an audit Level.
-Requests must match the rules of every field (an intersection of rules).
+<p>PolicyRule maps requests based off metadata to an audit Level.
+Requests must match the rules of every field (an intersection of rules).</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>level</code> <B>[Required]</B><br/>
 <a href="#audit-k8s-io-v1-Level"><code>Level</code></a>
 </td>
 <td>
-   The Level that requests matching this rule are recorded at.</td>
+   <p>The Level that requests matching this rule are recorded at.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>users</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   The users (by authenticated user name) this rule applies to.
-An empty list implies every user.</td>
+   <p>The users (by authenticated user name) this rule applies to.
+An empty list implies every user.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>userGroups</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   The user groups this rule applies to. A user is considered matching
+   <p>The user groups this rule applies to. A user is considered matching
 if it is a member of any of the UserGroups.
-An empty list implies every user group.</td>
+An empty list implies every user group.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>verbs</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   The verbs that match this rule.
-An empty list implies every verb.</td>
+   <p>The verbs that match this rule.
+An empty list implies every verb.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resources</code><br/>
 <a href="#audit-k8s-io-v1-GroupResources"><code>[]GroupResources</code></a>
 </td>
 <td>
-   Resources that this rule matches. An empty list implies all kinds in all API groups.</td>
+   <p>Resources that this rule matches. An empty list implies all kinds in all API groups.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>namespaces</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   Namespaces that this rule matches.
-The empty string "" matches non-namespaced resources.
-An empty list implies every namespace.</td>
+   <p>Namespaces that this rule matches.
+The empty string &quot;&quot; matches non-namespaced resources.
+An empty list implies every namespace.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nonResourceURLs</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   NonResourceURLs is a set of URL paths that should be audited.
-&lowast;s are allowed, but only as the full, final step in the path.
+   <p>NonResourceURLs is a set of URL paths that should be audited.
+<em>s are allowed, but only as the full, final step in the path.
 Examples:
- "/metrics" - Log requests for apiserver metrics
- "/healthz&lowast;" - Log all health checks</td>
+&quot;/metrics&quot; - Log requests for apiserver metrics
+&quot;/healthz</em>&quot; - Log all health checks</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>omitStages</code><br/>
 <a href="#audit-k8s-io-v1-Stage"><code>[]Stage</code></a>
 </td>
 <td>
-   OmitStages is a list of stages for which no events are created. Note that this can also
+   <p>OmitStages is a list of stages for which no events are created. Note that this can also
 be specified policy wide in which case the union of both are omitted.
-An empty list means no restrictions will apply.</td>
+An empty list means no restrictions will apply.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>omitManagedFields</code><br/>
 <code>bool</code>
 </td>
 <td>
-   OmitManagedFields indicates whether to omit the managed fields of the request
-and response bodies from being written to the API audit log.
-- a value of 'true' will drop the managed fields from the API audit log
-- a value of 'false' indicates that the managed fileds should be included
-  in the API audit log
+   <p>OmitManagedFields indicates whether to omit the managed fields of the request
+and response bodies from being written to the API audit log.</p>
+<ul>
+<li>a value of 'true' will drop the managed fields from the API audit log</li>
+<li>a value of 'false' indicates that the managed fileds should be included
+in the API audit log
 Note that the value, if specified, in this rule will override the global default
 If a value is not specified then the global default specified in
-Policy.OmitManagedFields will stand.</td>
+Policy.OmitManagedFields will stand.</li>
+</ul>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Stage`     {#audit-k8s-io-v1-Stage}
     
 (Alias of `string`)
-
 
 **Appears in:**
 
@@ -641,8 +540,8 @@ Policy.OmitManagedFields will stand.</td>
 - [PolicyRule](#audit-k8s-io-v1-PolicyRule)
 
 
-Stage defines the stages in request handling that audit events may be generated.
+<p>Stage defines the stages in request handling that audit events may be generated.</p>
 
 
-    
+
   

--- a/genref/output/md/apiserver-config.v1.md
+++ b/genref/output/md/apiserver-config.v1.md
@@ -4,7 +4,8 @@ content_type: tool-reference
 package: apiserver.config.k8s.io/v1
 auto_generated: true
 ---
-Package v1 is the v1 version of the API.
+<p>Package v1 is the v1 version of the API.</p>
+
 
 ## Resource Types 
 
@@ -13,14 +14,12 @@ Package v1 is the v1 version of the API.
   
     
 
-
 ## `AdmissionConfiguration`     {#apiserver-config-k8s-io-v1-AdmissionConfiguration}
     
 
 
+<p>AdmissionConfiguration provides versioned configuration for admission controllers.</p>
 
-
-AdmissionConfiguration provides versioned configuration for admission controllers.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -29,68 +28,57 @@ AdmissionConfiguration provides versioned configuration for admission controller
 <tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>AdmissionConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>plugins</code><br/>
 <a href="#apiserver-config-k8s-io-v1-AdmissionPluginConfiguration"><code>[]AdmissionPluginConfiguration</code></a>
 </td>
 <td>
-   Plugins allows specifying a configuration per admission control plugin.</td>
+   <p>Plugins allows specifying a configuration per admission control plugin.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `AdmissionPluginConfiguration`     {#apiserver-config-k8s-io-v1-AdmissionPluginConfiguration}
     
-
-
 
 **Appears in:**
 
 - [AdmissionConfiguration](#apiserver-config-k8s-io-v1-AdmissionConfiguration)
 
 
-AdmissionPluginConfiguration provides the configuration for a single plug-in.
+<p>AdmissionPluginConfiguration provides the configuration for a single plug-in.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the name of the admission controller.
-It must match the registered admission plugin name.</td>
+   <p>Name is the name of the admission controller.
+It must match the registered admission plugin name.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>path</code><br/>
 <code>string</code>
 </td>
 <td>
-   Path is the path to a configuration file that contains the plugin's
-configuration</td>
+   <p>Path is the path to a configuration file that contains the plugin's
+configuration</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>configuration</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
 </td>
 <td>
-   Configuration is an embedded configuration object to be used as the plugin's
-configuration. If present, it will be used instead of the path to the configuration file.</td>
+   <p>Configuration is an embedded configuration object to be used as the plugin's
+configuration. If present, it will be used instead of the path to the configuration file.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   

--- a/genref/output/md/apiserver-config.v1beta1.md
+++ b/genref/output/md/apiserver-config.v1beta1.md
@@ -1,0 +1,268 @@
+---
+title: kube-apiserver Configuration (v1beta1)
+content_type: tool-reference
+package: apiserver.k8s.io/v1beta1
+auto_generated: true
+---
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
+
+
+## Resource Types 
+
+
+- [EgressSelectorConfiguration](#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration)
+  
+    
+
+## `EgressSelectorConfiguration`     {#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration}
+    
+
+
+<p>EgressSelectorConfiguration provides versioned configuration for egress selector clients.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>EgressSelectorConfiguration</code></td></tr>
+    
+  
+<tr><td><code>egressSelections</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1beta1-EgressSelection"><code>[]EgressSelection</code></a>
+</td>
+<td>
+   <p>connectionServices contains a list of egress selection client configurations</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Connection`     {#apiserver-k8s-io-v1beta1-Connection}
+    
+
+**Appears in:**
+
+- [EgressSelection](#apiserver-k8s-io-v1beta1-EgressSelection)
+
+
+<p>Connection provides the configuration for a single egress selection client.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>proxyProtocol</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1beta1-ProtocolType"><code>ProtocolType</code></a>
+</td>
+<td>
+   <p>Protocol is the protocol used to connect from client to the konnectivity server.</p>
+</td>
+</tr>
+<tr><td><code>transport</code><br/>
+<a href="#apiserver-k8s-io-v1beta1-Transport"><code>Transport</code></a>
+</td>
+<td>
+   <p>Transport defines the transport configurations we use to dial to the konnectivity server.
+This is required if ProxyProtocol is HTTPConnect or GRPC.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `EgressSelection`     {#apiserver-k8s-io-v1beta1-EgressSelection}
+    
+
+**Appears in:**
+
+- [EgressSelectorConfiguration](#apiserver-k8s-io-v1beta1-EgressSelectorConfiguration)
+
+
+<p>EgressSelection provides the configuration for a single egress selection client.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>name is the name of the egress selection.
+Currently supported values are &quot;controlplane&quot;, &quot;master&quot;, &quot;etcd&quot; and &quot;cluster&quot;
+The &quot;master&quot; egress selector is deprecated in favor of &quot;controlplane&quot;</p>
+</td>
+</tr>
+<tr><td><code>connection</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1beta1-Connection"><code>Connection</code></a>
+</td>
+<td>
+   <p>connection is the exact information used to configure the egress selection</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ProtocolType`     {#apiserver-k8s-io-v1beta1-ProtocolType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [Connection](#apiserver-k8s-io-v1beta1-Connection)
+
+
+<p>ProtocolType is a set of valid values for Connection.ProtocolType</p>
+
+
+
+
+## `TCPTransport`     {#apiserver-k8s-io-v1beta1-TCPTransport}
+    
+
+**Appears in:**
+
+- [Transport](#apiserver-k8s-io-v1beta1-Transport)
+
+
+<p>TCPTransport provides the information to connect to konnectivity server via TCP</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>url</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>URL is the location of the konnectivity server to connect to.
+As an example it might be &quot;https://127.0.0.1:8131&quot;</p>
+</td>
+</tr>
+<tr><td><code>tlsConfig</code><br/>
+<a href="#apiserver-k8s-io-v1beta1-TLSConfig"><code>TLSConfig</code></a>
+</td>
+<td>
+   <p>TLSConfig is the config needed to use TLS when connecting to konnectivity server</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TLSConfig`     {#apiserver-k8s-io-v1beta1-TLSConfig}
+    
+
+**Appears in:**
+
+- [TCPTransport](#apiserver-k8s-io-v1beta1-TCPTransport)
+
+
+<p>TLSConfig provides the authentication information to connect to konnectivity server
+Only used with TCPTransport</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>caBundle</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>caBundle is the file location of the CA to be used to determine trust with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+If absent while TCPTransport.URL is prefixed with https://, default to system trust roots.</p>
+</td>
+</tr>
+<tr><td><code>clientKey</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clientKey is the file location of the client key to be used in mtls handshakes with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+Must be configured if TCPTransport.URL is prefixed with https://</p>
+</td>
+</tr>
+<tr><td><code>clientCert</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clientCert is the file location of the client certificate to be used in mtls handshakes with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+Must be configured if TCPTransport.URL is prefixed with https://</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Transport`     {#apiserver-k8s-io-v1beta1-Transport}
+    
+
+**Appears in:**
+
+- [Connection](#apiserver-k8s-io-v1beta1-Connection)
+
+
+<p>Transport defines the transport configurations we use to dial to the konnectivity server</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>tcp</code><br/>
+<a href="#apiserver-k8s-io-v1beta1-TCPTransport"><code>TCPTransport</code></a>
+</td>
+<td>
+   <p>TCP is the TCP configuration for communicating with the konnectivity server via TCP
+ProxyProtocol of GRPC is not supported with TCP transport at the moment
+Requires at least one of TCP or UDS to be set</p>
+</td>
+</tr>
+<tr><td><code>uds</code><br/>
+<a href="#apiserver-k8s-io-v1beta1-UDSTransport"><code>UDSTransport</code></a>
+</td>
+<td>
+   <p>UDS is the UDS configuration for communicating with the konnectivity server via UDS
+Requires at least one of TCP or UDS to be set</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `UDSTransport`     {#apiserver-k8s-io-v1beta1-UDSTransport}
+    
+
+**Appears in:**
+
+- [Transport](#apiserver-k8s-io-v1beta1-Transport)
+
+
+<p>UDSTransport provides the information to connect to konnectivity server via UDS</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>udsName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>UDSName is the name of the unix domain socket to connect to konnectivity server
+This does not use a unix:// prefix. (Eg: /etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket)</p>
+</td>
+</tr>
+</tbody>
+</table>
+  

--- a/genref/output/md/apiserver-encryption.v1.md
+++ b/genref/output/md/apiserver-encryption.v1.md
@@ -4,7 +4,8 @@ content_type: tool-reference
 package: apiserver.config.k8s.io/v1
 auto_generated: true
 ---
-Package v1 is the v1 version of the API.
+<p>Package v1 is the v1 version of the API.</p>
+
 
 ## Resource Types 
 
@@ -13,14 +14,12 @@ Package v1 is the v1 version of the API.
   
     
 
-
 ## `EncryptionConfiguration`     {#apiserver-config-k8s-io-v1-EncryptionConfiguration}
     
 
 
+<p>EncryptionConfiguration stores the complete configuration for encryption providers.</p>
 
-
-EncryptionConfiguration stores the complete configuration for encryption providers.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -29,130 +28,107 @@ EncryptionConfiguration stores the complete configuration for encryption provide
 <tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>EncryptionConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>resources</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-ResourceConfiguration"><code>[]ResourceConfiguration</code></a>
 </td>
 <td>
-   resources is a list containing resources, and their corresponding encryption providers.</td>
+   <p>resources is a list containing resources, and their corresponding encryption providers.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `AESConfiguration`     {#apiserver-config-k8s-io-v1-AESConfiguration}
     
-
-
 
 **Appears in:**
 
 - [ProviderConfiguration](#apiserver-config-k8s-io-v1-ProviderConfiguration)
 
 
-AESConfiguration contains the API configuration for an AES transformer.
+<p>AESConfiguration contains the API configuration for an AES transformer.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>keys</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-Key"><code>[]Key</code></a>
 </td>
 <td>
-   keys is a list of keys to be used for creating the AES transformer.
-Each key has to be 32 bytes long for AES-CBC and 16, 24 or 32 bytes for AES-GCM.</td>
+   <p>keys is a list of keys to be used for creating the AES transformer.
+Each key has to be 32 bytes long for AES-CBC and 16, 24 or 32 bytes for AES-GCM.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `IdentityConfiguration`     {#apiserver-config-k8s-io-v1-IdentityConfiguration}
     
-
-
 
 **Appears in:**
 
 - [ProviderConfiguration](#apiserver-config-k8s-io-v1-ProviderConfiguration)
 
 
-IdentityConfiguration is an empty struct to allow identity transformer in provider configuration.
+<p>IdentityConfiguration is an empty struct to allow identity transformer in provider configuration.</p>
 
 
-    
 
 
 ## `KMSConfiguration`     {#apiserver-config-k8s-io-v1-KMSConfiguration}
     
 
-
-
 **Appears in:**
 
 - [ProviderConfiguration](#apiserver-config-k8s-io-v1-ProviderConfiguration)
 
 
-KMSConfiguration contains the name, cache size and path to configuration file for a KMS based envelope transformer.
+<p>KMSConfiguration contains the name, cache size and path to configuration file for a KMS based envelope transformer.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   name is the name of the KMS plugin to be used.</td>
+   <p>name is the name of the KMS plugin to be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cachesize</code><br/>
 <code>int32</code>
 </td>
 <td>
-   cachesize is the maximum number of secrets which are cached in memory. The default value is 1000.
-Set to a negative value to disable caching.</td>
+   <p>cachesize is the maximum number of secrets which are cached in memory. The default value is 1000.
+Set to a negative value to disable caching.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>endpoint</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   endpoint is the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".</td>
+   <p>endpoint is the gRPC server listening address, for example &quot;unix:///var/run/kms-provider.sock&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>timeout</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.</td>
+   <p>timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Key`     {#apiserver-config-k8s-io-v1-Key}
     
-
-
 
 **Appears in:**
 
@@ -161,166 +137,143 @@ Set to a negative value to disable caching.</td>
 - [SecretboxConfiguration](#apiserver-config-k8s-io-v1-SecretboxConfiguration)
 
 
-Key contains name and secret of the provided key for a transformer.
+<p>Key contains name and secret of the provided key for a transformer.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   name is the name of the key to be used while storing data to disk.</td>
+   <p>name is the name of the key to be used while storing data to disk.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>secret</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   secret is the actual key, encoded in base64.</td>
+   <p>secret is the actual key, encoded in base64.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ProviderConfiguration`     {#apiserver-config-k8s-io-v1-ProviderConfiguration}
     
-
-
 
 **Appears in:**
 
 - [ResourceConfiguration](#apiserver-config-k8s-io-v1-ResourceConfiguration)
 
 
-ProviderConfiguration stores the provided configuration for an encryption provider.
+<p>ProviderConfiguration stores the provided configuration for an encryption provider.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>aesgcm</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-AESConfiguration"><code>AESConfiguration</code></a>
 </td>
 <td>
-   aesgcm is the configuration for the AES-GCM transformer.</td>
+   <p>aesgcm is the configuration for the AES-GCM transformer.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>aescbc</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-AESConfiguration"><code>AESConfiguration</code></a>
 </td>
 <td>
-   aescbc is the configuration for the AES-CBC transformer.</td>
+   <p>aescbc is the configuration for the AES-CBC transformer.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>secretbox</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-SecretboxConfiguration"><code>SecretboxConfiguration</code></a>
 </td>
 <td>
-   secretbox is the configuration for the Secretbox based transformer.</td>
+   <p>secretbox is the configuration for the Secretbox based transformer.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>identity</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-IdentityConfiguration"><code>IdentityConfiguration</code></a>
 </td>
 <td>
-   identity is the (empty) configuration for the identity transformer.</td>
+   <p>identity is the (empty) configuration for the identity transformer.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kms</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-KMSConfiguration"><code>KMSConfiguration</code></a>
 </td>
 <td>
-   kms contains the name, cache size and path to configuration file for a KMS based envelope transformer.</td>
+   <p>kms contains the name, cache size and path to configuration file for a KMS based envelope transformer.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ResourceConfiguration`     {#apiserver-config-k8s-io-v1-ResourceConfiguration}
     
-
-
 
 **Appears in:**
 
 - [EncryptionConfiguration](#apiserver-config-k8s-io-v1-EncryptionConfiguration)
 
 
-ResourceConfiguration stores per resource configuration.
+<p>ResourceConfiguration stores per resource configuration.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>resources</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   resources is a list of kubernetes resources which have to be encrypted.</td>
+   <p>resources is a list of kubernetes resources which have to be encrypted.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>providers</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-ProviderConfiguration"><code>[]ProviderConfiguration</code></a>
 </td>
 <td>
-   providers is a list of transformers to be used for reading and writing the resources to disk.
-eg: aesgcm, aescbc, secretbox, identity.</td>
+   <p>providers is a list of transformers to be used for reading and writing the resources to disk.
+eg: aesgcm, aescbc, secretbox, identity.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `SecretboxConfiguration`     {#apiserver-config-k8s-io-v1-SecretboxConfiguration}
     
-
-
 
 **Appears in:**
 
 - [ProviderConfiguration](#apiserver-config-k8s-io-v1-ProviderConfiguration)
 
 
-SecretboxConfiguration contains the API configuration for an Secretbox transformer.
+<p>SecretboxConfiguration contains the API configuration for an Secretbox transformer.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>keys</code> <B>[Required]</B><br/>
 <a href="#apiserver-config-k8s-io-v1-Key"><code>[]Key</code></a>
 </td>
 <td>
-   keys is a list of keys to be used for creating the Secretbox transformer.
-Each key has to be 32 bytes long.</td>
+   <p>keys is a list of keys to be used for creating the Secretbox transformer.
+Each key has to be 32 bytes long.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   

--- a/genref/output/md/apiserver-resourcequota.v1.md
+++ b/genref/output/md/apiserver-resourcequota.v1.md
@@ -4,7 +4,8 @@ content_type: tool-reference
 package: apiserver.config.k8s.io/v1
 auto_generated: true
 ---
-Package v1 is the v1 version of the API.
+<p>Package v1 is the v1 version of the API.</p>
+
 
 ## Resource Types 
 
@@ -13,14 +14,12 @@ Package v1 is the v1 version of the API.
   
     
 
-
 ## `Configuration`     {#apiserver-config-k8s-io-v1-Configuration}
     
 
 
+<p>Configuration provides configuration for the ResourceQuota admission controller.</p>
 
-
-Configuration provides configuration for the ResourceQuota admission controller.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -29,66 +28,57 @@ Configuration provides configuration for the ResourceQuota admission controller.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>Configuration</code></td></tr>
     
-
-  
   
 <tr><td><code>limitedResources</code><br/>
 <a href="#apiserver-config-k8s-io-v1-LimitedResource"><code>[]LimitedResource</code></a>
 </td>
 <td>
-   LimitedResources whose consumption is limited by default.</td>
+   <p>LimitedResources whose consumption is limited by default.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `LimitedResource`     {#apiserver-config-k8s-io-v1-LimitedResource}
     
-
-
 
 **Appears in:**
 
 - [Configuration](#apiserver-config-k8s-io-v1-Configuration)
 
 
-LimitedResource matches a resource whose consumption is limited by default.
+<p>LimitedResource matches a resource whose consumption is limited by default.
 To consume the resource, there must exist an associated quota that limits
-its consumption.
+its consumption.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>apiGroup</code><br/>
 <code>string</code>
 </td>
 <td>
-   APIGroup is the name of the APIGroup that contains the limited resource.</td>
+   <p>APIGroup is the name of the APIGroup that contains the limited resource.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resource</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Resource is the name of the resource this rule applies to.
+   <p>Resource is the name of the resource this rule applies to.
 For example, if the administrator wants to limit consumption
 of a storage resource associated with persistent volume claims,
-the value would be "persistentvolumeclaims".</td>
+the value would be &quot;persistentvolumeclaims&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>matchContains</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   For each intercepted request, the quota system will evaluate
+   <p>For each intercepted request, the quota system will evaluate
 its resource usage.  It will iterate through each resource consumed
 and if the resource contains any substring in this listing, the
 quota system will ensure that there is a covering quota.  In the
@@ -96,25 +86,22 @@ absence of a covering quota, the quota system will deny the request.
 For example, if an administrator wants to globally enforce that
 that a quota must exist to consume persistent volume claims associated
 with any storage class, the list would include
-".storageclass.storage.k8s.io/requests.storage"</td>
+&quot;.storageclass.storage.k8s.io/requests.storage&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>matchScopes</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#scopedresourceselectorrequirement-v1-core"><code>[]core/v1.ScopedResourceSelectorRequirement</code></a>
 </td>
 <td>
-   For each intercepted request, the quota system will figure out if the input object
+   <p>For each intercepted request, the quota system will figure out if the input object
 satisfies a scope which is present in this listing, then
 quota system will ensure that there is a covering quota.  In the
 absence of a covering quota, the quota system will deny the request.
 For example, if an administrator wants to globally enforce that
-a quota must exist to create a pod with "cluster-services" priorityclass
-the list would include "scopeName=PriorityClass, Operator=In, Value=cluster-services"</td>
+a quota must exist to create a pod with &quot;cluster-services&quot; priorityclass
+the list would include &quot;scopeName=PriorityClass, Operator=In, Value=cluster-services&quot;</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   

--- a/genref/output/md/apiserver-webhookadmission.v1.md
+++ b/genref/output/md/apiserver-webhookadmission.v1.md
@@ -4,7 +4,8 @@ content_type: tool-reference
 package: apiserver.config.k8s.io/v1
 auto_generated: true
 ---
-Package v1 is the v1 version of the API.
+<p>Package v1 is the v1 version of the API.</p>
+
 
 ## Resource Types 
 
@@ -13,14 +14,12 @@ Package v1 is the v1 version of the API.
   
     
 
-
 ## `WebhookAdmission`     {#apiserver-config-k8s-io-v1-WebhookAdmission}
     
 
 
+<p>WebhookAdmission provides configuration for the webhook admission controller.</p>
 
-
-WebhookAdmission provides configuration for the webhook admission controller.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -29,18 +28,14 @@ WebhookAdmission provides configuration for the webhook admission controller.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.config.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>WebhookAdmission</code></td></tr>
     
-
-  
   
 <tr><td><code>kubeConfigFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   KubeConfigFile is the path to the kubeconfig file.</td>
+   <p>KubeConfigFile is the path to the kubeconfig file.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   

--- a/genref/output/md/client-authentication.v1.md
+++ b/genref/output/md/client-authentication.v1.md
@@ -13,15 +13,13 @@ auto_generated: true
   
     
 
-
 ## `ExecCredential`     {#client-authentication-k8s-io-v1-ExecCredential}
     
 
 
+<p>ExecCredential is used by exec-based plugins to communicate credentials to
+HTTP transports.</p>
 
-
-ExecCredential is used by exec-based plugins to communicate credentials to
-HTTP transports.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -30,231 +28,202 @@ HTTP transports.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>client.authentication.k8s.io/v1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>ExecCredential</code></td></tr>
     
-
-  
   
 <tr><td><code>spec</code> <B>[Required]</B><br/>
 <a href="#client-authentication-k8s-io-v1-ExecCredentialSpec"><code>ExecCredentialSpec</code></a>
 </td>
 <td>
-   Spec holds information passed to the plugin by the transport.</td>
+   <p>Spec holds information passed to the plugin by the transport.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>status</code><br/>
 <a href="#client-authentication-k8s-io-v1-ExecCredentialStatus"><code>ExecCredentialStatus</code></a>
 </td>
 <td>
-   Status is filled in by the plugin and holds the credentials that the transport
-should use to contact the API.</td>
+   <p>Status is filled in by the plugin and holds the credentials that the transport
+should use to contact the API.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Cluster`     {#client-authentication-k8s-io-v1-Cluster}
     
-
-
 
 **Appears in:**
 
 - [ExecCredentialSpec](#client-authentication-k8s-io-v1-ExecCredentialSpec)
 
 
-Cluster contains information to allow an exec plugin to communicate
-with the kubernetes cluster being authenticated to.
-
-To ensure that this struct contains everything someone would need to communicate
+<p>Cluster contains information to allow an exec plugin to communicate
+with the kubernetes cluster being authenticated to.</p>
+<p>To ensure that this struct contains everything someone would need to communicate
 with a kubernetes cluster (just like they would via a kubeconfig), the fields
-should shadow "k8s.io/client-go/tools/clientcmd/api/v1".Cluster, with the exception
-of CertificateAuthority, since CA data will always be passed to the plugin as bytes.
+should shadow &quot;k8s.io/client-go/tools/clientcmd/api/v1&quot;.Cluster, with the exception
+of CertificateAuthority, since CA data will always be passed to the plugin as bytes.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>server</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Server is the address of the kubernetes cluster (https://hostname:port).</td>
+   <p>Server is the address of the kubernetes cluster (https://hostname:port).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tls-server-name</code><br/>
 <code>string</code>
 </td>
 <td>
-   TLSServerName is passed to the server for SNI and is used in the client to
+   <p>TLSServerName is passed to the server for SNI and is used in the client to
 check server certificates against. If ServerName is empty, the hostname
-used to contact the server is used.</td>
+used to contact the server is used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>insecure-skip-tls-verify</code><br/>
 <code>bool</code>
 </td>
 <td>
-   InsecureSkipTLSVerify skips the validity check for the server's certificate.
-This will make your HTTPS connections insecure.</td>
+   <p>InsecureSkipTLSVerify skips the validity check for the server's certificate.
+This will make your HTTPS connections insecure.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certificate-authority-data</code><br/>
 <code>[]byte</code>
 </td>
 <td>
-   CAData contains PEM-encoded certificate authority certificates.
-If empty, system roots should be used.</td>
+   <p>CAData contains PEM-encoded certificate authority certificates.
+If empty, system roots should be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>proxy-url</code><br/>
 <code>string</code>
 </td>
 <td>
-   ProxyURL is the URL to the proxy to be used for all requests to this
-cluster.</td>
+   <p>ProxyURL is the URL to the proxy to be used for all requests to this
+cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>config</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
 </td>
 <td>
-   Config holds additional config data that is specific to the exec
-plugin with regards to the cluster being authenticated to.
-
-This data is sourced from the clientcmd Cluster object's
-extensions[client.authentication.k8s.io/exec] field:
-
-clusters:
-- name: my-cluster
-  cluster:
-    ...
-    extensions:
-    - name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config
-      extension:
-        audience: 06e3fbd18de8  # arbitrary config
-
-In some environments, the user config may be exactly the same across many clusters
+   <p>Config holds additional config data that is specific to the exec
+plugin with regards to the cluster being authenticated to.</p>
+<p>This data is sourced from the clientcmd Cluster object's
+extensions[client.authentication.k8s.io/exec] field:</p>
+<p>clusters:</p>
+<ul>
+<li>name: my-cluster
+cluster:
+...
+extensions:
+<ul>
+<li>name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config
+extension:
+audience: 06e3fbd18de8  # arbitrary config</li>
+</ul>
+</li>
+</ul>
+<p>In some environments, the user config may be exactly the same across many clusters
 (i.e. call this exec plugin) minus some details that are specific to each cluster
 such as the audience.  This field allows the per cluster config to be directly
 specified with the cluster info.  Using this field to store secret data is not
 recommended as one of the prime benefits of exec plugins is that no secrets need
-to be stored directly in the kubeconfig.</td>
+to be stored directly in the kubeconfig.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExecCredentialSpec`     {#client-authentication-k8s-io-v1-ExecCredentialSpec}
     
-
-
 
 **Appears in:**
 
 - [ExecCredential](#client-authentication-k8s-io-v1-ExecCredential)
 
 
-ExecCredentialSpec holds request and runtime specific information provided by
-the transport.
+<p>ExecCredentialSpec holds request and runtime specific information provided by
+the transport.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>cluster</code><br/>
 <a href="#client-authentication-k8s-io-v1-Cluster"><code>Cluster</code></a>
 </td>
 <td>
-   Cluster contains information to allow an exec plugin to communicate with the
+   <p>Cluster contains information to allow an exec plugin to communicate with the
 kubernetes cluster being authenticated to. Note that Cluster is non-nil only
 when provideClusterInfo is set to true in the exec provider config (i.e.,
-ExecConfig.ProvideClusterInfo).</td>
+ExecConfig.ProvideClusterInfo).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>interactive</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   Interactive declares whether stdin has been passed to this exec plugin.</td>
+   <p>Interactive declares whether stdin has been passed to this exec plugin.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExecCredentialStatus`     {#client-authentication-k8s-io-v1-ExecCredentialStatus}
     
-
-
 
 **Appears in:**
 
 - [ExecCredential](#client-authentication-k8s-io-v1-ExecCredential)
 
 
-ExecCredentialStatus holds credentials for the transport to use.
-
-Token and ClientKeyData are sensitive fields. This data should only be
+<p>ExecCredentialStatus holds credentials for the transport to use.</p>
+<p>Token and ClientKeyData are sensitive fields. This data should only be
 transmitted in-memory between client and exec plugin process. Exec plugin
-itself should at least be protected via file permissions.
+itself should at least be protected via file permissions.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>expirationTimestamp</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
-   ExpirationTimestamp indicates a time when the provided credentials expire.</td>
+   <p>ExpirationTimestamp indicates a time when the provided credentials expire.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>token</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Token is a bearer token used by the client for request authentication.</td>
+   <p>Token is a bearer token used by the client for request authentication.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clientCertificateData</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   PEM-encoded client TLS certificates (including intermediates, if any).</td>
+   <p>PEM-encoded client TLS certificates (including intermediates, if any).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clientKeyData</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   PEM-encoded private key for the above certificate.</td>
+   <p>PEM-encoded private key for the above certificate.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   

--- a/genref/output/md/cloud-provider-config.v1alpha1.md
+++ b/genref/output/md/cloud-provider-config.v1alpha1.md
@@ -13,47 +13,8 @@ auto_generated: true
   
     
 
-## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-ServiceControllerConfiguration contains elements describing ServiceController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentServiceSyncs is the number of services that are
-allowed to sync concurrently. Larger number = more responsive service
-management, but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-  
-    
-
-
 ## `CloudControllerManagerConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration}
     
-
-
-
 
 
 
@@ -64,91 +25,75 @@ management, but more CPU (and network) load.</td>
 <tr><td><code>apiVersion</code><br/>string</td><td><code>cloudcontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>CloudControllerManagerConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>Generic</code> <B>[Required]</B><br/>
 <a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
 </td>
 <td>
-   Generic holds configuration for a generic controller-manager</td>
+   <p>Generic holds configuration for a generic controller-manager</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
 <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
 </td>
 <td>
-   KubeCloudSharedConfiguration holds configuration for shared related features
-both in cloud controller manager and kube-controller manager.</td>
+   <p>KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ServiceController</code> <B>[Required]</B><br/>
 <a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
 </td>
 <td>
-   ServiceControllerConfiguration holds configuration for ServiceController
-related features.</td>
+   <p>ServiceControllerConfiguration holds configuration for ServiceController
+related features.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>NodeStatusUpdateFrequency</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status</td>
+   <p>NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `CloudProviderConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration}
     
-
-
 
 **Appears in:**
 
 - [KubeCloudSharedConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration)
 
 
-CloudProviderConfiguration contains basically elements about cloud provider.
+<p>CloudProviderConfiguration contains basically elements about cloud provider.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>Name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the provider for cloud services.</td>
+   <p>Name is the provider for cloud services.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>CloudConfigFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   cloudConfigFile is the path to the cloud provider configuration file.</td>
+   <p>cloudConfigFile is the path to the cloud provider configuration file.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeCloudSharedConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration}
     
-
-
 
 **Appears in:**
 
@@ -157,171 +102,149 @@ CloudProviderConfiguration contains basically elements about cloud provider.
 - [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
 
 
-KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
-and cloud-controller manager, but not genericconfig.
+<p>KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
+and cloud-controller manager, but not genericconfig.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>CloudProvider</code> <B>[Required]</B><br/>
 <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration"><code>CloudProviderConfiguration</code></a>
 </td>
 <td>
-   CloudProviderConfiguration holds configuration for CloudProvider related features.</td>
+   <p>CloudProviderConfiguration holds configuration for CloudProvider related features.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ExternalCloudVolumePlugin</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   externalCloudVolumePlugin specifies the plugin to use when cloudProvider is "external".
-It is currently used by the in repo cloud providers to handle node and volume control in the KCM.</td>
+   <p>externalCloudVolumePlugin specifies the plugin to use when cloudProvider is &quot;external&quot;.
+It is currently used by the in repo cloud providers to handle node and volume control in the KCM.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>UseServiceAccountCredentials</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   useServiceAccountCredentials indicates whether controllers should be run with
-individual service account credentials.</td>
+   <p>useServiceAccountCredentials indicates whether controllers should be run with
+individual service account credentials.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>AllowUntaggedCloud</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   run with untagged cloud instances</td>
+   <p>run with untagged cloud instances</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>RouteReconciliationPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</td>
+   <p>routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>NodeMonitorPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</td>
+   <p>nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ClusterName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   clusterName is the instance prefix for the cluster.</td>
+   <p>clusterName is the instance prefix for the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ClusterCIDR</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   clusterCIDR is CIDR Range for Pods in cluster.</td>
+   <p>clusterCIDR is CIDR Range for Pods in cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>AllocateNodeCIDRs</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
-ConfigureCloudRoutes is true, to be set on the cloud provider.</td>
+   <p>AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+ConfigureCloudRoutes is true, to be set on the cloud provider.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>CIDRAllocatorType</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CIDRAllocatorType determines what kind of pod CIDR allocator will be used.</td>
+   <p>CIDRAllocatorType determines what kind of pod CIDR allocator will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ConfigureCloudRoutes</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
-to be configured on the cloud provider.</td>
+   <p>configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
+to be configured on the cloud provider.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>NodeSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
+   <p>nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
 periods will result in fewer calls to cloud provider, but may delay addition
-of new nodes to cluster.</td>
+of new nodes to cluster.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   
   
     
-
 
 ## `ControllerLeaderConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration}
     
-
-
 
 **Appears in:**
 
 - [LeaderMigrationConfiguration](#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration)
 
 
-ControllerLeaderConfiguration provides the configuration for a migrating leader lock.
+<p>ControllerLeaderConfiguration provides the configuration for a migrating leader lock.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the name of the controller being migrated
-E.g. service-controller, route-controller, cloud-node-controller, etc</td>
+   <p>Name is the name of the controller being migrated
+E.g. service-controller, route-controller, cloud-node-controller, etc</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>component</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Component is the name of the component in which the controller should be running.
+   <p>Component is the name of the component in which the controller should be running.
 E.g. kube-controller-manager, cloud-controller-manager, etc
-Or '&lowast;' meaning the controller can be run under any component that participates in the migration</td>
+Or '&lowast;' meaning the controller can be run under any component that participates in the migration</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `GenericControllerManagerConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration}
     
-
-
 
 **Appears in:**
 
@@ -330,151 +253,164 @@ Or '&lowast;' meaning the controller can be run under any component that partici
 - [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
 
 
-GenericControllerManagerConfiguration holds configuration for a generic controller-manager.
+<p>GenericControllerManagerConfiguration holds configuration for a generic controller-manager.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>Port</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   port is the port that the controller-manager's http service runs on.</td>
+   <p>port is the port that the controller-manager's http service runs on.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>Address</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   address is the IP address to serve on (set to 0.0.0.0 for all interfaces).</td>
+   <p>address is the IP address to serve on (set to 0.0.0.0 for all interfaces).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>MinResyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   minResyncPeriod is the resync period in reflectors; will be random between
-minResyncPeriod and 2&lowast;minResyncPeriod.</td>
+   <p>minResyncPeriod is the resync period in reflectors; will be random between
+minResyncPeriod and 2&lowast;minResyncPeriod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ClientConnection</code> <B>[Required]</B><br/>
 <a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
 </td>
 <td>
-   ClientConnection specifies the kubeconfig file and client connection
-settings for the proxy server to use when communicating with the apiserver.</td>
+   <p>ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ControllerStartInterval</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   How long to wait between starting controller managers</td>
+   <p>How long to wait between starting controller managers</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>LeaderElection</code> <B>[Required]</B><br/>
 <a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
 </td>
 <td>
-   leaderElection defines the configuration of leader election client.</td>
+   <p>leaderElection defines the configuration of leader election client.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>Controllers</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   Controllers is the list of controllers to enable or disable
-'&lowast;' means "all enabled by default controllers"
-'foo' means "enable 'foo'"
-'-foo' means "disable 'foo'"
-first item for a particular name wins</td>
+   <p>Controllers is the list of controllers to enable or disable
+'&lowast;' means &quot;all enabled by default controllers&quot;
+'foo' means &quot;enable 'foo'&quot;
+'-foo' means &quot;disable 'foo'&quot;
+first item for a particular name wins</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>Debugging</code> <B>[Required]</B><br/>
 <a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
 </td>
 <td>
-   DebuggingConfiguration holds configuration for Debugging related features.</td>
+   <p>DebuggingConfiguration holds configuration for Debugging related features.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>LeaderMigrationEnabled</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   LeaderMigrationEnabled indicates whether Leader Migration should be enabled for the controller manager.</td>
+   <p>LeaderMigrationEnabled indicates whether Leader Migration should be enabled for the controller manager.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>LeaderMigration</code> <B>[Required]</B><br/>
 <a href="#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration"><code>LeaderMigrationConfiguration</code></a>
 </td>
 <td>
-   LeaderMigration holds the configuration for Leader Migration.</td>
+   <p>LeaderMigration holds the configuration for Leader Migration.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `LeaderMigrationConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration}
     
-
-
 
 **Appears in:**
 
 - [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
 
 
-LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.
+<p>LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
-  
   
 <tr><td><code>leaderName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   LeaderName is the name of the leader election resource that protects the migration
-E.g. 1-20-KCM-to-1-21-CCM</td>
+   <p>LeaderName is the name of the leader election resource that protects the migration
+E.g. 1-20-KCM-to-1-21-CCM</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceLock</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ResourceLock indicates the resource object type that will be used to lock
-Should be "leases" or "endpoints"</td>
+   <p>ResourceLock indicates the resource object type that will be used to lock
+Should be &quot;leases&quot; or &quot;endpoints&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>controllerLeaders</code> <B>[Required]</B><br/>
 <a href="#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration"><code>[]ControllerLeaderConfiguration</code></a>
 </td>
 <td>
-   ControllerLeaders contains a list of migrating leader lock configurations</td>
+   <p>ControllerLeaders contains a list of migrating leader lock configurations</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
+  
+  
+    
+
+## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
+    
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>ServiceControllerConfiguration contains elements describing ServiceController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
     
   
+<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>

--- a/genref/output/md/cloud-provider-service.v1alpha1.md
+++ b/genref/output/md/cloud-provider-service.v1alpha1.md
@@ -9,8 +9,6 @@
 ## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
     
 
-
-
 **Appears in:**
 
 - [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
@@ -18,23 +16,22 @@
 - [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
 
 
-ServiceControllerConfiguration contains elements describing ServiceController.
+<p>ServiceControllerConfiguration contains elements describing ServiceController.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   concurrentServiceSyncs is the number of services that are
+   <p>concurrentServiceSyncs is the number of services that are
 allowed to sync concurrently. Larger number = more responsive service
-management, but more CPU (and network) load.</td>
+management, but more CPU (and network) load.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>

--- a/genref/output/md/kube-controller-manager-config.v1alpha1.md
+++ b/genref/output/md/kube-controller-manager-config.v1alpha1.md
@@ -1,7 +1,7 @@
 ---
 title: kube-controller-manager Configuration (v1alpha1)
 content_type: tool-reference
-package: cloudcontrollermanager.config.k8s.io/v1alpha1
+package: kubecontrollermanager.config.k8s.io/v1alpha1
 auto_generated: true
 ---
 
@@ -9,17 +9,1468 @@ auto_generated: true
 ## Resource Types 
 
 
-- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
 - [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
   
     
 
-
-## `CloudControllerManagerConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration}
+## `KubeControllerManagerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration}
     
 
 
+<p>KubeControllerManagerConfiguration contains elements describing kube-controller manager.</p>
 
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>kubecontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>KubeControllerManagerConfiguration</code></td></tr>
+    
+  
+<tr><td><code>Generic</code> <B>[Required]</B><br/>
+<a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
+</td>
+<td>
+   <p>Generic holds configuration for a generic controller-manager</p>
+</td>
+</tr>
+<tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
+<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
+</td>
+<td>
+   <p>KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.</p>
+</td>
+</tr>
+<tr><td><code>AttachDetachController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-AttachDetachControllerConfiguration"><code>AttachDetachControllerConfiguration</code></a>
+</td>
+<td>
+   <p>AttachDetachControllerConfiguration holds configuration for
+AttachDetachController related features.</p>
+</td>
+</tr>
+<tr><td><code>CSRSigningController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration"><code>CSRSigningControllerConfiguration</code></a>
+</td>
+<td>
+   <p>CSRSigningControllerConfiguration holds configuration for
+CSRSigningController related features.</p>
+</td>
+</tr>
+<tr><td><code>DaemonSetController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DaemonSetControllerConfiguration"><code>DaemonSetControllerConfiguration</code></a>
+</td>
+<td>
+   <p>DaemonSetControllerConfiguration holds configuration for DaemonSetController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>DeploymentController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DeploymentControllerConfiguration"><code>DeploymentControllerConfiguration</code></a>
+</td>
+<td>
+   <p>DeploymentControllerConfiguration holds configuration for
+DeploymentController related features.</p>
+</td>
+</tr>
+<tr><td><code>StatefulSetController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-StatefulSetControllerConfiguration"><code>StatefulSetControllerConfiguration</code></a>
+</td>
+<td>
+   <p>StatefulSetControllerConfiguration holds configuration for
+StatefulSetController related features.</p>
+</td>
+</tr>
+<tr><td><code>DeprecatedController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DeprecatedControllerConfiguration"><code>DeprecatedControllerConfiguration</code></a>
+</td>
+<td>
+   <p>DeprecatedControllerConfiguration holds configuration for some deprecated
+features.</p>
+</td>
+</tr>
+<tr><td><code>EndpointController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointControllerConfiguration"><code>EndpointControllerConfiguration</code></a>
+</td>
+<td>
+   <p>EndpointControllerConfiguration holds configuration for EndpointController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>EndpointSliceController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceControllerConfiguration"><code>EndpointSliceControllerConfiguration</code></a>
+</td>
+<td>
+   <p>EndpointSliceControllerConfiguration holds configuration for
+EndpointSliceController related features.</p>
+</td>
+</tr>
+<tr><td><code>EndpointSliceMirroringController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceMirroringControllerConfiguration"><code>EndpointSliceMirroringControllerConfiguration</code></a>
+</td>
+<td>
+   <p>EndpointSliceMirroringControllerConfiguration holds configuration for
+EndpointSliceMirroringController related features.</p>
+</td>
+</tr>
+<tr><td><code>EphemeralVolumeController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EphemeralVolumeControllerConfiguration"><code>EphemeralVolumeControllerConfiguration</code></a>
+</td>
+<td>
+   <p>EphemeralVolumeControllerConfiguration holds configuration for EphemeralVolumeController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>GarbageCollectorController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration"><code>GarbageCollectorControllerConfiguration</code></a>
+</td>
+<td>
+   <p>GarbageCollectorControllerConfiguration holds configuration for
+GarbageCollectorController related features.</p>
+</td>
+</tr>
+<tr><td><code>HPAController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-HPAControllerConfiguration"><code>HPAControllerConfiguration</code></a>
+</td>
+<td>
+   <p>HPAControllerConfiguration holds configuration for HPAController related features.</p>
+</td>
+</tr>
+<tr><td><code>JobController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-JobControllerConfiguration"><code>JobControllerConfiguration</code></a>
+</td>
+<td>
+   <p>JobControllerConfiguration holds configuration for JobController related features.</p>
+</td>
+</tr>
+<tr><td><code>CronJobController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CronJobControllerConfiguration"><code>CronJobControllerConfiguration</code></a>
+</td>
+<td>
+   <p>CronJobControllerConfiguration holds configuration for CronJobController related features.</p>
+</td>
+</tr>
+<tr><td><code>NamespaceController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NamespaceControllerConfiguration"><code>NamespaceControllerConfiguration</code></a>
+</td>
+<td>
+   <p>NamespaceControllerConfiguration holds configuration for NamespaceController
+related features.
+NamespaceControllerConfiguration holds configuration for NamespaceController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>NodeIPAMController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NodeIPAMControllerConfiguration"><code>NodeIPAMControllerConfiguration</code></a>
+</td>
+<td>
+   <p>NodeIPAMControllerConfiguration holds configuration for NodeIPAMController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>NodeLifecycleController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NodeLifecycleControllerConfiguration"><code>NodeLifecycleControllerConfiguration</code></a>
+</td>
+<td>
+   <p>NodeLifecycleControllerConfiguration holds configuration for
+NodeLifecycleController related features.</p>
+</td>
+</tr>
+<tr><td><code>PersistentVolumeBinderController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration"><code>PersistentVolumeBinderControllerConfiguration</code></a>
+</td>
+<td>
+   <p>PersistentVolumeBinderControllerConfiguration holds configuration for
+PersistentVolumeBinderController related features.</p>
+</td>
+</tr>
+<tr><td><code>PodGCController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PodGCControllerConfiguration"><code>PodGCControllerConfiguration</code></a>
+</td>
+<td>
+   <p>PodGCControllerConfiguration holds configuration for PodGCController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>ReplicaSetController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicaSetControllerConfiguration"><code>ReplicaSetControllerConfiguration</code></a>
+</td>
+<td>
+   <p>ReplicaSetControllerConfiguration holds configuration for ReplicaSet related features.</p>
+</td>
+</tr>
+<tr><td><code>ReplicationController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicationControllerConfiguration"><code>ReplicationControllerConfiguration</code></a>
+</td>
+<td>
+   <p>ReplicationControllerConfiguration holds configuration for
+ReplicationController related features.</p>
+</td>
+</tr>
+<tr><td><code>ResourceQuotaController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceQuotaControllerConfiguration"><code>ResourceQuotaControllerConfiguration</code></a>
+</td>
+<td>
+   <p>ResourceQuotaControllerConfiguration holds configuration for
+ResourceQuotaController related features.</p>
+</td>
+</tr>
+<tr><td><code>SAController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-SAControllerConfiguration"><code>SAControllerConfiguration</code></a>
+</td>
+<td>
+   <p>SAControllerConfiguration holds configuration for ServiceAccountController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>ServiceController</code> <B>[Required]</B><br/>
+<a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
+</td>
+<td>
+   <p>ServiceControllerConfiguration holds configuration for ServiceController
+related features.</p>
+</td>
+</tr>
+<tr><td><code>TTLAfterFinishedController</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-TTLAfterFinishedControllerConfiguration"><code>TTLAfterFinishedControllerConfiguration</code></a>
+</td>
+<td>
+   <p>TTLAfterFinishedControllerConfiguration holds configuration for
+TTLAfterFinishedController related features.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AttachDetachControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-AttachDetachControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>AttachDetachControllerConfiguration contains elements describing AttachDetachController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>DisableAttachDetachReconcilerSync</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>Reconciler runs a periodic loop to reconcile the desired state of the with
+the actual state of the world by triggering attach detach operations.
+This flag enables or disables reconcile.  Is false by default, and thus enabled.</p>
+</td>
+</tr>
+<tr><td><code>ReconcilerSyncLoopPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
+wait between successive executions. Is set to 5 sec by default.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `CSRSigningConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration}
+    
+
+**Appears in:**
+
+- [CSRSigningControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration)
+
+
+<p>CSRSigningConfiguration holds information about a particular CSR signer</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>CertFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>certFile is the filename containing a PEM-encoded
+X509 CA certificate used to issue certificates</p>
+</td>
+</tr>
+<tr><td><code>KeyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>keyFile is the filename containing a PEM-encoded
+RSA or ECDSA private key used to issue certificates</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `CSRSigningControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>CSRSigningControllerConfiguration contains elements describing CSRSigningController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ClusterSigningCertFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clusterSigningCertFile is the filename containing a PEM-encoded
+X509 CA certificate used to issue cluster-scoped certificates</p>
+</td>
+</tr>
+<tr><td><code>ClusterSigningKeyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clusterSigningCertFile is the filename containing a PEM-encoded
+RSA or ECDSA private key used to issue cluster-scoped certificates</p>
+</td>
+</tr>
+<tr><td><code>KubeletServingSignerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
+</td>
+<td>
+   <p>kubeletServingSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kubelet-serving signer</p>
+</td>
+</tr>
+<tr><td><code>KubeletClientSignerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
+</td>
+<td>
+   <p>kubeletClientSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kube-apiserver-client-kubelet</p>
+</td>
+</tr>
+<tr><td><code>KubeAPIServerClientSignerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
+</td>
+<td>
+   <p>kubeAPIServerClientSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kube-apiserver-client</p>
+</td>
+</tr>
+<tr><td><code>LegacyUnknownSignerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
+</td>
+<td>
+   <p>legacyUnknownSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/legacy-unknown</p>
+</td>
+</tr>
+<tr><td><code>ClusterSigningDuration</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>clusterSigningDuration is the max length of duration signed certificates will be given.
+Individual CSRs may request shorter certs by setting spec.expirationSeconds.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `CronJobControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CronJobControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>CronJobControllerConfiguration contains elements describing CrongJob2Controller.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentCronJobSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentCronJobSyncs is the number of job objects that are
+allowed to sync concurrently. Larger number = more responsive jobs,
+but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DaemonSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DaemonSetControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>DaemonSetControllerConfiguration contains elements describing DaemonSetController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentDaemonSetSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentDaemonSetSyncs is the number of daemonset objects that are
+allowed to sync concurrently. Larger number = more responsive daemonset,
+but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DeploymentControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DeploymentControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>DeploymentControllerConfiguration contains elements describing DeploymentController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentDeploymentSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentDeploymentSyncs is the number of deployment objects that are
+allowed to sync concurrently. Larger number = more responsive deployments,
+but more CPU (and network) load.</p>
+</td>
+</tr>
+<tr><td><code>DeploymentControllerSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>deploymentControllerSyncPeriod is the period for syncing the deployments.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DeprecatedControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DeprecatedControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>DeprecatedControllerConfiguration contains elements be deprecated.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>DeletingPodsQPS</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   <p>DEPRECATED: deletingPodsQps is the number of nodes per second on which pods are deleted in
+case of node failure.</p>
+</td>
+</tr>
+<tr><td><code>DeletingPodsBurst</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>DEPRECATED: deletingPodsBurst is the number of nodes on which pods are bursty deleted in
+case of node failure. For more details look into RateLimiter.</p>
+</td>
+</tr>
+<tr><td><code>RegisterRetryCount</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>registerRetryCount is the number of retries for initial node registration.
+Retry interval equals node-sync-period.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `EndpointControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>EndpointControllerConfiguration contains elements describing EndpointController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentEndpointSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentEndpointSyncs is the number of endpoint syncing operations
+that will be done concurrently. Larger number = faster endpoint updating,
+but more CPU (and network) load.</p>
+</td>
+</tr>
+<tr><td><code>EndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>EndpointUpdatesBatchPeriod describes the length of endpoint updates batching period.
+Processing of pod changes will be delayed by this duration to join them with potential
+upcoming updates and reduce the overall number of endpoints updates.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `EndpointSliceControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>EndpointSliceControllerConfiguration contains elements describing
+EndpointSliceController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentServiceEndpointSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentServiceEndpointSyncs is the number of service endpoint syncing
+operations that will be done concurrently. Larger number = faster
+endpoint slice updating, but more CPU (and network) load.</p>
+</td>
+</tr>
+<tr><td><code>MaxEndpointsPerSlice</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>maxEndpointsPerSlice is the maximum number of endpoints that will be
+added to an EndpointSlice. More endpoints per slice will result in fewer
+and larger endpoint slices, but larger resources.</p>
+</td>
+</tr>
+<tr><td><code>EndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>EndpointUpdatesBatchPeriod describes the length of endpoint updates batching period.
+Processing of pod changes will be delayed by this duration to join them with potential
+upcoming updates and reduce the overall number of endpoints updates.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `EndpointSliceMirroringControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceMirroringControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>EndpointSliceMirroringControllerConfiguration contains elements describing
+EndpointSliceMirroringController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>MirroringConcurrentServiceEndpointSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>mirroringConcurrentServiceEndpointSyncs is the number of service endpoint
+syncing operations that will be done concurrently. Larger number = faster
+endpoint slice updating, but more CPU (and network) load.</p>
+</td>
+</tr>
+<tr><td><code>MirroringMaxEndpointsPerSubset</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>mirroringMaxEndpointsPerSubset is the maximum number of endpoints that
+will be mirrored to an EndpointSlice for an EndpointSubset.</p>
+</td>
+</tr>
+<tr><td><code>MirroringEndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>mirroringEndpointUpdatesBatchPeriod can be used to batch EndpointSlice
+updates. All updates triggered by EndpointSlice changes will be delayed
+by up to 'mirroringEndpointUpdatesBatchPeriod'. If other addresses in the
+same Endpoints resource change in that period, they will be batched to a
+single EndpointSlice update. Default 0 value means that each Endpoints
+update triggers an EndpointSlice update.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `EphemeralVolumeControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EphemeralVolumeControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>EphemeralVolumeControllerConfiguration contains elements describing EphemeralVolumeController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentEphemeralVolumeSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>ConcurrentEphemeralVolumeSyncseSyncs is the number of ephemeral volume syncing operations
+that will be done concurrently. Larger number = faster ephemeral volume updating,
+but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `GarbageCollectorControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>GarbageCollectorControllerConfiguration contains elements describing GarbageCollectorController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>EnableGarbageCollector</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>enables the generic garbage collector. MUST be synced with the
+corresponding flag of the kube-apiserver. WARNING: the generic garbage
+collector is an alpha feature.</p>
+</td>
+</tr>
+<tr><td><code>ConcurrentGCSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentGCSyncs is the number of garbage collector workers that are
+allowed to sync concurrently.</p>
+</td>
+</tr>
+<tr><td><code>GCIgnoredResources</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GroupResource"><code>[]GroupResource</code></a>
+</td>
+<td>
+   <p>gcIgnoredResources is the list of GroupResources that garbage collection should ignore.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `GroupResource`     {#kubecontrollermanager-config-k8s-io-v1alpha1-GroupResource}
+    
+
+**Appears in:**
+
+- [GarbageCollectorControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration)
+
+
+<p>GroupResource describes an group resource.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>Group</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>group is the group portion of the GroupResource.</p>
+</td>
+</tr>
+<tr><td><code>Resource</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>resource is the resource portion of the GroupResource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `HPAControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-HPAControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>HPAControllerConfiguration contains elements describing HPAController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>HorizontalPodAutoscalerSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>HorizontalPodAutoscalerSyncPeriod is the period for syncing the number of
+pods in horizontal pod autoscaler.</p>
+</td>
+</tr>
+<tr><td><code>HorizontalPodAutoscalerUpscaleForbiddenWindow</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>HorizontalPodAutoscalerUpscaleForbiddenWindow is a period after which next upscale allowed.</p>
+</td>
+</tr>
+<tr><td><code>HorizontalPodAutoscalerDownscaleStabilizationWindow</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>HorizontalPodAutoscalerDowncaleStabilizationWindow is a period for which autoscaler will look
+backwards and not scale down below any recommendation it made during that period.</p>
+</td>
+</tr>
+<tr><td><code>HorizontalPodAutoscalerDownscaleForbiddenWindow</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>HorizontalPodAutoscalerDownscaleForbiddenWindow is a period after which next downscale allowed.</p>
+</td>
+</tr>
+<tr><td><code>HorizontalPodAutoscalerTolerance</code> <B>[Required]</B><br/>
+<code>float64</code>
+</td>
+<td>
+   <p>HorizontalPodAutoscalerTolerance is the tolerance for when
+resource usage suggests upscaling/downscaling</p>
+</td>
+</tr>
+<tr><td><code>HorizontalPodAutoscalerCPUInitializationPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>HorizontalPodAutoscalerCPUInitializationPeriod is the period after pod start when CPU samples
+might be skipped.</p>
+</td>
+</tr>
+<tr><td><code>HorizontalPodAutoscalerInitialReadinessDelay</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>HorizontalPodAutoscalerInitialReadinessDelay is period after pod start during which readiness
+changes are treated as readiness being set for the first time. The only effect of this is that
+HPA will disregard CPU samples from unready pods that had last readiness change during that
+period.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `JobControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-JobControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>JobControllerConfiguration contains elements describing JobController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentJobSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentJobSyncs is the number of job objects that are
+allowed to sync concurrently. Larger number = more responsive jobs,
+but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `NamespaceControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NamespaceControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>NamespaceControllerConfiguration contains elements describing NamespaceController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>NamespaceSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>namespaceSyncPeriod is the period for syncing namespace life-cycle
+updates.</p>
+</td>
+</tr>
+<tr><td><code>ConcurrentNamespaceSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentNamespaceSyncs is the number of namespace objects that are
+allowed to sync concurrently.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `NodeIPAMControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NodeIPAMControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>NodeIPAMControllerConfiguration contains elements describing NodeIpamController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ServiceCIDR</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>serviceCIDR is CIDR Range for Services in cluster.</p>
+</td>
+</tr>
+<tr><td><code>SecondaryServiceCIDR</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>secondaryServiceCIDR is CIDR Range for Services in cluster. This is used in dual stack clusters. SecondaryServiceCIDR must be of different IP family than ServiceCIDR</p>
+</td>
+</tr>
+<tr><td><code>NodeCIDRMaskSize</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>NodeCIDRMaskSize is the mask size for node cidr in cluster.</p>
+</td>
+</tr>
+<tr><td><code>NodeCIDRMaskSizeIPv4</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>NodeCIDRMaskSizeIPv4 is the mask size for node cidr in dual-stack cluster.</p>
+</td>
+</tr>
+<tr><td><code>NodeCIDRMaskSizeIPv6</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>NodeCIDRMaskSizeIPv6 is the mask size for node cidr in dual-stack cluster.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `NodeLifecycleControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NodeLifecycleControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>NodeLifecycleControllerConfiguration contains elements describing NodeLifecycleController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>EnableTaintManager</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>If set to true enables NoExecute Taints and will evict all not-tolerating
+Pod running on Nodes tainted with this kind of Taints.</p>
+</td>
+</tr>
+<tr><td><code>NodeEvictionRate</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   <p>nodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is healthy</p>
+</td>
+</tr>
+<tr><td><code>SecondaryNodeEvictionRate</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   <p>secondaryNodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is unhealthy</p>
+</td>
+</tr>
+<tr><td><code>NodeStartupGracePeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>nodeStartupGracePeriod is the amount of time which we allow starting a node to
+be unresponsive before marking it unhealthy.</p>
+</td>
+</tr>
+<tr><td><code>NodeMonitorGracePeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>nodeMontiorGracePeriod is the amount of time which we allow a running node to be
+unresponsive before marking it unhealthy. Must be N times more than kubelet's
+nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet
+to post node status.</p>
+</td>
+</tr>
+<tr><td><code>PodEvictionTimeout</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>podEvictionTimeout is the grace period for deleting pods on failed nodes.</p>
+</td>
+</tr>
+<tr><td><code>LargeClusterSizeThreshold</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>secondaryNodeEvictionRate is implicitly overridden to 0 for clusters smaller than or equal to largeClusterSizeThreshold</p>
+</td>
+</tr>
+<tr><td><code>UnhealthyZoneThreshold</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   <p>Zone is treated as unhealthy in nodeEvictionRate and secondaryNodeEvictionRate when at least
+unhealthyZoneThreshold (no less than 3) of Nodes in the zone are NotReady</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PersistentVolumeBinderControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>PersistentVolumeBinderControllerConfiguration contains elements describing
+PersistentVolumeBinderController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>PVClaimBinderSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>pvClaimBinderSyncPeriod is the period for syncing persistent volumes
+and persistent volume claims.</p>
+</td>
+</tr>
+<tr><td><code>VolumeConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration"><code>VolumeConfiguration</code></a>
+</td>
+<td>
+   <p>volumeConfiguration holds configuration for volume related features.</p>
+</td>
+</tr>
+<tr><td><code>VolumeHostCIDRDenylist</code> <B>[Required]</B><br/>
+<code>[]string</code>
+</td>
+<td>
+   <p>VolumeHostCIDRDenylist is a list of CIDRs that should not be reachable by the
+controller from plugins.</p>
+</td>
+</tr>
+<tr><td><code>VolumeHostAllowLocalLoopback</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>VolumeHostAllowLocalLoopback indicates if local loopback hosts (127.0.0.1, etc)
+should be allowed from plugins.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PersistentVolumeRecyclerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeRecyclerConfiguration}
+    
+
+**Appears in:**
+
+- [VolumeConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration)
+
+
+<p>PersistentVolumeRecyclerConfiguration contains elements describing persistent volume plugins.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>MaximumRetry</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>maximumRetry is number of retries the PV recycler will execute on failure to recycle
+PV.</p>
+</td>
+</tr>
+<tr><td><code>MinimumTimeoutNFS</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>minimumTimeoutNFS is the minimum ActiveDeadlineSeconds to use for an NFS Recycler
+pod.</p>
+</td>
+</tr>
+<tr><td><code>PodTemplateFilePathNFS</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>podTemplateFilePathNFS is the file path to a pod definition used as a template for
+NFS persistent volume recycling</p>
+</td>
+</tr>
+<tr><td><code>IncrementTimeoutNFS</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>incrementTimeoutNFS is the increment of time added per Gi to ActiveDeadlineSeconds
+for an NFS scrubber pod.</p>
+</td>
+</tr>
+<tr><td><code>PodTemplateFilePathHostPath</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>podTemplateFilePathHostPath is the file path to a pod definition used as a template for
+HostPath persistent volume recycling. This is for development and testing only and
+will not work in a multi-node cluster.</p>
+</td>
+</tr>
+<tr><td><code>MinimumTimeoutHostPath</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>minimumTimeoutHostPath is the minimum ActiveDeadlineSeconds to use for a HostPath
+Recycler pod.  This is for development and testing only and will not work in a multi-node
+cluster.</p>
+</td>
+</tr>
+<tr><td><code>IncrementTimeoutHostPath</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>incrementTimeoutHostPath is the increment of time added per Gi to ActiveDeadlineSeconds
+for a HostPath scrubber pod.  This is for development and testing only and will not work
+in a multi-node cluster.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `PodGCControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PodGCControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>PodGCControllerConfiguration contains elements describing PodGCController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>TerminatedPodGCThreshold</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>terminatedPodGCThreshold is the number of terminated pods that can exist
+before the terminated pod garbage collector starts deleting terminated pods.
+If &lt;= 0, the terminated pod garbage collector is disabled.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ReplicaSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicaSetControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>ReplicaSetControllerConfiguration contains elements describing ReplicaSetController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentRSSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentRSSyncs is the number of replica sets that are  allowed to sync
+concurrently. Larger number = more responsive replica  management, but more
+CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ReplicationControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicationControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>ReplicationControllerConfiguration contains elements describing ReplicationController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentRCSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentRCSyncs is the number of replication controllers that are
+allowed to sync concurrently. Larger number = more responsive replica
+management, but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ResourceQuotaControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceQuotaControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>ResourceQuotaControllerConfiguration contains elements describing ResourceQuotaController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ResourceQuotaSyncPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>resourceQuotaSyncPeriod is the period for syncing quota usage status
+in the system.</p>
+</td>
+</tr>
+<tr><td><code>ConcurrentResourceQuotaSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentResourceQuotaSyncs is the number of resource quotas that are
+allowed to sync concurrently. Larger number = more responsive quota
+management, but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `SAControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-SAControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>SAControllerConfiguration contains elements describing ServiceAccountController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ServiceAccountKeyFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
+used to sign service account tokens.</p>
+</td>
+</tr>
+<tr><td><code>ConcurrentSATokenSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentSATokenSyncs is the number of service account token syncing operations
+that will be done concurrently.</p>
+</td>
+</tr>
+<tr><td><code>RootCAFile</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>rootCAFile is the root certificate authority will be included in service
+account's token secret. This must be a valid PEM-encoded CA bundle.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `StatefulSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-StatefulSetControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>StatefulSetControllerConfiguration contains elements describing StatefulSetController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentStatefulSetSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentStatefulSetSyncs is the number of statefulset objects that are
+allowed to sync concurrently. Larger number = more responsive statefulsets,
+but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TTLAfterFinishedControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-TTLAfterFinishedControllerConfiguration}
+    
+
+**Appears in:**
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>TTLAfterFinishedControllerConfiguration contains elements describing TTLAfterFinishedController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentTTLSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentTTLSyncs is the number of TTL-after-finished collector workers that are
+allowed to sync concurrently.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `VolumeConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration}
+    
+
+**Appears in:**
+
+- [PersistentVolumeBinderControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration)
+
+
+<p>VolumeConfiguration contains <em>all</em> enumerated flags meant to configure all volume
+plugins. From this config, the controller-manager binary will create many instances of
+volume.VolumeConfig, each containing only the configuration needed for that plugin which
+are then passed to the appropriate plugin. The ControllerManager binary is the only part
+of the code which knows what plugins are supported and which flags correspond to each plugin.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>EnableHostPathProvisioning</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>enableHostPathProvisioning enables HostPath PV provisioning when running without a
+cloud provider. This allows testing and development of provisioning features. HostPath
+provisioning is not supported in any way, won't work in a multi-node cluster, and
+should not be used for anything other than testing or development.</p>
+</td>
+</tr>
+<tr><td><code>EnableDynamicProvisioning</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>enableDynamicProvisioning enables the provisioning of volumes when running within an environment
+that supports dynamic provisioning. Defaults to true.</p>
+</td>
+</tr>
+<tr><td><code>PersistentVolumeRecyclerConfiguration</code> <B>[Required]</B><br/>
+<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeRecyclerConfiguration"><code>PersistentVolumeRecyclerConfiguration</code></a>
+</td>
+<td>
+   <p>persistentVolumeRecyclerConfiguration holds configuration for persistent volume plugins.</p>
+</td>
+</tr>
+<tr><td><code>FlexVolumePluginDir</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>volumePluginDir is the full path of the directory in which the flex
+volume plugin should search for additional third party volume plugins</p>
+</td>
+</tr>
+</tbody>
+</table>
+  
+  
+    
+
+## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
+    
+
+**Appears in:**
+
+- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
+
+- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
+
+
+<p>ServiceControllerConfiguration contains elements describing ServiceController.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>concurrentServiceSyncs is the number of services that are
+allowed to sync concurrently. Larger number = more responsive service
+management, but more CPU (and network) load.</p>
+</td>
+</tr>
+</tbody>
+</table>
+  
+    
+
+## `CloudControllerManagerConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration}
+    
 
 
 
@@ -30,91 +1481,75 @@ auto_generated: true
 <tr><td><code>apiVersion</code><br/>string</td><td><code>cloudcontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>CloudControllerManagerConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>Generic</code> <B>[Required]</B><br/>
 <a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
 </td>
 <td>
-   Generic holds configuration for a generic controller-manager</td>
+   <p>Generic holds configuration for a generic controller-manager</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
 <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
 </td>
 <td>
-   KubeCloudSharedConfiguration holds configuration for shared related features
-both in cloud controller manager and kube-controller manager.</td>
+   <p>KubeCloudSharedConfiguration holds configuration for shared related features
+both in cloud controller manager and kube-controller manager.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ServiceController</code> <B>[Required]</B><br/>
 <a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
 </td>
 <td>
-   ServiceControllerConfiguration holds configuration for ServiceController
-related features.</td>
+   <p>ServiceControllerConfiguration holds configuration for ServiceController
+related features.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>NodeStatusUpdateFrequency</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status</td>
+   <p>NodeStatusUpdateFrequency is the frequency at which the controller updates nodes' status</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `CloudProviderConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration}
     
-
-
 
 **Appears in:**
 
 - [KubeCloudSharedConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration)
 
 
-CloudProviderConfiguration contains basically elements about cloud provider.
+<p>CloudProviderConfiguration contains basically elements about cloud provider.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>Name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the provider for cloud services.</td>
+   <p>Name is the provider for cloud services.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>CloudConfigFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   cloudConfigFile is the path to the cloud provider configuration file.</td>
+   <p>cloudConfigFile is the path to the cloud provider configuration file.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeCloudSharedConfiguration`     {#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration}
     
-
-
 
 **Appears in:**
 
@@ -123,171 +1558,149 @@ CloudProviderConfiguration contains basically elements about cloud provider.
 - [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
 
 
-KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
-and cloud-controller manager, but not genericconfig.
+<p>KubeCloudSharedConfiguration contains elements shared by both kube-controller manager
+and cloud-controller manager, but not genericconfig.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>CloudProvider</code> <B>[Required]</B><br/>
 <a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudProviderConfiguration"><code>CloudProviderConfiguration</code></a>
 </td>
 <td>
-   CloudProviderConfiguration holds configuration for CloudProvider related features.</td>
+   <p>CloudProviderConfiguration holds configuration for CloudProvider related features.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ExternalCloudVolumePlugin</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   externalCloudVolumePlugin specifies the plugin to use when cloudProvider is "external".
-It is currently used by the in repo cloud providers to handle node and volume control in the KCM.</td>
+   <p>externalCloudVolumePlugin specifies the plugin to use when cloudProvider is &quot;external&quot;.
+It is currently used by the in repo cloud providers to handle node and volume control in the KCM.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>UseServiceAccountCredentials</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   useServiceAccountCredentials indicates whether controllers should be run with
-individual service account credentials.</td>
+   <p>useServiceAccountCredentials indicates whether controllers should be run with
+individual service account credentials.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>AllowUntaggedCloud</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   run with untagged cloud instances</td>
+   <p>run with untagged cloud instances</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>RouteReconciliationPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</td>
+   <p>routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>NodeMonitorPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</td>
+   <p>nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ClusterName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   clusterName is the instance prefix for the cluster.</td>
+   <p>clusterName is the instance prefix for the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ClusterCIDR</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   clusterCIDR is CIDR Range for Pods in cluster.</td>
+   <p>clusterCIDR is CIDR Range for Pods in cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>AllocateNodeCIDRs</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
-ConfigureCloudRoutes is true, to be set on the cloud provider.</td>
+   <p>AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
+ConfigureCloudRoutes is true, to be set on the cloud provider.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>CIDRAllocatorType</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CIDRAllocatorType determines what kind of pod CIDR allocator will be used.</td>
+   <p>CIDRAllocatorType determines what kind of pod CIDR allocator will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ConfigureCloudRoutes</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
-to be configured on the cloud provider.</td>
+   <p>configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
+to be configured on the cloud provider.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>NodeSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
+   <p>nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
 periods will result in fewer calls to cloud provider, but may delay addition
-of new nodes to cluster.</td>
+of new nodes to cluster.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   
   
     
-
 
 ## `ControllerLeaderConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration}
     
-
-
 
 **Appears in:**
 
 - [LeaderMigrationConfiguration](#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration)
 
 
-ControllerLeaderConfiguration provides the configuration for a migrating leader lock.
+<p>ControllerLeaderConfiguration provides the configuration for a migrating leader lock.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the name of the controller being migrated
-E.g. service-controller, route-controller, cloud-node-controller, etc</td>
+   <p>Name is the name of the controller being migrated
+E.g. service-controller, route-controller, cloud-node-controller, etc</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>component</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Component is the name of the component in which the controller should be running.
+   <p>Component is the name of the component in which the controller should be running.
 E.g. kube-controller-manager, cloud-controller-manager, etc
-Or '&lowast;' meaning the controller can be run under any component that participates in the migration</td>
+Or '&lowast;' meaning the controller can be run under any component that participates in the migration</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `GenericControllerManagerConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration}
     
-
-
 
 **Appears in:**
 
@@ -296,1833 +1709,132 @@ Or '&lowast;' meaning the controller can be run under any component that partici
 - [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
 
 
-GenericControllerManagerConfiguration holds configuration for a generic controller-manager.
+<p>GenericControllerManagerConfiguration holds configuration for a generic controller-manager.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>Port</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   port is the port that the controller-manager's http service runs on.</td>
+   <p>port is the port that the controller-manager's http service runs on.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>Address</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   address is the IP address to serve on (set to 0.0.0.0 for all interfaces).</td>
+   <p>address is the IP address to serve on (set to 0.0.0.0 for all interfaces).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>MinResyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   minResyncPeriod is the resync period in reflectors; will be random between
-minResyncPeriod and 2&lowast;minResyncPeriod.</td>
+   <p>minResyncPeriod is the resync period in reflectors; will be random between
+minResyncPeriod and 2&lowast;minResyncPeriod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ClientConnection</code> <B>[Required]</B><br/>
 <a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
 </td>
 <td>
-   ClientConnection specifies the kubeconfig file and client connection
-settings for the proxy server to use when communicating with the apiserver.</td>
+   <p>ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ControllerStartInterval</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   How long to wait between starting controller managers</td>
+   <p>How long to wait between starting controller managers</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>LeaderElection</code> <B>[Required]</B><br/>
 <a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
 </td>
 <td>
-   leaderElection defines the configuration of leader election client.</td>
+   <p>leaderElection defines the configuration of leader election client.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>Controllers</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   Controllers is the list of controllers to enable or disable
-'&lowast;' means "all enabled by default controllers"
-'foo' means "enable 'foo'"
-'-foo' means "disable 'foo'"
-first item for a particular name wins</td>
+   <p>Controllers is the list of controllers to enable or disable
+'&lowast;' means &quot;all enabled by default controllers&quot;
+'foo' means &quot;enable 'foo'&quot;
+'-foo' means &quot;disable 'foo'&quot;
+first item for a particular name wins</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>Debugging</code> <B>[Required]</B><br/>
 <a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
 </td>
 <td>
-   DebuggingConfiguration holds configuration for Debugging related features.</td>
+   <p>DebuggingConfiguration holds configuration for Debugging related features.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>LeaderMigrationEnabled</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   LeaderMigrationEnabled indicates whether Leader Migration should be enabled for the controller manager.</td>
+   <p>LeaderMigrationEnabled indicates whether Leader Migration should be enabled for the controller manager.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>LeaderMigration</code> <B>[Required]</B><br/>
 <a href="#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration"><code>LeaderMigrationConfiguration</code></a>
 </td>
 <td>
-   LeaderMigration holds the configuration for Leader Migration.</td>
+   <p>LeaderMigration holds the configuration for Leader Migration.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `LeaderMigrationConfiguration`     {#controllermanager-config-k8s-io-v1alpha1-LeaderMigrationConfiguration}
     
-
-
 
 **Appears in:**
 
 - [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
 
 
-LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.
+<p>LeaderMigrationConfiguration provides versioned configuration for all migrating leader locks.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
-  
   
 <tr><td><code>leaderName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   LeaderName is the name of the leader election resource that protects the migration
-E.g. 1-20-KCM-to-1-21-CCM</td>
+   <p>LeaderName is the name of the leader election resource that protects the migration
+E.g. 1-20-KCM-to-1-21-CCM</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceLock</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ResourceLock indicates the resource object type that will be used to lock
-Should be "leases" or "endpoints"</td>
+   <p>ResourceLock indicates the resource object type that will be used to lock
+Should be &quot;leases&quot; or &quot;endpoints&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>controllerLeaders</code> <B>[Required]</B><br/>
 <a href="#controllermanager-config-k8s-io-v1alpha1-ControllerLeaderConfiguration"><code>[]ControllerLeaderConfiguration</code></a>
 </td>
 <td>
-   ControllerLeaders contains a list of migrating leader lock configurations</td>
+   <p>ControllerLeaders contains a list of migrating leader lock configurations</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   
-  
-    
-
-
-## `KubeControllerManagerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration}
-    
-
-
-
-
-KubeControllerManagerConfiguration contains elements describing kube-controller manager.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-<tr><td><code>apiVersion</code><br/>string</td><td><code>kubecontrollermanager.config.k8s.io/v1alpha1</code></td></tr>
-<tr><td><code>kind</code><br/>string</td><td><code>KubeControllerManagerConfiguration</code></td></tr>
-    
-
-  
-  
-<tr><td><code>Generic</code> <B>[Required]</B><br/>
-<a href="#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration"><code>GenericControllerManagerConfiguration</code></a>
-</td>
-<td>
-   Generic holds configuration for a generic controller-manager</td>
-</tr>
-    
-  
-<tr><td><code>KubeCloudShared</code> <B>[Required]</B><br/>
-<a href="#cloudcontrollermanager-config-k8s-io-v1alpha1-KubeCloudSharedConfiguration"><code>KubeCloudSharedConfiguration</code></a>
-</td>
-<td>
-   KubeCloudSharedConfiguration holds configuration for shared related features
-both in cloud controller manager and kube-controller manager.</td>
-</tr>
-    
-  
-<tr><td><code>AttachDetachController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-AttachDetachControllerConfiguration"><code>AttachDetachControllerConfiguration</code></a>
-</td>
-<td>
-   AttachDetachControllerConfiguration holds configuration for
-AttachDetachController related features.</td>
-</tr>
-    
-  
-<tr><td><code>CSRSigningController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration"><code>CSRSigningControllerConfiguration</code></a>
-</td>
-<td>
-   CSRSigningControllerConfiguration holds configuration for
-CSRSigningController related features.</td>
-</tr>
-    
-  
-<tr><td><code>DaemonSetController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DaemonSetControllerConfiguration"><code>DaemonSetControllerConfiguration</code></a>
-</td>
-<td>
-   DaemonSetControllerConfiguration holds configuration for DaemonSetController
-related features.</td>
-</tr>
-    
-  
-<tr><td><code>DeploymentController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DeploymentControllerConfiguration"><code>DeploymentControllerConfiguration</code></a>
-</td>
-<td>
-   DeploymentControllerConfiguration holds configuration for
-DeploymentController related features.</td>
-</tr>
-    
-  
-<tr><td><code>StatefulSetController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-StatefulSetControllerConfiguration"><code>StatefulSetControllerConfiguration</code></a>
-</td>
-<td>
-   StatefulSetControllerConfiguration holds configuration for
-StatefulSetController related features.</td>
-</tr>
-    
-  
-<tr><td><code>DeprecatedController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-DeprecatedControllerConfiguration"><code>DeprecatedControllerConfiguration</code></a>
-</td>
-<td>
-   DeprecatedControllerConfiguration holds configuration for some deprecated
-features.</td>
-</tr>
-    
-  
-<tr><td><code>EndpointController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointControllerConfiguration"><code>EndpointControllerConfiguration</code></a>
-</td>
-<td>
-   EndpointControllerConfiguration holds configuration for EndpointController
-related features.</td>
-</tr>
-    
-  
-<tr><td><code>EndpointSliceController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceControllerConfiguration"><code>EndpointSliceControllerConfiguration</code></a>
-</td>
-<td>
-   EndpointSliceControllerConfiguration holds configuration for
-EndpointSliceController related features.</td>
-</tr>
-    
-  
-<tr><td><code>EndpointSliceMirroringController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceMirroringControllerConfiguration"><code>EndpointSliceMirroringControllerConfiguration</code></a>
-</td>
-<td>
-   EndpointSliceMirroringControllerConfiguration holds configuration for
-EndpointSliceMirroringController related features.</td>
-</tr>
-    
-  
-<tr><td><code>EphemeralVolumeController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-EphemeralVolumeControllerConfiguration"><code>EphemeralVolumeControllerConfiguration</code></a>
-</td>
-<td>
-   EphemeralVolumeControllerConfiguration holds configuration for EphemeralVolumeController
-related features.</td>
-</tr>
-    
-  
-<tr><td><code>GarbageCollectorController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration"><code>GarbageCollectorControllerConfiguration</code></a>
-</td>
-<td>
-   GarbageCollectorControllerConfiguration holds configuration for
-GarbageCollectorController related features.</td>
-</tr>
-    
-  
-<tr><td><code>HPAController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-HPAControllerConfiguration"><code>HPAControllerConfiguration</code></a>
-</td>
-<td>
-   HPAControllerConfiguration holds configuration for HPAController related features.</td>
-</tr>
-    
-  
-<tr><td><code>JobController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-JobControllerConfiguration"><code>JobControllerConfiguration</code></a>
-</td>
-<td>
-   JobControllerConfiguration holds configuration for JobController related features.</td>
-</tr>
-    
-  
-<tr><td><code>CronJobController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CronJobControllerConfiguration"><code>CronJobControllerConfiguration</code></a>
-</td>
-<td>
-   CronJobControllerConfiguration holds configuration for CronJobController related features.</td>
-</tr>
-    
-  
-<tr><td><code>NamespaceController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NamespaceControllerConfiguration"><code>NamespaceControllerConfiguration</code></a>
-</td>
-<td>
-   NamespaceControllerConfiguration holds configuration for NamespaceController
-related features.
-NamespaceControllerConfiguration holds configuration for NamespaceController
-related features.</td>
-</tr>
-    
-  
-<tr><td><code>NodeIPAMController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NodeIPAMControllerConfiguration"><code>NodeIPAMControllerConfiguration</code></a>
-</td>
-<td>
-   NodeIPAMControllerConfiguration holds configuration for NodeIPAMController
-related features.</td>
-</tr>
-    
-  
-<tr><td><code>NodeLifecycleController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-NodeLifecycleControllerConfiguration"><code>NodeLifecycleControllerConfiguration</code></a>
-</td>
-<td>
-   NodeLifecycleControllerConfiguration holds configuration for
-NodeLifecycleController related features.</td>
-</tr>
-    
-  
-<tr><td><code>PersistentVolumeBinderController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration"><code>PersistentVolumeBinderControllerConfiguration</code></a>
-</td>
-<td>
-   PersistentVolumeBinderControllerConfiguration holds configuration for
-PersistentVolumeBinderController related features.</td>
-</tr>
-    
-  
-<tr><td><code>PodGCController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PodGCControllerConfiguration"><code>PodGCControllerConfiguration</code></a>
-</td>
-<td>
-   PodGCControllerConfiguration holds configuration for PodGCController
-related features.</td>
-</tr>
-    
-  
-<tr><td><code>ReplicaSetController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicaSetControllerConfiguration"><code>ReplicaSetControllerConfiguration</code></a>
-</td>
-<td>
-   ReplicaSetControllerConfiguration holds configuration for ReplicaSet related features.</td>
-</tr>
-    
-  
-<tr><td><code>ReplicationController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicationControllerConfiguration"><code>ReplicationControllerConfiguration</code></a>
-</td>
-<td>
-   ReplicationControllerConfiguration holds configuration for
-ReplicationController related features.</td>
-</tr>
-    
-  
-<tr><td><code>ResourceQuotaController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceQuotaControllerConfiguration"><code>ResourceQuotaControllerConfiguration</code></a>
-</td>
-<td>
-   ResourceQuotaControllerConfiguration holds configuration for
-ResourceQuotaController related features.</td>
-</tr>
-    
-  
-<tr><td><code>SAController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-SAControllerConfiguration"><code>SAControllerConfiguration</code></a>
-</td>
-<td>
-   SAControllerConfiguration holds configuration for ServiceAccountController
-related features.</td>
-</tr>
-    
-  
-<tr><td><code>ServiceController</code> <B>[Required]</B><br/>
-<a href="#ServiceControllerConfiguration"><code>ServiceControllerConfiguration</code></a>
-</td>
-<td>
-   ServiceControllerConfiguration holds configuration for ServiceController
-related features.</td>
-</tr>
-    
-  
-<tr><td><code>TTLAfterFinishedController</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-TTLAfterFinishedControllerConfiguration"><code>TTLAfterFinishedControllerConfiguration</code></a>
-</td>
-<td>
-   TTLAfterFinishedControllerConfiguration holds configuration for
-TTLAfterFinishedController related features.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `AttachDetachControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-AttachDetachControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-AttachDetachControllerConfiguration contains elements describing AttachDetachController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>DisableAttachDetachReconcilerSync</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   Reconciler runs a periodic loop to reconcile the desired state of the with
-the actual state of the world by triggering attach detach operations.
-This flag enables or disables reconcile.  Is false by default, and thus enabled.</td>
-</tr>
-    
-  
-<tr><td><code>ReconcilerSyncLoopPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
-wait between successive executions. Is set to 5 sec by default.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `CSRSigningConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [CSRSigningControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration)
-
-
-CSRSigningConfiguration holds information about a particular CSR signer
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>CertFile</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   certFile is the filename containing a PEM-encoded
-X509 CA certificate used to issue certificates</td>
-</tr>
-    
-  
-<tr><td><code>KeyFile</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   keyFile is the filename containing a PEM-encoded
-RSA or ECDSA private key used to issue certificates</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `CSRSigningControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-CSRSigningControllerConfiguration contains elements describing CSRSigningController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ClusterSigningCertFile</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   clusterSigningCertFile is the filename containing a PEM-encoded
-X509 CA certificate used to issue cluster-scoped certificates</td>
-</tr>
-    
-  
-<tr><td><code>ClusterSigningKeyFile</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   clusterSigningCertFile is the filename containing a PEM-encoded
-RSA or ECDSA private key used to issue cluster-scoped certificates</td>
-</tr>
-    
-  
-<tr><td><code>KubeletServingSignerConfiguration</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
-</td>
-<td>
-   kubeletServingSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kubelet-serving signer</td>
-</tr>
-    
-  
-<tr><td><code>KubeletClientSignerConfiguration</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
-</td>
-<td>
-   kubeletClientSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kube-apiserver-client-kubelet</td>
-</tr>
-    
-  
-<tr><td><code>KubeAPIServerClientSignerConfiguration</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
-</td>
-<td>
-   kubeAPIServerClientSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/kube-apiserver-client</td>
-</tr>
-    
-  
-<tr><td><code>LegacyUnknownSignerConfiguration</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-CSRSigningConfiguration"><code>CSRSigningConfiguration</code></a>
-</td>
-<td>
-   legacyUnknownSignerConfiguration holds the certificate and key used to issue certificates for the kubernetes.io/legacy-unknown</td>
-</tr>
-    
-  
-<tr><td><code>ClusterSigningDuration</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   clusterSigningDuration is the max length of duration signed certificates will be given.
-Individual CSRs may request shorter certs by setting spec.expirationSeconds.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `CronJobControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-CronJobControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-CronJobControllerConfiguration contains elements describing CrongJob2Controller.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentCronJobSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentCronJobSyncs is the number of job objects that are
-allowed to sync concurrently. Larger number = more responsive jobs,
-but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `DaemonSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DaemonSetControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-DaemonSetControllerConfiguration contains elements describing DaemonSetController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentDaemonSetSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentDaemonSetSyncs is the number of daemonset objects that are
-allowed to sync concurrently. Larger number = more responsive daemonset,
-but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `DeploymentControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DeploymentControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-DeploymentControllerConfiguration contains elements describing DeploymentController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentDeploymentSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentDeploymentSyncs is the number of deployment objects that are
-allowed to sync concurrently. Larger number = more responsive deployments,
-but more CPU (and network) load.</td>
-</tr>
-    
-  
-<tr><td><code>DeploymentControllerSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   deploymentControllerSyncPeriod is the period for syncing the deployments.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `DeprecatedControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-DeprecatedControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-DeprecatedControllerConfiguration contains elements be deprecated.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>DeletingPodsQPS</code> <B>[Required]</B><br/>
-<code>float32</code>
-</td>
-<td>
-   DEPRECATED: deletingPodsQps is the number of nodes per second on which pods are deleted in
-case of node failure.</td>
-</tr>
-    
-  
-<tr><td><code>DeletingPodsBurst</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   DEPRECATED: deletingPodsBurst is the number of nodes on which pods are bursty deleted in
-case of node failure. For more details look into RateLimiter.</td>
-</tr>
-    
-  
-<tr><td><code>RegisterRetryCount</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   registerRetryCount is the number of retries for initial node registration.
-Retry interval equals node-sync-period.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `EndpointControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-EndpointControllerConfiguration contains elements describing EndpointController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentEndpointSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentEndpointSyncs is the number of endpoint syncing operations
-that will be done concurrently. Larger number = faster endpoint updating,
-but more CPU (and network) load.</td>
-</tr>
-    
-  
-<tr><td><code>EndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   EndpointUpdatesBatchPeriod describes the length of endpoint updates batching period.
-Processing of pod changes will be delayed by this duration to join them with potential
-upcoming updates and reduce the overall number of endpoints updates.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `EndpointSliceControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-EndpointSliceControllerConfiguration contains elements describing
-EndpointSliceController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentServiceEndpointSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentServiceEndpointSyncs is the number of service endpoint syncing
-operations that will be done concurrently. Larger number = faster
-endpoint slice updating, but more CPU (and network) load.</td>
-</tr>
-    
-  
-<tr><td><code>MaxEndpointsPerSlice</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   maxEndpointsPerSlice is the maximum number of endpoints that will be
-added to an EndpointSlice. More endpoints per slice will result in fewer
-and larger endpoint slices, but larger resources.</td>
-</tr>
-    
-  
-<tr><td><code>EndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   EndpointUpdatesBatchPeriod describes the length of endpoint updates batching period.
-Processing of pod changes will be delayed by this duration to join them with potential
-upcoming updates and reduce the overall number of endpoints updates.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `EndpointSliceMirroringControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EndpointSliceMirroringControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-EndpointSliceMirroringControllerConfiguration contains elements describing
-EndpointSliceMirroringController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>MirroringConcurrentServiceEndpointSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   mirroringConcurrentServiceEndpointSyncs is the number of service endpoint
-syncing operations that will be done concurrently. Larger number = faster
-endpoint slice updating, but more CPU (and network) load.</td>
-</tr>
-    
-  
-<tr><td><code>MirroringMaxEndpointsPerSubset</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   mirroringMaxEndpointsPerSubset is the maximum number of endpoints that
-will be mirrored to an EndpointSlice for an EndpointSubset.</td>
-</tr>
-    
-  
-<tr><td><code>MirroringEndpointUpdatesBatchPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   mirroringEndpointUpdatesBatchPeriod can be used to batch EndpointSlice
-updates. All updates triggered by EndpointSlice changes will be delayed
-by up to 'mirroringEndpointUpdatesBatchPeriod'. If other addresses in the
-same Endpoints resource change in that period, they will be batched to a
-single EndpointSlice update. Default 0 value means that each Endpoints
-update triggers an EndpointSlice update.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `EphemeralVolumeControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-EphemeralVolumeControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-EphemeralVolumeControllerConfiguration contains elements describing EphemeralVolumeController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentEphemeralVolumeSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   ConcurrentEphemeralVolumeSyncseSyncs is the number of ephemeral volume syncing operations
-that will be done concurrently. Larger number = faster ephemeral volume updating,
-but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `GarbageCollectorControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-GarbageCollectorControllerConfiguration contains elements describing GarbageCollectorController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>EnableGarbageCollector</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   enables the generic garbage collector. MUST be synced with the
-corresponding flag of the kube-apiserver. WARNING: the generic garbage
-collector is an alpha feature.</td>
-</tr>
-    
-  
-<tr><td><code>ConcurrentGCSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentGCSyncs is the number of garbage collector workers that are
-allowed to sync concurrently.</td>
-</tr>
-    
-  
-<tr><td><code>GCIgnoredResources</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-GroupResource"><code>[]GroupResource</code></a>
-</td>
-<td>
-   gcIgnoredResources is the list of GroupResources that garbage collection should ignore.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `GroupResource`     {#kubecontrollermanager-config-k8s-io-v1alpha1-GroupResource}
-    
-
-
-
-**Appears in:**
-
-- [GarbageCollectorControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-GarbageCollectorControllerConfiguration)
-
-
-GroupResource describes an group resource.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>Group</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   group is the group portion of the GroupResource.</td>
-</tr>
-    
-  
-<tr><td><code>Resource</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   resource is the resource portion of the GroupResource.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `HPAControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-HPAControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-HPAControllerConfiguration contains elements describing HPAController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>HorizontalPodAutoscalerSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   HorizontalPodAutoscalerSyncPeriod is the period for syncing the number of
-pods in horizontal pod autoscaler.</td>
-</tr>
-    
-  
-<tr><td><code>HorizontalPodAutoscalerUpscaleForbiddenWindow</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   HorizontalPodAutoscalerUpscaleForbiddenWindow is a period after which next upscale allowed.</td>
-</tr>
-    
-  
-<tr><td><code>HorizontalPodAutoscalerDownscaleStabilizationWindow</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   HorizontalPodAutoscalerDowncaleStabilizationWindow is a period for which autoscaler will look
-backwards and not scale down below any recommendation it made during that period.</td>
-</tr>
-    
-  
-<tr><td><code>HorizontalPodAutoscalerDownscaleForbiddenWindow</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   HorizontalPodAutoscalerDownscaleForbiddenWindow is a period after which next downscale allowed.</td>
-</tr>
-    
-  
-<tr><td><code>HorizontalPodAutoscalerTolerance</code> <B>[Required]</B><br/>
-<code>float64</code>
-</td>
-<td>
-   HorizontalPodAutoscalerTolerance is the tolerance for when
-resource usage suggests upscaling/downscaling</td>
-</tr>
-    
-  
-<tr><td><code>HorizontalPodAutoscalerCPUInitializationPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   HorizontalPodAutoscalerCPUInitializationPeriod is the period after pod start when CPU samples
-might be skipped.</td>
-</tr>
-    
-  
-<tr><td><code>HorizontalPodAutoscalerInitialReadinessDelay</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   HorizontalPodAutoscalerInitialReadinessDelay is period after pod start during which readiness
-changes are treated as readiness being set for the first time. The only effect of this is that
-HPA will disregard CPU samples from unready pods that had last readiness change during that
-period.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `JobControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-JobControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-JobControllerConfiguration contains elements describing JobController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentJobSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentJobSyncs is the number of job objects that are
-allowed to sync concurrently. Larger number = more responsive jobs,
-but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `NamespaceControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NamespaceControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-NamespaceControllerConfiguration contains elements describing NamespaceController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>NamespaceSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   namespaceSyncPeriod is the period for syncing namespace life-cycle
-updates.</td>
-</tr>
-    
-  
-<tr><td><code>ConcurrentNamespaceSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentNamespaceSyncs is the number of namespace objects that are
-allowed to sync concurrently.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `NodeIPAMControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NodeIPAMControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-NodeIPAMControllerConfiguration contains elements describing NodeIpamController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ServiceCIDR</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   serviceCIDR is CIDR Range for Services in cluster.</td>
-</tr>
-    
-  
-<tr><td><code>SecondaryServiceCIDR</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   secondaryServiceCIDR is CIDR Range for Services in cluster. This is used in dual stack clusters. SecondaryServiceCIDR must be of different IP family than ServiceCIDR</td>
-</tr>
-    
-  
-<tr><td><code>NodeCIDRMaskSize</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   NodeCIDRMaskSize is the mask size for node cidr in cluster.</td>
-</tr>
-    
-  
-<tr><td><code>NodeCIDRMaskSizeIPv4</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   NodeCIDRMaskSizeIPv4 is the mask size for node cidr in dual-stack cluster.</td>
-</tr>
-    
-  
-<tr><td><code>NodeCIDRMaskSizeIPv6</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   NodeCIDRMaskSizeIPv6 is the mask size for node cidr in dual-stack cluster.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `NodeLifecycleControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-NodeLifecycleControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-NodeLifecycleControllerConfiguration contains elements describing NodeLifecycleController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>EnableTaintManager</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   If set to true enables NoExecute Taints and will evict all not-tolerating
-Pod running on Nodes tainted with this kind of Taints.</td>
-</tr>
-    
-  
-<tr><td><code>NodeEvictionRate</code> <B>[Required]</B><br/>
-<code>float32</code>
-</td>
-<td>
-   nodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is healthy</td>
-</tr>
-    
-  
-<tr><td><code>SecondaryNodeEvictionRate</code> <B>[Required]</B><br/>
-<code>float32</code>
-</td>
-<td>
-   secondaryNodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is unhealthy</td>
-</tr>
-    
-  
-<tr><td><code>NodeStartupGracePeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   nodeStartupGracePeriod is the amount of time which we allow starting a node to
-be unresponsive before marking it unhealthy.</td>
-</tr>
-    
-  
-<tr><td><code>NodeMonitorGracePeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   nodeMontiorGracePeriod is the amount of time which we allow a running node to be
-unresponsive before marking it unhealthy. Must be N times more than kubelet's
-nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet
-to post node status.</td>
-</tr>
-    
-  
-<tr><td><code>PodEvictionTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   podEvictionTimeout is the grace period for deleting pods on failed nodes.</td>
-</tr>
-    
-  
-<tr><td><code>LargeClusterSizeThreshold</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   secondaryNodeEvictionRate is implicitly overridden to 0 for clusters smaller than or equal to largeClusterSizeThreshold</td>
-</tr>
-    
-  
-<tr><td><code>UnhealthyZoneThreshold</code> <B>[Required]</B><br/>
-<code>float32</code>
-</td>
-<td>
-   Zone is treated as unhealthy in nodeEvictionRate and secondaryNodeEvictionRate when at least
-unhealthyZoneThreshold (no less than 3) of Nodes in the zone are NotReady</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `PersistentVolumeBinderControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-PersistentVolumeBinderControllerConfiguration contains elements describing
-PersistentVolumeBinderController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>PVClaimBinderSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   pvClaimBinderSyncPeriod is the period for syncing persistent volumes
-and persistent volume claims.</td>
-</tr>
-    
-  
-<tr><td><code>VolumeConfiguration</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration"><code>VolumeConfiguration</code></a>
-</td>
-<td>
-   volumeConfiguration holds configuration for volume related features.</td>
-</tr>
-    
-  
-<tr><td><code>VolumeHostCIDRDenylist</code> <B>[Required]</B><br/>
-<code>[]string</code>
-</td>
-<td>
-   VolumeHostCIDRDenylist is a list of CIDRs that should not be reachable by the
-controller from plugins.</td>
-</tr>
-    
-  
-<tr><td><code>VolumeHostAllowLocalLoopback</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   VolumeHostAllowLocalLoopback indicates if local loopback hosts (127.0.0.1, etc)
-should be allowed from plugins.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `PersistentVolumeRecyclerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeRecyclerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [VolumeConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration)
-
-
-PersistentVolumeRecyclerConfiguration contains elements describing persistent volume plugins.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>MaximumRetry</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   maximumRetry is number of retries the PV recycler will execute on failure to recycle
-PV.</td>
-</tr>
-    
-  
-<tr><td><code>MinimumTimeoutNFS</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   minimumTimeoutNFS is the minimum ActiveDeadlineSeconds to use for an NFS Recycler
-pod.</td>
-</tr>
-    
-  
-<tr><td><code>PodTemplateFilePathNFS</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   podTemplateFilePathNFS is the file path to a pod definition used as a template for
-NFS persistent volume recycling</td>
-</tr>
-    
-  
-<tr><td><code>IncrementTimeoutNFS</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   incrementTimeoutNFS is the increment of time added per Gi to ActiveDeadlineSeconds
-for an NFS scrubber pod.</td>
-</tr>
-    
-  
-<tr><td><code>PodTemplateFilePathHostPath</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   podTemplateFilePathHostPath is the file path to a pod definition used as a template for
-HostPath persistent volume recycling. This is for development and testing only and
-will not work in a multi-node cluster.</td>
-</tr>
-    
-  
-<tr><td><code>MinimumTimeoutHostPath</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   minimumTimeoutHostPath is the minimum ActiveDeadlineSeconds to use for a HostPath
-Recycler pod.  This is for development and testing only and will not work in a multi-node
-cluster.</td>
-</tr>
-    
-  
-<tr><td><code>IncrementTimeoutHostPath</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   incrementTimeoutHostPath is the increment of time added per Gi to ActiveDeadlineSeconds
-for a HostPath scrubber pod.  This is for development and testing only and will not work
-in a multi-node cluster.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `PodGCControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-PodGCControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-PodGCControllerConfiguration contains elements describing PodGCController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>TerminatedPodGCThreshold</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   terminatedPodGCThreshold is the number of terminated pods that can exist
-before the terminated pod garbage collector starts deleting terminated pods.
-If <= 0, the terminated pod garbage collector is disabled.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `ReplicaSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicaSetControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-ReplicaSetControllerConfiguration contains elements describing ReplicaSetController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentRSSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentRSSyncs is the number of replica sets that are  allowed to sync
-concurrently. Larger number = more responsive replica  management, but more
-CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `ReplicationControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ReplicationControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-ReplicationControllerConfiguration contains elements describing ReplicationController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentRCSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentRCSyncs is the number of replication controllers that are
-allowed to sync concurrently. Larger number = more responsive replica
-management, but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `ResourceQuotaControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-ResourceQuotaControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-ResourceQuotaControllerConfiguration contains elements describing ResourceQuotaController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ResourceQuotaSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   resourceQuotaSyncPeriod is the period for syncing quota usage status
-in the system.</td>
-</tr>
-    
-  
-<tr><td><code>ConcurrentResourceQuotaSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentResourceQuotaSyncs is the number of resource quotas that are
-allowed to sync concurrently. Larger number = more responsive quota
-management, but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `SAControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-SAControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-SAControllerConfiguration contains elements describing ServiceAccountController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ServiceAccountKeyFile</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
-used to sign service account tokens.</td>
-</tr>
-    
-  
-<tr><td><code>ConcurrentSATokenSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentSATokenSyncs is the number of service account token syncing operations
-that will be done concurrently.</td>
-</tr>
-    
-  
-<tr><td><code>RootCAFile</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   rootCAFile is the root certificate authority will be included in service
-account's token secret. This must be a valid PEM-encoded CA bundle.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `StatefulSetControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-StatefulSetControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-StatefulSetControllerConfiguration contains elements describing StatefulSetController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentStatefulSetSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentStatefulSetSyncs is the number of statefulset objects that are
-allowed to sync concurrently. Larger number = more responsive statefulsets,
-but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `TTLAfterFinishedControllerConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-TTLAfterFinishedControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-TTLAfterFinishedControllerConfiguration contains elements describing TTLAfterFinishedController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentTTLSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentTTLSyncs is the number of TTL-after-finished collector workers that are
-allowed to sync concurrently.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-
-
-## `VolumeConfiguration`     {#kubecontrollermanager-config-k8s-io-v1alpha1-VolumeConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [PersistentVolumeBinderControllerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeBinderControllerConfiguration)
-
-
-VolumeConfiguration contains &lowast;all&lowast; enumerated flags meant to configure all volume
-plugins. From this config, the controller-manager binary will create many instances of
-volume.VolumeConfig, each containing only the configuration needed for that plugin which
-are then passed to the appropriate plugin. The ControllerManager binary is the only part
-of the code which knows what plugins are supported and which flags correspond to each plugin.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>EnableHostPathProvisioning</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   enableHostPathProvisioning enables HostPath PV provisioning when running without a
-cloud provider. This allows testing and development of provisioning features. HostPath
-provisioning is not supported in any way, won't work in a multi-node cluster, and
-should not be used for anything other than testing or development.</td>
-</tr>
-    
-  
-<tr><td><code>EnableDynamicProvisioning</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   enableDynamicProvisioning enables the provisioning of volumes when running within an environment
-that supports dynamic provisioning. Defaults to true.</td>
-</tr>
-    
-  
-<tr><td><code>PersistentVolumeRecyclerConfiguration</code> <B>[Required]</B><br/>
-<a href="#kubecontrollermanager-config-k8s-io-v1alpha1-PersistentVolumeRecyclerConfiguration"><code>PersistentVolumeRecyclerConfiguration</code></a>
-</td>
-<td>
-   persistentVolumeRecyclerConfiguration holds configuration for persistent volume plugins.</td>
-</tr>
-    
-  
-<tr><td><code>FlexVolumePluginDir</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   volumePluginDir is the full path of the directory in which the flex
-volume plugin should search for additional third party volume plugins</td>
-</tr>
-    
-  
-</tbody>
-</table>
-    
-  
-  
-    
-
-## `ServiceControllerConfiguration`     {#ServiceControllerConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [CloudControllerManagerConfiguration](#cloudcontrollermanager-config-k8s-io-v1alpha1-CloudControllerManagerConfiguration)
-
-- [KubeControllerManagerConfiguration](#kubecontrollermanager-config-k8s-io-v1alpha1-KubeControllerManagerConfiguration)
-
-
-ServiceControllerConfiguration contains elements describing ServiceController.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>ConcurrentServiceSyncs</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   concurrentServiceSyncs is the number of services that are
-allowed to sync concurrently. Larger number = more responsive service
-management, but more CPU (and network) load.</td>
-</tr>
-    
-  
-</tbody>
-</table>

--- a/genref/output/md/kube-proxy-config.v1alpha1.md
+++ b/genref/output/md/kube-proxy-config.v1alpha1.md
@@ -13,388 +13,13 @@ auto_generated: true
   
     
 
-## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
-
-- [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
-
-
-ClientConnectionConfiguration contains details for constructing a client.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>kubeconfig</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   kubeconfig is the path to a KubeConfig file.</td>
-</tr>
-    
-  
-<tr><td><code>acceptContentTypes</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
-default value of 'application/json'. This field will control all connections to the server used by a particular
-client.</td>
-</tr>
-    
-  
-<tr><td><code>contentType</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   contentType is the content type used when sending data to the server from this client.</td>
-</tr>
-    
-  
-<tr><td><code>qps</code> <B>[Required]</B><br/>
-<code>float32</code>
-</td>
-<td>
-   qps controls the number of queries per second allowed for this connection.</td>
-</tr>
-    
-  
-<tr><td><code>burst</code> <B>[Required]</B><br/>
-<code>int32</code>
-</td>
-<td>
-   burst allows extra queries to accumulate when a client is exceeding its rate.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-
-## `DebuggingConfiguration`     {#DebuggingConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
-
-- [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
-
-
-DebuggingConfiguration holds configuration for Debugging related features.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   enableProfiling enables profiling via web interface host:port/debug/pprof/</td>
-</tr>
-    
-  
-<tr><td><code>enableContentionProfiling</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   enableContentionProfiling enables lock contention profiling, if
-enableProfiling is true.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-
-## `FormatOptions`     {#FormatOptions}
-    
-
-
-
-**Appears in:**
-
-- [LoggingConfiguration](#LoggingConfiguration)
-
-
-FormatOptions contains options for the different logging formats.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>json</code> <B>[Required]</B><br/>
-<a href="#JSONOptions"><code>JSONOptions</code></a>
-</td>
-<td>
-   [Experimental] JSON contains options for logging format "json".</td>
-</tr>
-    
-  
-</tbody>
-</table>
-
-## `JSONOptions`     {#JSONOptions}
-    
-
-
-
-**Appears in:**
-
-- [FormatOptions](#FormatOptions)
-
-
-JSONOptions contains options for logging format "json".
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>splitStream</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   [Experimental] SplitStream redirects error messages to stderr while
-info messages go to stdout, with buffering. The default is to write
-both to stdout, without buffering.</td>
-</tr>
-    
-  
-<tr><td><code>infoBufferSize</code> <B>[Required]</B><br/>
-<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue"><code>k8s.io/apimachinery/pkg/api/resource.QuantityValue</code></a>
-</td>
-<td>
-   [Experimental] InfoBufferSize sets the size of the info stream when
-using split streams. The default is zero, which disables buffering.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-
-## `LeaderElectionConfiguration`     {#LeaderElectionConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
-
-- [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
-
-
-LeaderElectionConfiguration defines the configuration of leader election
-clients for components that can run with leader election enabled.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>leaderElect</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   leaderElect enables a leader election client to gain leadership
-before executing the main loop. Enable this when running replicated
-components for high availability.</td>
-</tr>
-    
-  
-<tr><td><code>leaseDuration</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   leaseDuration is the duration that non-leader candidates will wait
-after observing a leadership renewal until attempting to acquire
-leadership of a led but unrenewed leader slot. This is effectively the
-maximum duration that a leader can be stopped before it is replaced
-by another candidate. This is only applicable if leader election is
-enabled.</td>
-</tr>
-    
-  
-<tr><td><code>renewDeadline</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   renewDeadline is the interval between attempts by the acting master to
-renew a leadership slot before it stops leading. This must be less
-than or equal to the lease duration. This is only applicable if leader
-election is enabled.</td>
-</tr>
-    
-  
-<tr><td><code>retryPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
-</td>
-<td>
-   retryPeriod is the duration the clients should wait between attempting
-acquisition and renewal of a leadership. This is only applicable if
-leader election is enabled.</td>
-</tr>
-    
-  
-<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   resourceLock indicates the resource object type that will be used to lock
-during leader election cycles.</td>
-</tr>
-    
-  
-<tr><td><code>resourceName</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   resourceName indicates the name of resource object that will be used to lock
-during leader election cycles.</td>
-</tr>
-    
-  
-<tr><td><code>resourceNamespace</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   resourceName indicates the namespace of resource object that will be used to lock
-during leader election cycles.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-
-## `LoggingConfiguration`     {#LoggingConfiguration}
-    
-
-
-
-**Appears in:**
-
-- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
-
-
-LoggingConfiguration contains logging options
-Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-
-  
-<tr><td><code>format</code> <B>[Required]</B><br/>
-<code>string</code>
-</td>
-<td>
-   Format Flag specifies the structure of log messages.
-default value of format is `text`</td>
-</tr>
-    
-  
-<tr><td><code>flushFrequency</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/time#Duration"><code>time.Duration</code></a>
-</td>
-<td>
-   Maximum number of seconds between log flushes. Ignored if the
-selected logging backend writes log messages without buffering.</td>
-</tr>
-    
-  
-<tr><td><code>verbosity</code> <B>[Required]</B><br/>
-<code>uint32</code>
-</td>
-<td>
-   Verbosity is the threshold that determines which log messages are
-logged. Default is zero which logs only the most important
-messages. Higher values enable additional messages. Error messages
-are always logged.</td>
-</tr>
-    
-  
-<tr><td><code>vmodule</code> <B>[Required]</B><br/>
-<a href="#VModuleConfiguration"><code>VModuleConfiguration</code></a>
-</td>
-<td>
-   VModule overrides the verbosity threshold for individual files.
-Only supported for "text" log format.</td>
-</tr>
-    
-  
-<tr><td><code>sanitization</code> <B>[Required]</B><br/>
-<code>bool</code>
-</td>
-<td>
-   [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
-Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</td>
-</tr>
-    
-  
-<tr><td><code>options</code> <B>[Required]</B><br/>
-<a href="#FormatOptions"><code>FormatOptions</code></a>
-</td>
-<td>
-   [Experimental] Options holds additional parameters that are specific
-to the different logging formats. Only the options for the selected
-format get used, but all of them get validated.</td>
-</tr>
-    
-  
-</tbody>
-</table>
-
-## `VModuleConfiguration`     {#VModuleConfiguration}
-    
-(Alias of `[]k8s.io/component-base/config/v1alpha1.VModuleItem`)
-
-
-**Appears in:**
-
-- [LoggingConfiguration](#LoggingConfiguration)
-
-
-VModuleConfiguration is a collection of individual file names or patterns
-and the corresponding verbosity threshold.
-
-
-  
-    
-
-
 ## `KubeProxyConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration}
     
 
 
+<p>KubeProxyConfiguration contains everything necessary to configure the
+Kubernetes proxy server.</p>
 
-
-KubeProxyConfiguration contains everything necessary to configure the
-Kubernetes proxy server.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -403,507 +28,778 @@ Kubernetes proxy server.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubeproxy.config.k8s.io/v1alpha1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>KubeProxyConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>featureGates</code> <B>[Required]</B><br/>
 <code>map[string]bool</code>
 </td>
 <td>
-   featureGates is a map of feature names to bools that enable or disable alpha/experimental features.</td>
+   <p>featureGates is a map of feature names to bools that enable or disable alpha/experimental features.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>bindAddress</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
-for all interfaces)</td>
+   <p>bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
+for all interfaces)</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>healthzBindAddress</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   healthzBindAddress is the IP address and port for the health check server to serve on,
-defaulting to 0.0.0.0:10256</td>
+   <p>healthzBindAddress is the IP address and port for the health check server to serve on,
+defaulting to 0.0.0.0:10256</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>metricsBindAddress</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   metricsBindAddress is the IP address and port for the metrics server to serve on,
-defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)</td>
+   <p>metricsBindAddress is the IP address and port for the metrics server to serve on,
+defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>bindAddressHardFail</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   bindAddressHardFail, if true, kube-proxy will treat failure to bind to a port as fatal and exit</td>
+   <p>bindAddressHardFail, if true, kube-proxy will treat failure to bind to a port as fatal and exit</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   enableProfiling enables profiling via web interface on /debug/pprof handler.
-Profiling handlers will be handled by metrics server.</td>
+   <p>enableProfiling enables profiling via web interface on /debug/pprof handler.
+Profiling handlers will be handled by metrics server.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clusterCIDR</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   clusterCIDR is the CIDR range of the pods in the cluster. It is used to
+   <p>clusterCIDR is the CIDR range of the pods in the cluster. It is used to
 bridge traffic coming from outside of the cluster. If not provided,
-no off-cluster bridging will be performed.</td>
+no off-cluster bridging will be performed.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>hostnameOverride</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.</td>
+   <p>hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clientConnection</code> <B>[Required]</B><br/>
 <a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
 </td>
 <td>
-   clientConnection specifies the kubeconfig file and client connection settings for the proxy
-server to use when communicating with the apiserver.</td>
+   <p>clientConnection specifies the kubeconfig file and client connection settings for the proxy
+server to use when communicating with the apiserver.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>iptables</code> <B>[Required]</B><br/>
 <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPTablesConfiguration"><code>KubeProxyIPTablesConfiguration</code></a>
 </td>
 <td>
-   iptables contains iptables-related configuration options.</td>
+   <p>iptables contains iptables-related configuration options.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ipvs</code> <B>[Required]</B><br/>
 <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPVSConfiguration"><code>KubeProxyIPVSConfiguration</code></a>
 </td>
 <td>
-   ipvs contains ipvs-related configuration options.</td>
+   <p>ipvs contains ipvs-related configuration options.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>oomScoreAdj</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
-the range [-1000, 1000]</td>
+   <p>oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
+the range [-1000, 1000]</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>mode</code> <B>[Required]</B><br/>
 <a href="#kubeproxy-config-k8s-io-v1alpha1-ProxyMode"><code>ProxyMode</code></a>
 </td>
 <td>
-   mode specifies which proxy mode to use.</td>
+   <p>mode specifies which proxy mode to use.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>portRange</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
-in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.</td>
+   <p>portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
+in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>udpIdleTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
-Must be greater than 0. Only applicable for proxyMode=userspace.</td>
+   <p>udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
+Must be greater than 0. Only applicable for proxyMode=userspace.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>conntrack</code> <B>[Required]</B><br/>
 <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConntrackConfiguration"><code>KubeProxyConntrackConfiguration</code></a>
 </td>
 <td>
-   conntrack contains conntrack-related configuration options.</td>
+   <p>conntrack contains conntrack-related configuration options.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>configSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
-than 0.</td>
+   <p>configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
+than 0.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodePortAddresses</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   nodePortAddresses is the --nodeport-addresses value for kube-proxy process. Values must be valid
+   <p>nodePortAddresses is the --nodeport-addresses value for kube-proxy process. Values must be valid
 IP blocks. These values are as a parameter to select the interfaces where nodeport works.
 In case someone would like to expose a service on localhost for local visit and some other interfaces for
 particular purpose, a list of IP blocks would do that.
-If set it to "127.0.0.0/8", kube-proxy will only select the loopback interface for NodePort.
+If set it to &quot;127.0.0.0/8&quot;, kube-proxy will only select the loopback interface for NodePort.
 If set it to a non-zero IP block, kube-proxy will filter that down to just the IPs that applied to the node.
-An empty string slice is meant to select all network interfaces.</td>
+An empty string slice is meant to select all network interfaces.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>winkernel</code> <B>[Required]</B><br/>
 <a href="#kubeproxy-config-k8s-io-v1alpha1-KubeProxyWinkernelConfiguration"><code>KubeProxyWinkernelConfiguration</code></a>
 </td>
 <td>
-   winkernel contains winkernel-related configuration options.</td>
+   <p>winkernel contains winkernel-related configuration options.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>showHiddenMetricsForVersion</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ShowHiddenMetricsForVersion is the version for which you want to show hidden metrics.</td>
+   <p>ShowHiddenMetricsForVersion is the version for which you want to show hidden metrics.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>detectLocalMode</code> <B>[Required]</B><br/>
 <a href="#kubeproxy-config-k8s-io-v1alpha1-LocalMode"><code>LocalMode</code></a>
 </td>
 <td>
-   DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR</td>
+   <p>DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeProxyConntrackConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConntrackConfiguration}
     
-
-
 
 **Appears in:**
 
 - [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
 
 
-KubeProxyConntrackConfiguration contains conntrack settings for
-the Kubernetes proxy server.
+<p>KubeProxyConntrackConfiguration contains conntrack settings for
+the Kubernetes proxy server.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>maxPerCore</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   maxPerCore is the maximum number of NAT connections to track
-per CPU core (0 to leave the limit as-is and ignore min).</td>
+   <p>maxPerCore is the maximum number of NAT connections to track
+per CPU core (0 to leave the limit as-is and ignore min).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>min</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   min is the minimum value of connect-tracking records to allocate,
-regardless of conntrackMaxPerCore (set maxPerCore=0 to leave the limit as-is).</td>
+   <p>min is the minimum value of connect-tracking records to allocate,
+regardless of conntrackMaxPerCore (set maxPerCore=0 to leave the limit as-is).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tcpEstablishedTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   tcpEstablishedTimeout is how long an idle TCP connection will be kept open
-(e.g. '2s').  Must be greater than 0 to set.</td>
+   <p>tcpEstablishedTimeout is how long an idle TCP connection will be kept open
+(e.g. '2s').  Must be greater than 0 to set.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tcpCloseWaitTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   tcpCloseWaitTimeout is how long an idle conntrack entry
+   <p>tcpCloseWaitTimeout is how long an idle conntrack entry
 in CLOSE_WAIT state will remain in the conntrack
-table. (e.g. '60s'). Must be greater than 0 to set.</td>
+table. (e.g. '60s'). Must be greater than 0 to set.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeProxyIPTablesConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPTablesConfiguration}
     
-
-
 
 **Appears in:**
 
 - [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
 
 
-KubeProxyIPTablesConfiguration contains iptables-related configuration
-details for the Kubernetes proxy server.
+<p>KubeProxyIPTablesConfiguration contains iptables-related configuration
+details for the Kubernetes proxy server.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>masqueradeBit</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
-the pure iptables proxy mode. Values must be within the range [0, 31].</td>
+   <p>masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
+the pure iptables proxy mode. Values must be within the range [0, 31].</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>masqueradeAll</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.</td>
+   <p>masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>syncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
-'2h22m').  Must be greater than 0.</td>
+   <p>syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
+'2h22m').  Must be greater than 0.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>minSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
-'2h22m').</td>
+   <p>minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
+'2h22m').</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeProxyIPVSConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyIPVSConfiguration}
     
 
-
-
 **Appears in:**
 
 - [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
 
 
-KubeProxyIPVSConfiguration contains ipvs-related configuration
-details for the Kubernetes proxy server.
+<p>KubeProxyIPVSConfiguration contains ipvs-related configuration
+details for the Kubernetes proxy server.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>syncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
-'2h22m').  Must be greater than 0.</td>
+   <p>syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
+'2h22m').  Must be greater than 0.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>minSyncPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
-'2h22m').</td>
+   <p>minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
+'2h22m').</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>scheduler</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ipvs scheduler</td>
+   <p>ipvs scheduler</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>excludeCIDRs</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
-when cleaning up ipvs services.</td>
+   <p>excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
+when cleaning up ipvs services.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>strictARP</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
-from kube-ipvs0 interface</td>
+   <p>strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
+from kube-ipvs0 interface</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tcpTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   tcpTimeout is the timeout value used for idle IPVS TCP sessions.
-The default value is 0, which preserves the current timeout value on the system.</td>
+   <p>tcpTimeout is the timeout value used for idle IPVS TCP sessions.
+The default value is 0, which preserves the current timeout value on the system.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tcpFinTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   tcpFinTimeout is the timeout value used for IPVS TCP sessions after receiving a FIN.
-The default value is 0, which preserves the current timeout value on the system.</td>
+   <p>tcpFinTimeout is the timeout value used for IPVS TCP sessions after receiving a FIN.
+The default value is 0, which preserves the current timeout value on the system.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>udpTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   udpTimeout is the timeout value used for IPVS UDP packets.
-The default value is 0, which preserves the current timeout value on the system.</td>
+   <p>udpTimeout is the timeout value used for IPVS UDP packets.
+The default value is 0, which preserves the current timeout value on the system.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeProxyWinkernelConfiguration`     {#kubeproxy-config-k8s-io-v1alpha1-KubeProxyWinkernelConfiguration}
     
-
-
 
 **Appears in:**
 
 - [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
 
 
-KubeProxyWinkernelConfiguration contains Windows/HNS settings for
-the Kubernetes proxy server.
+<p>KubeProxyWinkernelConfiguration contains Windows/HNS settings for
+the Kubernetes proxy server.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>networkName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   networkName is the name of the network kube-proxy will use
-to create endpoints and policies</td>
+   <p>networkName is the name of the network kube-proxy will use
+to create endpoints and policies</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>sourceVip</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   sourceVip is the IP address of the source VIP endoint used for
-NAT when loadbalancing</td>
+   <p>sourceVip is the IP address of the source VIP endoint used for
+NAT when loadbalancing</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableDSR</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   enableDSR tells kube-proxy whether HNS policies should be created
-with DSR</td>
+   <p>enableDSR tells kube-proxy whether HNS policies should be created
+with DSR</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `LocalMode`     {#kubeproxy-config-k8s-io-v1alpha1-LocalMode}
     
 (Alias of `string`)
-
 
 **Appears in:**
 
 - [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
 
 
-LocalMode represents modes to detect local traffic from the node
+<p>LocalMode represents modes to detect local traffic from the node</p>
 
 
-    
 
 
 ## `ProxyMode`     {#kubeproxy-config-k8s-io-v1alpha1-ProxyMode}
     
 (Alias of `string`)
 
-
 **Appears in:**
 
 - [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
 
 
-ProxyMode represents modes used by the Kubernetes proxy server.
-
-Currently, three modes of proxy are available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'
-(newer, faster), 'ipvs'(newest, better in performance and scalability).
-
-Two modes of proxy are available in Windows platform: 'userspace'(older, stable) and 'kernelspace' (newer, faster).
-
-In Linux platform, if proxy mode is blank, use the best-available proxy (currently iptables, but may change in the
+<p>ProxyMode represents modes used by the Kubernetes proxy server.</p>
+<p>Currently, three modes of proxy are available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'
+(newer, faster), 'ipvs'(newest, better in performance and scalability).</p>
+<p>Two modes of proxy are available in Windows platform: 'userspace'(older, stable) and 'kernelspace' (newer, faster).</p>
+<p>In Linux platform, if proxy mode is blank, use the best-available proxy (currently iptables, but may change in the
 future). If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are
 insufficient, this always falls back to the userspace proxy. IPVS mode will be enabled when proxy mode is set to 'ipvs',
-and the fall back path is firstly iptables and then userspace.
-
-In Windows platform, if proxy mode is blank, use the best-available proxy (currently userspace, but may change in the
+and the fall back path is firstly iptables and then userspace.</p>
+<p>In Windows platform, if proxy mode is blank, use the best-available proxy (currently userspace, but may change in the
 future). If winkernel proxy is selected, regardless of how, but the Windows kernel can't support this mode of proxy,
-this always falls back to the userspace proxy.
+this always falls back to the userspace proxy.</p>
 
 
+
+  
+  
+    
+
+## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
+    
+
+**Appears in:**
+
+- [KubeProxyConfiguration](#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
+
+- [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
+
+
+<p>ClientConnectionConfiguration contains details for constructing a client.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
     
   
+<tr><td><code>kubeconfig</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>kubeconfig is the path to a KubeConfig file.</p>
+</td>
+</tr>
+<tr><td><code>acceptContentTypes</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
+default value of 'application/json'. This field will control all connections to the server used by a particular
+client.</p>
+</td>
+</tr>
+<tr><td><code>contentType</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>contentType is the content type used when sending data to the server from this client.</p>
+</td>
+</tr>
+<tr><td><code>qps</code> <B>[Required]</B><br/>
+<code>float32</code>
+</td>
+<td>
+   <p>qps controls the number of queries per second allowed for this connection.</p>
+</td>
+</tr>
+<tr><td><code>burst</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>burst allows extra queries to accumulate when a client is exceeding its rate.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `DebuggingConfiguration`     {#DebuggingConfiguration}
+    
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
+
+- [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
+
+
+<p>DebuggingConfiguration holds configuration for Debugging related features.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>enableProfiling enables profiling via web interface host:port/debug/pprof/</p>
+</td>
+</tr>
+<tr><td><code>enableContentionProfiling</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>enableContentionProfiling enables lock contention profiling, if
+enableProfiling is true.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `FormatOptions`     {#FormatOptions}
+    
+
+**Appears in:**
+
+- [LoggingConfiguration](#LoggingConfiguration)
+
+
+<p>FormatOptions contains options for the different logging formats.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>json</code> <B>[Required]</B><br/>
+<a href="#JSONOptions"><code>JSONOptions</code></a>
+</td>
+<td>
+   <p>[Experimental] JSON contains options for logging format &quot;json&quot;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `JSONOptions`     {#JSONOptions}
+    
+
+**Appears in:**
+
+- [FormatOptions](#FormatOptions)
+
+
+<p>JSONOptions contains options for logging format &quot;json&quot;.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>splitStream</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>[Experimental] SplitStream redirects error messages to stderr while
+info messages go to stdout, with buffering. The default is to write
+both to stdout, without buffering.</p>
+</td>
+</tr>
+<tr><td><code>infoBufferSize</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue"><code>k8s.io/apimachinery/pkg/api/resource.QuantityValue</code></a>
+</td>
+<td>
+   <p>[Experimental] InfoBufferSize sets the size of the info stream when
+using split streams. The default is zero, which disables buffering.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LeaderElectionConfiguration`     {#LeaderElectionConfiguration}
+    
+
+**Appears in:**
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
+
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
+
+- [GenericControllerManagerConfiguration](#controllermanager-config-k8s-io-v1alpha1-GenericControllerManagerConfiguration)
+
+
+<p>LeaderElectionConfiguration defines the configuration of leader election
+clients for components that can run with leader election enabled.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>leaderElect</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>leaderElect enables a leader election client to gain leadership
+before executing the main loop. Enable this when running replicated
+components for high availability.</p>
+</td>
+</tr>
+<tr><td><code>leaseDuration</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>leaseDuration is the duration that non-leader candidates will wait
+after observing a leadership renewal until attempting to acquire
+leadership of a led but unrenewed leader slot. This is effectively the
+maximum duration that a leader can be stopped before it is replaced
+by another candidate. This is only applicable if leader election is
+enabled.</p>
+</td>
+</tr>
+<tr><td><code>renewDeadline</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>renewDeadline is the interval between attempts by the acting master to
+renew a leadership slot before it stops leading. This must be less
+than or equal to the lease duration. This is only applicable if leader
+election is enabled.</p>
+</td>
+</tr>
+<tr><td><code>retryPeriod</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>retryPeriod is the duration the clients should wait between attempting
+acquisition and renewal of a leadership. This is only applicable if
+leader election is enabled.</p>
+</td>
+</tr>
+<tr><td><code>resourceLock</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>resourceLock indicates the resource object type that will be used to lock
+during leader election cycles.</p>
+</td>
+</tr>
+<tr><td><code>resourceName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>resourceName indicates the name of resource object that will be used to lock
+during leader election cycles.</p>
+</td>
+</tr>
+<tr><td><code>resourceNamespace</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>resourceName indicates the namespace of resource object that will be used to lock
+during leader election cycles.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LoggingConfiguration`     {#LoggingConfiguration}
+    
+
+**Appears in:**
+
+- [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+
+
+<p>LoggingConfiguration contains logging options
+Refer <a href="https://github.com/kubernetes/component-base/blob/master/logs/options.go">Logs Options</a> for more information.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>format</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Format Flag specifies the structure of log messages.
+default value of format is <code>text</code></p>
+</td>
+</tr>
+<tr><td><code>flushFrequency</code> <B>[Required]</B><br/>
+<a href="https://pkg.go.dev/time#Duration"><code>time.Duration</code></a>
+</td>
+<td>
+   <p>Maximum number of seconds between log flushes. Ignored if the
+selected logging backend writes log messages without buffering.</p>
+</td>
+</tr>
+<tr><td><code>verbosity</code> <B>[Required]</B><br/>
+<code>uint32</code>
+</td>
+<td>
+   <p>Verbosity is the threshold that determines which log messages are
+logged. Default is zero which logs only the most important
+messages. Higher values enable additional messages. Error messages
+are always logged.</p>
+</td>
+</tr>
+<tr><td><code>vmodule</code> <B>[Required]</B><br/>
+<a href="#VModuleConfiguration"><code>VModuleConfiguration</code></a>
+</td>
+<td>
+   <p>VModule overrides the verbosity threshold for individual files.
+Only supported for &quot;text&quot; log format.</p>
+</td>
+</tr>
+<tr><td><code>sanitization</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>[Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</p>
+</td>
+</tr>
+<tr><td><code>options</code> <B>[Required]</B><br/>
+<a href="#FormatOptions"><code>FormatOptions</code></a>
+</td>
+<td>
+   <p>[Experimental] Options holds additional parameters that are specific
+to the different logging formats. Only the options for the selected
+format get used, but all of them get validated.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `VModuleConfiguration`     {#VModuleConfiguration}
+    
+(Alias of `[]k8s.io/component-base/config/v1alpha1.VModuleItem`)
+
+**Appears in:**
+
+- [LoggingConfiguration](#LoggingConfiguration)
+
+
+<p>VModuleConfiguration is a collection of individual file names or patterns
+and the corresponding verbosity threshold.</p>
+
+
+

--- a/genref/output/md/kube-scheduler-config.v1beta2.md
+++ b/genref/output/md/kube-scheduler-config.v1beta2.md
@@ -20,15 +20,13 @@ auto_generated: true
   
     
 
-
 ## `DefaultPreemptionArgs`     {#kubescheduler-config-k8s-io-v1beta2-DefaultPreemptionArgs}
     
 
 
+<p>DefaultPreemptionArgs holds arguments used to configure the
+DefaultPreemption plugin.</p>
 
-
-DefaultPreemptionArgs holds arguments used to configure the
-DefaultPreemption plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -37,46 +35,39 @@ DefaultPreemption plugin.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>DefaultPreemptionArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>minCandidateNodesPercentage</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   MinCandidateNodesPercentage is the minimum number of candidates to
+   <p>MinCandidateNodesPercentage is the minimum number of candidates to
 shortlist when dry running preemption as a percentage of number of nodes.
 Must be in the range [0, 100]. Defaults to 10% of the cluster size if
-unspecified.</td>
+unspecified.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>minCandidateNodesAbsolute</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   MinCandidateNodesAbsolute is the absolute minimum number of candidates to
+   <p>MinCandidateNodesAbsolute is the absolute minimum number of candidates to
 shortlist. The likely number of candidates enumerated for dry running
 preemption is given by the formula:
 numCandidates = max(numNodes &lowast; minCandidateNodesPercentage, minCandidateNodesAbsolute)
-We say "likely" because there are other factors such as PDB violations
+We say &quot;likely&quot; because there are other factors such as PDB violations
 that play a role in the number of candidates shortlisted. Must be at least
-0 nodes. Defaults to 100 nodes if unspecified.</td>
+0 nodes. Defaults to 100 nodes if unspecified.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `InterPodAffinityArgs`     {#kubescheduler-config-k8s-io-v1beta2-InterPodAffinityArgs}
     
 
 
+<p>InterPodAffinityArgs holds arguments used to configure the InterPodAffinity plugin.</p>
 
-
-InterPodAffinityArgs holds arguments used to configure the InterPodAffinity plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -85,30 +76,24 @@ InterPodAffinityArgs holds arguments used to configure the InterPodAffinity plug
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>InterPodAffinityArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>hardPodAffinityWeight</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   HardPodAffinityWeight is the scoring weight for existing pods with a
-matching hard affinity to the incoming pod.</td>
+   <p>HardPodAffinityWeight is the scoring weight for existing pods with a
+matching hard affinity to the incoming pod.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeSchedulerConfiguration`     {#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration}
     
 
 
+<p>KubeSchedulerConfiguration configures a scheduler</p>
 
-
-KubeSchedulerConfiguration configures a scheduler
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -117,128 +102,112 @@ KubeSchedulerConfiguration configures a scheduler
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>KubeSchedulerConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>parallelism</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   Parallelism defines the amount of parallelism in algorithms for scheduling a Pods. Must be greater than 0. Defaults to 16</td>
+   <p>Parallelism defines the amount of parallelism in algorithms for scheduling a Pods. Must be greater than 0. Defaults to 16</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>leaderElection</code> <B>[Required]</B><br/>
 <a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
 </td>
 <td>
-   LeaderElection defines the configuration of leader election client.</td>
+   <p>LeaderElection defines the configuration of leader election client.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clientConnection</code> <B>[Required]</B><br/>
 <a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
 </td>
 <td>
-   ClientConnection specifies the kubeconfig file and client connection
-settings for the proxy server to use when communicating with the apiserver.</td>
+   <p>ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>healthzBindAddress</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Note: Both HealthzBindAddress and MetricsBindAddress fields are deprecated.
+   <p>Note: Both HealthzBindAddress and MetricsBindAddress fields are deprecated.
 Only empty address or port 0 is allowed. Anything else will fail validation.
-HealthzBindAddress is the IP address and port for the health check server to serve on.</td>
+HealthzBindAddress is the IP address and port for the health check server to serve on.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>metricsBindAddress</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   MetricsBindAddress is the IP address and port for the metrics server to serve on.</td>
+   <p>MetricsBindAddress is the IP address and port for the metrics server to serve on.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>DebuggingConfiguration</code> <B>[Required]</B><br/>
 <a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
 </td>
 <td>(Members of <code>DebuggingConfiguration</code> are embedded into this type.)
-   DebuggingConfiguration holds configuration for Debugging related features
-TODO: We might wanna make this a substruct like Debugging componentbaseconfigv1alpha1.DebuggingConfiguration</td>
+   <p>DebuggingConfiguration holds configuration for Debugging related features
+TODO: We might wanna make this a substruct like Debugging componentbaseconfigv1alpha1.DebuggingConfiguration</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>percentageOfNodesToScore</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   PercentageOfNodesToScore is the percentage of all nodes that once found feasible
+   <p>PercentageOfNodesToScore is the percentage of all nodes that once found feasible
 for running a pod, the scheduler stops its search for more feasible nodes in
 the cluster. This helps improve scheduler's performance. Scheduler always tries to find
-at least "minFeasibleNodesToFind" feasible nodes no matter what the value of this flag is.
+at least &quot;minFeasibleNodesToFind&quot; feasible nodes no matter what the value of this flag is.
 Example: if the cluster size is 500 nodes and the value of this flag is 30,
 then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
 When the value is 0, default percentage (5%--50% based on the size of the cluster) of the
-nodes will be scored.</td>
+nodes will be scored.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podInitialBackoffSeconds</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
+   <p>PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
 If specified, it must be greater than 0. If this value is null, the default value (1s)
-will be used.</td>
+will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podMaxBackoffSeconds</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   PodMaxBackoffSeconds is the max backoff for unschedulable pods.
+   <p>PodMaxBackoffSeconds is the max backoff for unschedulable pods.
 If specified, it must be greater than podInitialBackoffSeconds. If this value is null,
-the default value (10s) will be used.</td>
+the default value (10s) will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>profiles</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile"><code>[]KubeSchedulerProfile</code></a>
 </td>
 <td>
-   Profiles are scheduling profiles that kube-scheduler supports. Pods can
+   <p>Profiles are scheduling profiles that kube-scheduler supports. Pods can
 choose to be scheduled under a particular profile by setting its associated
 scheduler name. Pods that don't specify any scheduler name are scheduled
-with the "default-scheduler" profile, if present here.</td>
+with the &quot;default-scheduler&quot; profile, if present here.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>extenders</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-Extender"><code>[]Extender</code></a>
 </td>
 <td>
-   Extenders are the list of scheduler extenders, each holding the values of how to communicate
-with the extender. These extenders are shared by all scheduler profiles.</td>
+   <p>Extenders are the list of scheduler extenders, each holding the values of how to communicate
+with the extender. These extenders are shared by all scheduler profiles.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeAffinityArgs`     {#kubescheduler-config-k8s-io-v1beta2-NodeAffinityArgs}
     
 
 
+<p>NodeAffinityArgs holds arguments to configure the NodeAffinity plugin.</p>
 
-
-NodeAffinityArgs holds arguments to configure the NodeAffinity plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -247,34 +216,28 @@ NodeAffinityArgs holds arguments to configure the NodeAffinity plugin.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeAffinityArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>addedAffinity</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#nodeaffinity-v1-core"><code>core/v1.NodeAffinity</code></a>
 </td>
 <td>
-   AddedAffinity is applied to all Pods additionally to the NodeAffinity
+   <p>AddedAffinity is applied to all Pods additionally to the NodeAffinity
 specified in the PodSpec. That is, Nodes need to satisfy AddedAffinity
 AND .spec.NodeAffinity. AddedAffinity is empty by default (all Nodes
 match).
 When AddedAffinity is used, some Pods with affinity requirements that match
-a specific Node (such as Daemonset Pods) might remain unschedulable.</td>
+a specific Node (such as Daemonset Pods) might remain unschedulable.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeResourcesBalancedAllocationArgs`     {#kubescheduler-config-k8s-io-v1beta2-NodeResourcesBalancedAllocationArgs}
     
 
 
+<p>NodeResourcesBalancedAllocationArgs holds arguments used to configure NodeResourcesBalancedAllocation plugin.</p>
 
-
-NodeResourcesBalancedAllocationArgs holds arguments used to configure NodeResourcesBalancedAllocation plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -283,29 +246,23 @@ NodeResourcesBalancedAllocationArgs holds arguments used to configure NodeResour
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeResourcesBalancedAllocationArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>resources</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-ResourceSpec"><code>[]ResourceSpec</code></a>
 </td>
 <td>
-   Resources to be managed, the default is "cpu" and "memory" if not specified.</td>
+   <p>Resources to be managed, the default is &quot;cpu&quot; and &quot;memory&quot; if not specified.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeResourcesFitArgs`     {#kubescheduler-config-k8s-io-v1beta2-NodeResourcesFitArgs}
     
 
 
+<p>NodeResourcesFitArgs holds arguments used to configure the NodeResourcesFit plugin.</p>
 
-
-NodeResourcesFitArgs holds arguments used to configure the NodeResourcesFit plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -314,50 +271,42 @@ NodeResourcesFitArgs holds arguments used to configure the NodeResourcesFit plug
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeResourcesFitArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>ignoredResources</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   IgnoredResources is the list of resources that NodeResources fit filter
-should ignore. This doesn't apply to scoring.</td>
+   <p>IgnoredResources is the list of resources that NodeResources fit filter
+should ignore. This doesn't apply to scoring.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ignoredResourceGroups</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   IgnoredResourceGroups defines the list of resource groups that NodeResources fit filter should ignore.
-e.g. if group is ["example.com"], it will ignore all resource names that begin
-with "example.com", such as "example.com/aaa" and "example.com/bbb".
-A resource group name can't contain '/'. This doesn't apply to scoring.</td>
+   <p>IgnoredResourceGroups defines the list of resource groups that NodeResources fit filter should ignore.
+e.g. if group is [&quot;example.com&quot;], it will ignore all resource names that begin
+with &quot;example.com&quot;, such as &quot;example.com/aaa&quot; and &quot;example.com/bbb&quot;.
+A resource group name can't contain '/'. This doesn't apply to scoring.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>scoringStrategy</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-ScoringStrategy"><code>ScoringStrategy</code></a>
 </td>
 <td>
-   ScoringStrategy selects the node resource scoring strategy.
-The default strategy is LeastAllocated with an equal "cpu" and "memory" weight.</td>
+   <p>ScoringStrategy selects the node resource scoring strategy.
+The default strategy is LeastAllocated with an equal &quot;cpu&quot; and &quot;memory&quot; weight.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PodTopologySpreadArgs`     {#kubescheduler-config-k8s-io-v1beta2-PodTopologySpreadArgs}
     
 
 
+<p>PodTopologySpreadArgs holds arguments used to configure the PodTopologySpread plugin.</p>
 
-
-PodTopologySpreadArgs holds arguments used to configure the PodTopologySpread plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -366,50 +315,43 @@ PodTopologySpreadArgs holds arguments used to configure the PodTopologySpread pl
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>PodTopologySpreadArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>defaultConstraints</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#topologyspreadconstraint-v1-core"><code>[]core/v1.TopologySpreadConstraint</code></a>
 </td>
 <td>
-   DefaultConstraints defines topology spread constraints to be applied to
-Pods that don't define any in `pod.spec.topologySpreadConstraints`.
-`.defaultConstraints[&lowast;].labelSelectors` must be empty, as they are
+   <p>DefaultConstraints defines topology spread constraints to be applied to
+Pods that don't define any in <code>pod.spec.topologySpreadConstraints</code>.
+<code>.defaultConstraints[&lowast;].labelSelectors</code> must be empty, as they are
 deduced from the Pod's membership to Services, ReplicationControllers,
 ReplicaSets or StatefulSets.
-When not empty, .defaultingType must be "List".</td>
+When not empty, .defaultingType must be &quot;List&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>defaultingType</code><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PodTopologySpreadConstraintsDefaulting"><code>PodTopologySpreadConstraintsDefaulting</code></a>
 </td>
 <td>
-   DefaultingType determines how .defaultConstraints are deduced. Can be one
-of "System" or "List".
-
-- "System": Use kubernetes defined constraints that spread Pods among
-  Nodes and Zones.
-- "List": Use constraints defined in .defaultConstraints.
-
-Defaults to "List" if feature gate DefaultPodTopologySpread is disabled
-and to "System" if enabled.</td>
+   <p>DefaultingType determines how .defaultConstraints are deduced. Can be one
+of &quot;System&quot; or &quot;List&quot;.</p>
+<ul>
+<li>&quot;System&quot;: Use kubernetes defined constraints that spread Pods among
+Nodes and Zones.</li>
+<li>&quot;List&quot;: Use constraints defined in .defaultConstraints.</li>
+</ul>
+<p>Defaults to &quot;List&quot; if feature gate DefaultPodTopologySpread is disabled
+and to &quot;System&quot; if enabled.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `VolumeBindingArgs`     {#kubescheduler-config-k8s-io-v1beta2-VolumeBindingArgs}
     
 
 
+<p>VolumeBindingArgs holds arguments used to configure the VolumeBinding plugin.</p>
 
-
-VolumeBindingArgs holds arguments used to configure the VolumeBinding plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -418,668 +360,582 @@ VolumeBindingArgs holds arguments used to configure the VolumeBinding plugin.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>VolumeBindingArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>bindTimeoutSeconds</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   BindTimeoutSeconds is the timeout in seconds in volume binding operation.
+   <p>BindTimeoutSeconds is the timeout in seconds in volume binding operation.
 Value must be non-negative integer. The value zero indicates no waiting.
-If this value is nil, the default value (600) will be used.</td>
+If this value is nil, the default value (600) will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>shape</code><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-UtilizationShapePoint"><code>[]UtilizationShapePoint</code></a>
 </td>
 <td>
-   Shape specifies the points defining the score function shape, which is
+   <p>Shape specifies the points defining the score function shape, which is
 used to score nodes based on the utilization of statically provisioned
 PVs. The utilization is calculated by dividing the total requested
 storage of the pod by the total capacity of feasible PVs on each node.
 Each point contains utilization (ranges from 0 to 100) and its
 associated score (ranges from 0 to 10). You can turn the priority by
 specifying different scores for different utilization numbers.
-The default shape points are:
-1) 0 for 0 utilization
-2) 10 for 100 utilization
-All points must be sorted in increasing order by utilization.</td>
+The default shape points are:</p>
+<ol>
+<li>0 for 0 utilization</li>
+<li>10 for 100 utilization
+All points must be sorted in increasing order by utilization.</li>
+</ol>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Extender`     {#kubescheduler-config-k8s-io-v1beta2-Extender}
     
-
-
 
 **Appears in:**
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
 
 
-Extender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
-it is assumed that the extender chose not to provide that extension.
+<p>Extender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
+it is assumed that the extender chose not to provide that extension.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>urlPrefix</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   URLPrefix at which the extender is available</td>
+   <p>URLPrefix at which the extender is available</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>filterVerb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.</td>
+   <p>Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>preemptVerb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.</td>
+   <p>Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>prioritizeVerb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.</td>
+   <p>Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>weight</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   The numeric multiplier for the node scores that the prioritize call generates.
-The weight should be a positive integer</td>
+   <p>The numeric multiplier for the node scores that the prioritize call generates.
+The weight should be a positive integer</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>bindVerb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+   <p>Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
 If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
-can implement this function.</td>
+can implement this function.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableHTTPS</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   EnableHTTPS specifies whether https should be used to communicate with the extender</td>
+   <p>EnableHTTPS specifies whether https should be used to communicate with the extender</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tlsConfig</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-ExtenderTLSConfig"><code>ExtenderTLSConfig</code></a>
 </td>
 <td>
-   TLSConfig specifies the transport layer security config</td>
+   <p>TLSConfig specifies the transport layer security config</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>httpTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
-timeout is ignored, k8s/other extenders priorities are used to select the node.</td>
+   <p>HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
+timeout is ignored, k8s/other extenders priorities are used to select the node.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodeCacheCapable</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   NodeCacheCapable specifies that the extender is capable of caching node information,
+   <p>NodeCacheCapable specifies that the extender is capable of caching node information,
 so the scheduler should only send minimal information about the eligible nodes
-assuming that the extender already cached full details of all nodes in the cluster</td>
+assuming that the extender already cached full details of all nodes in the cluster</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>managedResources</code><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-ExtenderManagedResource"><code>[]ExtenderManagedResource</code></a>
 </td>
 <td>
-   ManagedResources is a list of extended resources that are managed by
-this extender.
-- A pod will be sent to the extender on the Filter, Prioritize and Bind
-  (if the extender is the binder) phases iff the pod requests at least
-  one of the extended resources in this list. If empty or unspecified,
-  all pods will be sent to this extender.
-- If IgnoredByScheduler is set to true for a resource, kube-scheduler
-  will skip checking the resource in predicates.</td>
+   <p>ManagedResources is a list of extended resources that are managed by
+this extender.</p>
+<ul>
+<li>A pod will be sent to the extender on the Filter, Prioritize and Bind
+(if the extender is the binder) phases iff the pod requests at least
+one of the extended resources in this list. If empty or unspecified,
+all pods will be sent to this extender.</li>
+<li>If IgnoredByScheduler is set to true for a resource, kube-scheduler
+will skip checking the resource in predicates.</li>
+</ul>
+</td>
 </tr>
-    
-  
 <tr><td><code>ignorable</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   Ignorable specifies if the extender is ignorable, i.e. scheduling should not
-fail when the extender returns an error or is not reachable.</td>
+   <p>Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+fail when the extender returns an error or is not reachable.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExtenderManagedResource`     {#kubescheduler-config-k8s-io-v1beta2-ExtenderManagedResource}
     
-
-
 
 **Appears in:**
 
 - [Extender](#kubescheduler-config-k8s-io-v1beta2-Extender)
 
 
-ExtenderManagedResource describes the arguments of extended resources
-managed by an extender.
+<p>ExtenderManagedResource describes the arguments of extended resources
+managed by an extender.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the extended resource name.</td>
+   <p>Name is the extended resource name.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ignoredByScheduler</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   IgnoredByScheduler indicates whether kube-scheduler should ignore this
-resource when applying predicates.</td>
+   <p>IgnoredByScheduler indicates whether kube-scheduler should ignore this
+resource when applying predicates.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExtenderTLSConfig`     {#kubescheduler-config-k8s-io-v1beta2-ExtenderTLSConfig}
     
-
-
 
 **Appears in:**
 
 - [Extender](#kubescheduler-config-k8s-io-v1beta2-Extender)
 
 
-ExtenderTLSConfig contains settings to enable TLS with extender
+<p>ExtenderTLSConfig contains settings to enable TLS with extender</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>insecure</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   Server should be accessed without verifying the TLS certificate. For testing only.</td>
+   <p>Server should be accessed without verifying the TLS certificate. For testing only.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>serverName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ServerName is passed to the server for SNI and is used in the client to check server
+   <p>ServerName is passed to the server for SNI and is used in the client to check server
 certificates against. If ServerName is empty, the hostname used to contact the
-server is used.</td>
+server is used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Server requires TLS client certificate authentication</td>
+   <p>Server requires TLS client certificate authentication</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>keyFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Server requires TLS client certificate authentication</td>
+   <p>Server requires TLS client certificate authentication</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Trusted root certificates for server</td>
+   <p>Trusted root certificates for server</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certData</code> <B>[Required]</B><br/>
 <code>[]byte</code>
 </td>
 <td>
-   CertData holds PEM-encoded bytes (typically read from a client certificate file).
-CertData takes precedence over CertFile</td>
+   <p>CertData holds PEM-encoded bytes (typically read from a client certificate file).
+CertData takes precedence over CertFile</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>keyData</code> <B>[Required]</B><br/>
 <code>[]byte</code>
 </td>
 <td>
-   KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
-KeyData takes precedence over KeyFile</td>
+   <p>KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
+KeyData takes precedence over KeyFile</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caData</code> <B>[Required]</B><br/>
 <code>[]byte</code>
 </td>
 <td>
-   CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
-CAData takes precedence over CAFile</td>
+   <p>CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
+CAData takes precedence over CAFile</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeSchedulerProfile`     {#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile}
     
-
-
 
 **Appears in:**
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
 
 
-KubeSchedulerProfile is a scheduling profile.
+<p>KubeSchedulerProfile is a scheduling profile.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>schedulerName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   SchedulerName is the name of the scheduler associated to this profile.
-If SchedulerName matches with the pod's "spec.schedulerName", then the pod
-is scheduled with this profile.</td>
+   <p>SchedulerName is the name of the scheduler associated to this profile.
+If SchedulerName matches with the pod's &quot;spec.schedulerName&quot;, then the pod
+is scheduled with this profile.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>plugins</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-Plugins"><code>Plugins</code></a>
 </td>
 <td>
-   Plugins specify the set of plugins that should be enabled or disabled.
+   <p>Plugins specify the set of plugins that should be enabled or disabled.
 Enabled plugins are the ones that should be enabled in addition to the
 default plugins. Disabled plugins are any of the default plugins that
 should be disabled.
 When no enabled or disabled plugin is specified for an extension point,
 default plugins for that extension point will be used if there is any.
 If a QueueSort plugin is specified, the same QueueSort Plugin and
-PluginConfig must be specified for all profiles.</td>
+PluginConfig must be specified for all profiles.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>pluginConfig</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginConfig"><code>[]PluginConfig</code></a>
 </td>
 <td>
-   PluginConfig is an optional set of custom plugin arguments for each plugin.
+   <p>PluginConfig is an optional set of custom plugin arguments for each plugin.
 Omitting config args for a plugin is equivalent to using the default config
-for that plugin.</td>
+for that plugin.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Plugin`     {#kubescheduler-config-k8s-io-v1beta2-Plugin}
     
-
-
 
 **Appears in:**
 
 - [PluginSet](#kubescheduler-config-k8s-io-v1beta2-PluginSet)
 
 
-Plugin specifies a plugin name and its weight when applicable. Weight is used only for Score plugins.
+<p>Plugin specifies a plugin name and its weight when applicable. Weight is used only for Score plugins.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name defines the name of plugin</td>
+   <p>Name defines the name of plugin</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>weight</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   Weight defines the weight of plugin, only used for Score plugins.</td>
+   <p>Weight defines the weight of plugin, only used for Score plugins.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PluginConfig`     {#kubescheduler-config-k8s-io-v1beta2-PluginConfig}
     
-
-
 
 **Appears in:**
 
 - [KubeSchedulerProfile](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile)
 
 
-PluginConfig specifies arguments that should be passed to a plugin at the time of initialization.
+<p>PluginConfig specifies arguments that should be passed to a plugin at the time of initialization.
 A plugin that is invoked at multiple extension points is initialized once. Args can have arbitrary structure.
-It is up to the plugin to process these Args.
+It is up to the plugin to process these Args.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name defines the name of plugin being configured</td>
+   <p>Name defines the name of plugin being configured</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>args</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
 </td>
 <td>
-   Args defines the arguments passed to the plugins at the time of initialization. Args can have arbitrary structure.</td>
+   <p>Args defines the arguments passed to the plugins at the time of initialization. Args can have arbitrary structure.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PluginSet`     {#kubescheduler-config-k8s-io-v1beta2-PluginSet}
     
-
-
 
 **Appears in:**
 
 - [Plugins](#kubescheduler-config-k8s-io-v1beta2-Plugins)
 
 
-PluginSet specifies enabled and disabled plugins for an extension point.
-If an array is empty, missing, or nil, default plugins at that extension point will be used.
+<p>PluginSet specifies enabled and disabled plugins for an extension point.
+If an array is empty, missing, or nil, default plugins at that extension point will be used.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>enabled</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-Plugin"><code>[]Plugin</code></a>
 </td>
 <td>
-   Enabled specifies plugins that should be enabled in addition to default plugins.
+   <p>Enabled specifies plugins that should be enabled in addition to default plugins.
 If the default plugin is also configured in the scheduler config file, the weight of plugin will
 be overridden accordingly.
-These are called after default plugins and in the same order specified here.</td>
+These are called after default plugins and in the same order specified here.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>disabled</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-Plugin"><code>[]Plugin</code></a>
 </td>
 <td>
-   Disabled specifies default plugins that should be disabled.
-When all default plugins need to be disabled, an array containing only one "&lowast;" should be provided.</td>
+   <p>Disabled specifies default plugins that should be disabled.
+When all default plugins need to be disabled, an array containing only one &quot;&lowast;&quot; should be provided.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Plugins`     {#kubescheduler-config-k8s-io-v1beta2-Plugins}
     
-
-
 
 **Appears in:**
 
 - [KubeSchedulerProfile](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerProfile)
 
 
-Plugins include multiple extension points. When specified, the list of plugins for
+<p>Plugins include multiple extension points. When specified, the list of plugins for
 a particular extension point are the only ones enabled. If an extension point is
 omitted from the config, then the default set of plugins is used for that extension point.
 Enabled plugins are called in the order specified here, after default plugins. If they need to
-be invoked before default plugins, default plugins must be disabled and re-enabled here in desired order.
+be invoked before default plugins, default plugins must be disabled and re-enabled here in desired order.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>queueSort</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   QueueSort is a list of plugins that should be invoked when sorting pods in the scheduling queue.</td>
+   <p>QueueSort is a list of plugins that should be invoked when sorting pods in the scheduling queue.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>preFilter</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PreFilter is a list of plugins that should be invoked at "PreFilter" extension point of the scheduling framework.</td>
+   <p>PreFilter is a list of plugins that should be invoked at &quot;PreFilter&quot; extension point of the scheduling framework.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>filter</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.</td>
+   <p>Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>postFilter</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PostFilter is a list of plugins that are invoked after filtering phase, but only when no feasible nodes were found for the pod.</td>
+   <p>PostFilter is a list of plugins that are invoked after filtering phase, but only when no feasible nodes were found for the pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>preScore</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PreScore is a list of plugins that are invoked before scoring.</td>
+   <p>PreScore is a list of plugins that are invoked before scoring.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>score</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Score is a list of plugins that should be invoked when ranking nodes that have passed the filtering phase.</td>
+   <p>Score is a list of plugins that should be invoked when ranking nodes that have passed the filtering phase.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>reserve</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Reserve is a list of plugins invoked when reserving/unreserving resources
-after a node is assigned to run the pod.</td>
+   <p>Reserve is a list of plugins invoked when reserving/unreserving resources
+after a node is assigned to run the pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>permit</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Permit is a list of plugins that control binding of a Pod. These plugins can prevent or delay binding of a Pod.</td>
+   <p>Permit is a list of plugins that control binding of a Pod. These plugins can prevent or delay binding of a Pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>preBind</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PreBind is a list of plugins that should be invoked before a pod is bound.</td>
+   <p>PreBind is a list of plugins that should be invoked before a pod is bound.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>bind</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Bind is a list of plugins that should be invoked at "Bind" extension point of the scheduling framework.
-The scheduler call these plugins in order. Scheduler skips the rest of these plugins as soon as one returns success.</td>
+   <p>Bind is a list of plugins that should be invoked at &quot;Bind&quot; extension point of the scheduling framework.
+The scheduler call these plugins in order. Scheduler skips the rest of these plugins as soon as one returns success.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>postBind</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PostBind is a list of plugins that should be invoked after a pod is successfully bound.</td>
+   <p>PostBind is a list of plugins that should be invoked after a pod is successfully bound.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>multiPoint</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   MultiPoint is a simplified config section to enable plugins for all valid extension points.</td>
+   <p>MultiPoint is a simplified config section to enable plugins for all valid extension points.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PodTopologySpreadConstraintsDefaulting`     {#kubescheduler-config-k8s-io-v1beta2-PodTopologySpreadConstraintsDefaulting}
     
 (Alias of `string`)
-
 
 **Appears in:**
 
 - [PodTopologySpreadArgs](#kubescheduler-config-k8s-io-v1beta2-PodTopologySpreadArgs)
 
 
-PodTopologySpreadConstraintsDefaulting defines how to set default constraints
-for the PodTopologySpread plugin.
+<p>PodTopologySpreadConstraintsDefaulting defines how to set default constraints
+for the PodTopologySpread plugin.</p>
 
 
-    
 
 
 ## `RequestedToCapacityRatioParam`     {#kubescheduler-config-k8s-io-v1beta2-RequestedToCapacityRatioParam}
     
-
-
 
 **Appears in:**
 
 - [ScoringStrategy](#kubescheduler-config-k8s-io-v1beta2-ScoringStrategy)
 
 
-RequestedToCapacityRatioParam define RequestedToCapacityRatio parameters
+<p>RequestedToCapacityRatioParam define RequestedToCapacityRatio parameters</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>shape</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-UtilizationShapePoint"><code>[]UtilizationShapePoint</code></a>
 </td>
 <td>
-   Shape is a list of points defining the scoring function shape.</td>
+   <p>Shape is a list of points defining the scoring function shape.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ResourceSpec`     {#kubescheduler-config-k8s-io-v1beta2-ResourceSpec}
     
-
-
 
 **Appears in:**
 
@@ -1088,105 +944,90 @@ RequestedToCapacityRatioParam define RequestedToCapacityRatio parameters
 - [ScoringStrategy](#kubescheduler-config-k8s-io-v1beta2-ScoringStrategy)
 
 
-ResourceSpec represents a single resource.
+<p>ResourceSpec represents a single resource.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name of the resource.</td>
+   <p>Name of the resource.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>weight</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   Weight of the resource.</td>
+   <p>Weight of the resource.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ScoringStrategy`     {#kubescheduler-config-k8s-io-v1beta2-ScoringStrategy}
     
-
-
 
 **Appears in:**
 
 - [NodeResourcesFitArgs](#kubescheduler-config-k8s-io-v1beta2-NodeResourcesFitArgs)
 
 
-ScoringStrategy define ScoringStrategyType for node resource plugin
+<p>ScoringStrategy define ScoringStrategyType for node resource plugin</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>type</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-ScoringStrategyType"><code>ScoringStrategyType</code></a>
 </td>
 <td>
-   Type selects which strategy to run.</td>
+   <p>Type selects which strategy to run.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resources</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-ResourceSpec"><code>[]ResourceSpec</code></a>
 </td>
 <td>
-   Resources to consider when scoring.
-The default resource set includes "cpu" and "memory" with an equal weight.
+   <p>Resources to consider when scoring.
+The default resource set includes &quot;cpu&quot; and &quot;memory&quot; with an equal weight.
 Allowed weights go from 1 to 100.
-Weight defaults to 1 if not specified or explicitly set to 0.</td>
+Weight defaults to 1 if not specified or explicitly set to 0.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>requestedToCapacityRatio</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta2-RequestedToCapacityRatioParam"><code>RequestedToCapacityRatioParam</code></a>
 </td>
 <td>
-   Arguments specific to RequestedToCapacityRatio strategy.</td>
+   <p>Arguments specific to RequestedToCapacityRatio strategy.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ScoringStrategyType`     {#kubescheduler-config-k8s-io-v1beta2-ScoringStrategyType}
     
 (Alias of `string`)
-
 
 **Appears in:**
 
 - [ScoringStrategy](#kubescheduler-config-k8s-io-v1beta2-ScoringStrategy)
 
 
-ScoringStrategyType the type of scoring strategy used in NodeResourcesFit plugin.
+<p>ScoringStrategyType the type of scoring strategy used in NodeResourcesFit plugin.</p>
 
 
-    
 
 
 ## `UtilizationShapePoint`     {#kubescheduler-config-k8s-io-v1beta2-UtilizationShapePoint}
     
-
-
 
 **Appears in:**
 
@@ -1195,33 +1036,30 @@ ScoringStrategyType the type of scoring strategy used in NodeResourcesFit plugin
 - [RequestedToCapacityRatioParam](#kubescheduler-config-k8s-io-v1beta2-RequestedToCapacityRatioParam)
 
 
-UtilizationShapePoint represents single point of priority function shape.
+<p>UtilizationShapePoint represents single point of priority function shape.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>utilization</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.</td>
+   <p>Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>score</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   Score assigned to given utilization (y axis). Valid values are 0 to 10.</td>
+   <p>Score assigned to given utilization (y axis). Valid values are 0 to 10.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   
   
     
@@ -1229,342 +1067,307 @@ UtilizationShapePoint represents single point of priority function shape.
 ## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
     
 
-
-
 **Appears in:**
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
 
 
-ClientConnectionConfiguration contains details for constructing a client.
+<p>ClientConnectionConfiguration contains details for constructing a client.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>kubeconfig</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   kubeconfig is the path to a KubeConfig file.</td>
+   <p>kubeconfig is the path to a KubeConfig file.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>acceptContentTypes</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
+   <p>acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
 default value of 'application/json'. This field will control all connections to the server used by a particular
-client.</td>
+client.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>contentType</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   contentType is the content type used when sending data to the server from this client.</td>
+   <p>contentType is the content type used when sending data to the server from this client.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>qps</code> <B>[Required]</B><br/>
 <code>float32</code>
 </td>
 <td>
-   qps controls the number of queries per second allowed for this connection.</td>
+   <p>qps controls the number of queries per second allowed for this connection.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>burst</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   burst allows extra queries to accumulate when a client is exceeding its rate.</td>
+   <p>burst allows extra queries to accumulate when a client is exceeding its rate.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `DebuggingConfiguration`     {#DebuggingConfiguration}
     
 
-
-
 **Appears in:**
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
 
 
-DebuggingConfiguration holds configuration for Debugging related features.
+<p>DebuggingConfiguration holds configuration for Debugging related features.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   enableProfiling enables profiling via web interface host:port/debug/pprof/</td>
+   <p>enableProfiling enables profiling via web interface host:port/debug/pprof/</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableContentionProfiling</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   enableContentionProfiling enables lock contention profiling, if
-enableProfiling is true.</td>
+   <p>enableContentionProfiling enables lock contention profiling, if
+enableProfiling is true.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `FormatOptions`     {#FormatOptions}
     
 
-
-
 **Appears in:**
 
 - [LoggingConfiguration](#LoggingConfiguration)
 
 
-FormatOptions contains options for the different logging formats.
+<p>FormatOptions contains options for the different logging formats.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>json</code> <B>[Required]</B><br/>
 <a href="#JSONOptions"><code>JSONOptions</code></a>
 </td>
 <td>
-   [Experimental] JSON contains options for logging format "json".</td>
+   <p>[Experimental] JSON contains options for logging format &quot;json&quot;.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `JSONOptions`     {#JSONOptions}
     
 
-
-
 **Appears in:**
 
 - [FormatOptions](#FormatOptions)
 
 
-JSONOptions contains options for logging format "json".
+<p>JSONOptions contains options for logging format &quot;json&quot;.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>splitStream</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   [Experimental] SplitStream redirects error messages to stderr while
+   <p>[Experimental] SplitStream redirects error messages to stderr while
 info messages go to stdout, with buffering. The default is to write
-both to stdout, without buffering.</td>
+both to stdout, without buffering.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>infoBufferSize</code> <B>[Required]</B><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue"><code>k8s.io/apimachinery/pkg/api/resource.QuantityValue</code></a>
 </td>
 <td>
-   [Experimental] InfoBufferSize sets the size of the info stream when
-using split streams. The default is zero, which disables buffering.</td>
+   <p>[Experimental] InfoBufferSize sets the size of the info stream when
+using split streams. The default is zero, which disables buffering.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `LeaderElectionConfiguration`     {#LeaderElectionConfiguration}
     
 
-
-
 **Appears in:**
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
 
 
-LeaderElectionConfiguration defines the configuration of leader election
-clients for components that can run with leader election enabled.
+<p>LeaderElectionConfiguration defines the configuration of leader election
+clients for components that can run with leader election enabled.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>leaderElect</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   leaderElect enables a leader election client to gain leadership
+   <p>leaderElect enables a leader election client to gain leadership
 before executing the main loop. Enable this when running replicated
-components for high availability.</td>
+components for high availability.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>leaseDuration</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   leaseDuration is the duration that non-leader candidates will wait
+   <p>leaseDuration is the duration that non-leader candidates will wait
 after observing a leadership renewal until attempting to acquire
 leadership of a led but unrenewed leader slot. This is effectively the
 maximum duration that a leader can be stopped before it is replaced
 by another candidate. This is only applicable if leader election is
-enabled.</td>
+enabled.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>renewDeadline</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   renewDeadline is the interval between attempts by the acting master to
+   <p>renewDeadline is the interval between attempts by the acting master to
 renew a leadership slot before it stops leading. This must be less
 than or equal to the lease duration. This is only applicable if leader
-election is enabled.</td>
+election is enabled.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>retryPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   retryPeriod is the duration the clients should wait between attempting
+   <p>retryPeriod is the duration the clients should wait between attempting
 acquisition and renewal of a leadership. This is only applicable if
-leader election is enabled.</td>
+leader election is enabled.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceLock</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   resourceLock indicates the resource object type that will be used to lock
-during leader election cycles.</td>
+   <p>resourceLock indicates the resource object type that will be used to lock
+during leader election cycles.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   resourceName indicates the name of resource object that will be used to lock
-during leader election cycles.</td>
+   <p>resourceName indicates the name of resource object that will be used to lock
+during leader election cycles.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceNamespace</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   resourceName indicates the namespace of resource object that will be used to lock
-during leader election cycles.</td>
+   <p>resourceName indicates the namespace of resource object that will be used to lock
+during leader election cycles.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `LoggingConfiguration`     {#LoggingConfiguration}
     
 
-
-
 **Appears in:**
 
 - [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
 
 
-LoggingConfiguration contains logging options
-Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
+<p>LoggingConfiguration contains logging options
+Refer <a href="https://github.com/kubernetes/component-base/blob/master/logs/options.go">Logs Options</a> for more information.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>format</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Format Flag specifies the structure of log messages.
-default value of format is `text`</td>
+   <p>Format Flag specifies the structure of log messages.
+default value of format is <code>text</code></p>
+</td>
 </tr>
-    
-  
 <tr><td><code>flushFrequency</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/time#Duration"><code>time.Duration</code></a>
+<a href="https://pkg.go.dev/time#Duration"><code>time.Duration</code></a>
 </td>
 <td>
-   Maximum number of seconds between log flushes. Ignored if the
-selected logging backend writes log messages without buffering.</td>
+   <p>Maximum number of seconds between log flushes. Ignored if the
+selected logging backend writes log messages without buffering.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>verbosity</code> <B>[Required]</B><br/>
 <code>uint32</code>
 </td>
 <td>
-   Verbosity is the threshold that determines which log messages are
+   <p>Verbosity is the threshold that determines which log messages are
 logged. Default is zero which logs only the most important
 messages. Higher values enable additional messages. Error messages
-are always logged.</td>
+are always logged.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>vmodule</code> <B>[Required]</B><br/>
 <a href="#VModuleConfiguration"><code>VModuleConfiguration</code></a>
 </td>
 <td>
-   VModule overrides the verbosity threshold for individual files.
-Only supported for "text" log format.</td>
+   <p>VModule overrides the verbosity threshold for individual files.
+Only supported for &quot;text&quot; log format.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>sanitization</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
-Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</td>
+   <p>[Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>options</code> <B>[Required]</B><br/>
 <a href="#FormatOptions"><code>FormatOptions</code></a>
 </td>
 <td>
-   [Experimental] Options holds additional parameters that are specific
+   <p>[Experimental] Options holds additional parameters that are specific
 to the different logging formats. Only the options for the selected
-format get used, but all of them get validated.</td>
+format get used, but all of them get validated.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
@@ -1572,13 +1375,13 @@ format get used, but all of them get validated.</td>
     
 (Alias of `[]k8s.io/component-base/config/v1alpha1.VModuleItem`)
 
-
 **Appears in:**
 
 - [LoggingConfiguration](#LoggingConfiguration)
 
 
-VModuleConfiguration is a collection of individual file names or patterns
-and the corresponding verbosity threshold.
+<p>VModuleConfiguration is a collection of individual file names or patterns
+and the corresponding verbosity threshold.</p>
+
 
 

--- a/genref/output/md/kube-scheduler-config.v1beta3.md
+++ b/genref/output/md/kube-scheduler-config.v1beta3.md
@@ -20,15 +20,13 @@ auto_generated: true
   
     
 
-
 ## `DefaultPreemptionArgs`     {#kubescheduler-config-k8s-io-v1beta3-DefaultPreemptionArgs}
     
 
 
+<p>DefaultPreemptionArgs holds arguments used to configure the
+DefaultPreemption plugin.</p>
 
-
-DefaultPreemptionArgs holds arguments used to configure the
-DefaultPreemption plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -37,46 +35,39 @@ DefaultPreemption plugin.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>DefaultPreemptionArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>minCandidateNodesPercentage</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   MinCandidateNodesPercentage is the minimum number of candidates to
+   <p>MinCandidateNodesPercentage is the minimum number of candidates to
 shortlist when dry running preemption as a percentage of number of nodes.
 Must be in the range [0, 100]. Defaults to 10% of the cluster size if
-unspecified.</td>
+unspecified.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>minCandidateNodesAbsolute</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   MinCandidateNodesAbsolute is the absolute minimum number of candidates to
+   <p>MinCandidateNodesAbsolute is the absolute minimum number of candidates to
 shortlist. The likely number of candidates enumerated for dry running
 preemption is given by the formula:
 numCandidates = max(numNodes &lowast; minCandidateNodesPercentage, minCandidateNodesAbsolute)
-We say "likely" because there are other factors such as PDB violations
+We say &quot;likely&quot; because there are other factors such as PDB violations
 that play a role in the number of candidates shortlisted. Must be at least
-0 nodes. Defaults to 100 nodes if unspecified.</td>
+0 nodes. Defaults to 100 nodes if unspecified.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `InterPodAffinityArgs`     {#kubescheduler-config-k8s-io-v1beta3-InterPodAffinityArgs}
     
 
 
+<p>InterPodAffinityArgs holds arguments used to configure the InterPodAffinity plugin.</p>
 
-
-InterPodAffinityArgs holds arguments used to configure the InterPodAffinity plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -85,30 +76,24 @@ InterPodAffinityArgs holds arguments used to configure the InterPodAffinity plug
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>InterPodAffinityArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>hardPodAffinityWeight</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   HardPodAffinityWeight is the scoring weight for existing pods with a
-matching hard affinity to the incoming pod.</td>
+   <p>HardPodAffinityWeight is the scoring weight for existing pods with a
+matching hard affinity to the incoming pod.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeSchedulerConfiguration`     {#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration}
     
 
 
+<p>KubeSchedulerConfiguration configures a scheduler</p>
 
-
-KubeSchedulerConfiguration configures a scheduler
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -117,110 +102,96 @@ KubeSchedulerConfiguration configures a scheduler
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>KubeSchedulerConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>parallelism</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   Parallelism defines the amount of parallelism in algorithms for scheduling a Pods. Must be greater than 0. Defaults to 16</td>
+   <p>Parallelism defines the amount of parallelism in algorithms for scheduling a Pods. Must be greater than 0. Defaults to 16</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>leaderElection</code> <B>[Required]</B><br/>
 <a href="#LeaderElectionConfiguration"><code>LeaderElectionConfiguration</code></a>
 </td>
 <td>
-   LeaderElection defines the configuration of leader election client.</td>
+   <p>LeaderElection defines the configuration of leader election client.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clientConnection</code> <B>[Required]</B><br/>
 <a href="#ClientConnectionConfiguration"><code>ClientConnectionConfiguration</code></a>
 </td>
 <td>
-   ClientConnection specifies the kubeconfig file and client connection
-settings for the proxy server to use when communicating with the apiserver.</td>
+   <p>ClientConnection specifies the kubeconfig file and client connection
+settings for the proxy server to use when communicating with the apiserver.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>DebuggingConfiguration</code> <B>[Required]</B><br/>
 <a href="#DebuggingConfiguration"><code>DebuggingConfiguration</code></a>
 </td>
 <td>(Members of <code>DebuggingConfiguration</code> are embedded into this type.)
-   DebuggingConfiguration holds configuration for Debugging related features
-TODO: We might wanna make this a substruct like Debugging componentbaseconfigv1alpha1.DebuggingConfiguration</td>
+   <p>DebuggingConfiguration holds configuration for Debugging related features
+TODO: We might wanna make this a substruct like Debugging componentbaseconfigv1alpha1.DebuggingConfiguration</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>percentageOfNodesToScore</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   PercentageOfNodesToScore is the percentage of all nodes that once found feasible
+   <p>PercentageOfNodesToScore is the percentage of all nodes that once found feasible
 for running a pod, the scheduler stops its search for more feasible nodes in
 the cluster. This helps improve scheduler's performance. Scheduler always tries to find
-at least "minFeasibleNodesToFind" feasible nodes no matter what the value of this flag is.
+at least &quot;minFeasibleNodesToFind&quot; feasible nodes no matter what the value of this flag is.
 Example: if the cluster size is 500 nodes and the value of this flag is 30,
 then scheduler stops finding further feasible nodes once it finds 150 feasible ones.
 When the value is 0, default percentage (5%--50% based on the size of the cluster) of the
-nodes will be scored.</td>
+nodes will be scored.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podInitialBackoffSeconds</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
+   <p>PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
 If specified, it must be greater than 0. If this value is null, the default value (1s)
-will be used.</td>
+will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podMaxBackoffSeconds</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   PodMaxBackoffSeconds is the max backoff for unschedulable pods.
+   <p>PodMaxBackoffSeconds is the max backoff for unschedulable pods.
 If specified, it must be greater than podInitialBackoffSeconds. If this value is null,
-the default value (10s) will be used.</td>
+the default value (10s) will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>profiles</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerProfile"><code>[]KubeSchedulerProfile</code></a>
 </td>
 <td>
-   Profiles are scheduling profiles that kube-scheduler supports. Pods can
+   <p>Profiles are scheduling profiles that kube-scheduler supports. Pods can
 choose to be scheduled under a particular profile by setting its associated
 scheduler name. Pods that don't specify any scheduler name are scheduled
-with the "default-scheduler" profile, if present here.</td>
+with the &quot;default-scheduler&quot; profile, if present here.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>extenders</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-Extender"><code>[]Extender</code></a>
 </td>
 <td>
-   Extenders are the list of scheduler extenders, each holding the values of how to communicate
-with the extender. These extenders are shared by all scheduler profiles.</td>
+   <p>Extenders are the list of scheduler extenders, each holding the values of how to communicate
+with the extender. These extenders are shared by all scheduler profiles.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeAffinityArgs`     {#kubescheduler-config-k8s-io-v1beta3-NodeAffinityArgs}
     
 
 
+<p>NodeAffinityArgs holds arguments to configure the NodeAffinity plugin.</p>
 
-
-NodeAffinityArgs holds arguments to configure the NodeAffinity plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -229,34 +200,28 @@ NodeAffinityArgs holds arguments to configure the NodeAffinity plugin.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeAffinityArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>addedAffinity</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#nodeaffinity-v1-core"><code>core/v1.NodeAffinity</code></a>
 </td>
 <td>
-   AddedAffinity is applied to all Pods additionally to the NodeAffinity
+   <p>AddedAffinity is applied to all Pods additionally to the NodeAffinity
 specified in the PodSpec. That is, Nodes need to satisfy AddedAffinity
 AND .spec.NodeAffinity. AddedAffinity is empty by default (all Nodes
 match).
 When AddedAffinity is used, some Pods with affinity requirements that match
-a specific Node (such as Daemonset Pods) might remain unschedulable.</td>
+a specific Node (such as Daemonset Pods) might remain unschedulable.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeResourcesBalancedAllocationArgs`     {#kubescheduler-config-k8s-io-v1beta3-NodeResourcesBalancedAllocationArgs}
     
 
 
+<p>NodeResourcesBalancedAllocationArgs holds arguments used to configure NodeResourcesBalancedAllocation plugin.</p>
 
-
-NodeResourcesBalancedAllocationArgs holds arguments used to configure NodeResourcesBalancedAllocation plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -265,29 +230,23 @@ NodeResourcesBalancedAllocationArgs holds arguments used to configure NodeResour
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeResourcesBalancedAllocationArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>resources</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-ResourceSpec"><code>[]ResourceSpec</code></a>
 </td>
 <td>
-   Resources to be managed, the default is "cpu" and "memory" if not specified.</td>
+   <p>Resources to be managed, the default is &quot;cpu&quot; and &quot;memory&quot; if not specified.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeResourcesFitArgs`     {#kubescheduler-config-k8s-io-v1beta3-NodeResourcesFitArgs}
     
 
 
+<p>NodeResourcesFitArgs holds arguments used to configure the NodeResourcesFit plugin.</p>
 
-
-NodeResourcesFitArgs holds arguments used to configure the NodeResourcesFit plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -296,50 +255,42 @@ NodeResourcesFitArgs holds arguments used to configure the NodeResourcesFit plug
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeResourcesFitArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>ignoredResources</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   IgnoredResources is the list of resources that NodeResources fit filter
-should ignore. This doesn't apply to scoring.</td>
+   <p>IgnoredResources is the list of resources that NodeResources fit filter
+should ignore. This doesn't apply to scoring.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ignoredResourceGroups</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   IgnoredResourceGroups defines the list of resource groups that NodeResources fit filter should ignore.
-e.g. if group is ["example.com"], it will ignore all resource names that begin
-with "example.com", such as "example.com/aaa" and "example.com/bbb".
-A resource group name can't contain '/'. This doesn't apply to scoring.</td>
+   <p>IgnoredResourceGroups defines the list of resource groups that NodeResources fit filter should ignore.
+e.g. if group is [&quot;example.com&quot;], it will ignore all resource names that begin
+with &quot;example.com&quot;, such as &quot;example.com/aaa&quot; and &quot;example.com/bbb&quot;.
+A resource group name can't contain '/'. This doesn't apply to scoring.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>scoringStrategy</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-ScoringStrategy"><code>ScoringStrategy</code></a>
 </td>
 <td>
-   ScoringStrategy selects the node resource scoring strategy.
-The default strategy is LeastAllocated with an equal "cpu" and "memory" weight.</td>
+   <p>ScoringStrategy selects the node resource scoring strategy.
+The default strategy is LeastAllocated with an equal &quot;cpu&quot; and &quot;memory&quot; weight.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PodTopologySpreadArgs`     {#kubescheduler-config-k8s-io-v1beta3-PodTopologySpreadArgs}
     
 
 
+<p>PodTopologySpreadArgs holds arguments used to configure the PodTopologySpread plugin.</p>
 
-
-PodTopologySpreadArgs holds arguments used to configure the PodTopologySpread plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -348,50 +299,43 @@ PodTopologySpreadArgs holds arguments used to configure the PodTopologySpread pl
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>PodTopologySpreadArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>defaultConstraints</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#topologyspreadconstraint-v1-core"><code>[]core/v1.TopologySpreadConstraint</code></a>
 </td>
 <td>
-   DefaultConstraints defines topology spread constraints to be applied to
-Pods that don't define any in `pod.spec.topologySpreadConstraints`.
-`.defaultConstraints[&lowast;].labelSelectors` must be empty, as they are
+   <p>DefaultConstraints defines topology spread constraints to be applied to
+Pods that don't define any in <code>pod.spec.topologySpreadConstraints</code>.
+<code>.defaultConstraints[&lowast;].labelSelectors</code> must be empty, as they are
 deduced from the Pod's membership to Services, ReplicationControllers,
 ReplicaSets or StatefulSets.
-When not empty, .defaultingType must be "List".</td>
+When not empty, .defaultingType must be &quot;List&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>defaultingType</code><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PodTopologySpreadConstraintsDefaulting"><code>PodTopologySpreadConstraintsDefaulting</code></a>
 </td>
 <td>
-   DefaultingType determines how .defaultConstraints are deduced. Can be one
-of "System" or "List".
-
-- "System": Use kubernetes defined constraints that spread Pods among
-  Nodes and Zones.
-- "List": Use constraints defined in .defaultConstraints.
-
-Defaults to "List" if feature gate DefaultPodTopologySpread is disabled
-and to "System" if enabled.</td>
+   <p>DefaultingType determines how .defaultConstraints are deduced. Can be one
+of &quot;System&quot; or &quot;List&quot;.</p>
+<ul>
+<li>&quot;System&quot;: Use kubernetes defined constraints that spread Pods among
+Nodes and Zones.</li>
+<li>&quot;List&quot;: Use constraints defined in .defaultConstraints.</li>
+</ul>
+<p>Defaults to &quot;List&quot; if feature gate DefaultPodTopologySpread is disabled
+and to &quot;System&quot; if enabled.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `VolumeBindingArgs`     {#kubescheduler-config-k8s-io-v1beta3-VolumeBindingArgs}
     
 
 
+<p>VolumeBindingArgs holds arguments used to configure the VolumeBinding plugin.</p>
 
-
-VolumeBindingArgs holds arguments used to configure the VolumeBinding plugin.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -400,683 +344,598 @@ VolumeBindingArgs holds arguments used to configure the VolumeBinding plugin.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubescheduler.config.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>VolumeBindingArgs</code></td></tr>
     
-
-  
   
 <tr><td><code>bindTimeoutSeconds</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   BindTimeoutSeconds is the timeout in seconds in volume binding operation.
+   <p>BindTimeoutSeconds is the timeout in seconds in volume binding operation.
 Value must be non-negative integer. The value zero indicates no waiting.
-If this value is nil, the default value (600) will be used.</td>
+If this value is nil, the default value (600) will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>shape</code><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-UtilizationShapePoint"><code>[]UtilizationShapePoint</code></a>
 </td>
 <td>
-   Shape specifies the points defining the score function shape, which is
+   <p>Shape specifies the points defining the score function shape, which is
 used to score nodes based on the utilization of statically provisioned
 PVs. The utilization is calculated by dividing the total requested
 storage of the pod by the total capacity of feasible PVs on each node.
 Each point contains utilization (ranges from 0 to 100) and its
 associated score (ranges from 0 to 10). You can turn the priority by
 specifying different scores for different utilization numbers.
-The default shape points are:
-1) 0 for 0 utilization
-2) 10 for 100 utilization
-All points must be sorted in increasing order by utilization.</td>
+The default shape points are:</p>
+<ol>
+<li>0 for 0 utilization</li>
+<li>10 for 100 utilization
+All points must be sorted in increasing order by utilization.</li>
+</ol>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Extender`     {#kubescheduler-config-k8s-io-v1beta3-Extender}
     
-
-
 
 **Appears in:**
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
 
 
-Extender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
-it is assumed that the extender chose not to provide that extension.
+<p>Extender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,
+it is assumed that the extender chose not to provide that extension.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>urlPrefix</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   URLPrefix at which the extender is available</td>
+   <p>URLPrefix at which the extender is available</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>filterVerb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.</td>
+   <p>Verb for the filter call, empty if not supported. This verb is appended to the URLPrefix when issuing the filter call to extender.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>preemptVerb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.</td>
+   <p>Verb for the preempt call, empty if not supported. This verb is appended to the URLPrefix when issuing the preempt call to extender.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>prioritizeVerb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.</td>
+   <p>Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>weight</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   The numeric multiplier for the node scores that the prioritize call generates.
-The weight should be a positive integer</td>
+   <p>The numeric multiplier for the node scores that the prioritize call generates.
+The weight should be a positive integer</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>bindVerb</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+   <p>Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
 If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
-can implement this function.</td>
+can implement this function.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableHTTPS</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   EnableHTTPS specifies whether https should be used to communicate with the extender</td>
+   <p>EnableHTTPS specifies whether https should be used to communicate with the extender</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tlsConfig</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-ExtenderTLSConfig"><code>ExtenderTLSConfig</code></a>
 </td>
 <td>
-   TLSConfig specifies the transport layer security config</td>
+   <p>TLSConfig specifies the transport layer security config</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>httpTimeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
-timeout is ignored, k8s/other extenders priorities are used to select the node.</td>
+   <p>HTTPTimeout specifies the timeout duration for a call to the extender. Filter timeout fails the scheduling of the pod. Prioritize
+timeout is ignored, k8s/other extenders priorities are used to select the node.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodeCacheCapable</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   NodeCacheCapable specifies that the extender is capable of caching node information,
+   <p>NodeCacheCapable specifies that the extender is capable of caching node information,
 so the scheduler should only send minimal information about the eligible nodes
-assuming that the extender already cached full details of all nodes in the cluster</td>
+assuming that the extender already cached full details of all nodes in the cluster</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>managedResources</code><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-ExtenderManagedResource"><code>[]ExtenderManagedResource</code></a>
 </td>
 <td>
-   ManagedResources is a list of extended resources that are managed by
-this extender.
-- A pod will be sent to the extender on the Filter, Prioritize and Bind
-  (if the extender is the binder) phases iff the pod requests at least
-  one of the extended resources in this list. If empty or unspecified,
-  all pods will be sent to this extender.
-- If IgnoredByScheduler is set to true for a resource, kube-scheduler
-  will skip checking the resource in predicates.</td>
+   <p>ManagedResources is a list of extended resources that are managed by
+this extender.</p>
+<ul>
+<li>A pod will be sent to the extender on the Filter, Prioritize and Bind
+(if the extender is the binder) phases iff the pod requests at least
+one of the extended resources in this list. If empty or unspecified,
+all pods will be sent to this extender.</li>
+<li>If IgnoredByScheduler is set to true for a resource, kube-scheduler
+will skip checking the resource in predicates.</li>
+</ul>
+</td>
 </tr>
-    
-  
 <tr><td><code>ignorable</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   Ignorable specifies if the extender is ignorable, i.e. scheduling should not
-fail when the extender returns an error or is not reachable.</td>
+   <p>Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+fail when the extender returns an error or is not reachable.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExtenderManagedResource`     {#kubescheduler-config-k8s-io-v1beta3-ExtenderManagedResource}
     
-
-
 
 **Appears in:**
 
 - [Extender](#kubescheduler-config-k8s-io-v1beta3-Extender)
 
 
-ExtenderManagedResource describes the arguments of extended resources
-managed by an extender.
+<p>ExtenderManagedResource describes the arguments of extended resources
+managed by an extender.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the extended resource name.</td>
+   <p>Name is the extended resource name.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ignoredByScheduler</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   IgnoredByScheduler indicates whether kube-scheduler should ignore this
-resource when applying predicates.</td>
+   <p>IgnoredByScheduler indicates whether kube-scheduler should ignore this
+resource when applying predicates.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExtenderTLSConfig`     {#kubescheduler-config-k8s-io-v1beta3-ExtenderTLSConfig}
     
-
-
 
 **Appears in:**
 
 - [Extender](#kubescheduler-config-k8s-io-v1beta3-Extender)
 
 
-ExtenderTLSConfig contains settings to enable TLS with extender
+<p>ExtenderTLSConfig contains settings to enable TLS with extender</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>insecure</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   Server should be accessed without verifying the TLS certificate. For testing only.</td>
+   <p>Server should be accessed without verifying the TLS certificate. For testing only.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>serverName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ServerName is passed to the server for SNI and is used in the client to check server
+   <p>ServerName is passed to the server for SNI and is used in the client to check server
 certificates against. If ServerName is empty, the hostname used to contact the
-server is used.</td>
+server is used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Server requires TLS client certificate authentication</td>
+   <p>Server requires TLS client certificate authentication</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>keyFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Server requires TLS client certificate authentication</td>
+   <p>Server requires TLS client certificate authentication</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Trusted root certificates for server</td>
+   <p>Trusted root certificates for server</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certData</code> <B>[Required]</B><br/>
 <code>[]byte</code>
 </td>
 <td>
-   CertData holds PEM-encoded bytes (typically read from a client certificate file).
-CertData takes precedence over CertFile</td>
+   <p>CertData holds PEM-encoded bytes (typically read from a client certificate file).
+CertData takes precedence over CertFile</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>keyData</code> <B>[Required]</B><br/>
 <code>[]byte</code>
 </td>
 <td>
-   KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
-KeyData takes precedence over KeyFile</td>
+   <p>KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
+KeyData takes precedence over KeyFile</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caData</code> <B>[Required]</B><br/>
 <code>[]byte</code>
 </td>
 <td>
-   CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
-CAData takes precedence over CAFile</td>
+   <p>CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
+CAData takes precedence over CAFile</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeSchedulerProfile`     {#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerProfile}
     
-
-
 
 **Appears in:**
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
 
 
-KubeSchedulerProfile is a scheduling profile.
+<p>KubeSchedulerProfile is a scheduling profile.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>schedulerName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   SchedulerName is the name of the scheduler associated to this profile.
-If SchedulerName matches with the pod's "spec.schedulerName", then the pod
-is scheduled with this profile.</td>
+   <p>SchedulerName is the name of the scheduler associated to this profile.
+If SchedulerName matches with the pod's &quot;spec.schedulerName&quot;, then the pod
+is scheduled with this profile.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>plugins</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-Plugins"><code>Plugins</code></a>
 </td>
 <td>
-   Plugins specify the set of plugins that should be enabled or disabled.
+   <p>Plugins specify the set of plugins that should be enabled or disabled.
 Enabled plugins are the ones that should be enabled in addition to the
 default plugins. Disabled plugins are any of the default plugins that
 should be disabled.
 When no enabled or disabled plugin is specified for an extension point,
 default plugins for that extension point will be used if there is any.
 If a QueueSort plugin is specified, the same QueueSort Plugin and
-PluginConfig must be specified for all profiles.</td>
+PluginConfig must be specified for all profiles.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>pluginConfig</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginConfig"><code>[]PluginConfig</code></a>
 </td>
 <td>
-   PluginConfig is an optional set of custom plugin arguments for each plugin.
+   <p>PluginConfig is an optional set of custom plugin arguments for each plugin.
 Omitting config args for a plugin is equivalent to using the default config
-for that plugin.</td>
+for that plugin.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Plugin`     {#kubescheduler-config-k8s-io-v1beta3-Plugin}
     
-
-
 
 **Appears in:**
 
 - [PluginSet](#kubescheduler-config-k8s-io-v1beta3-PluginSet)
 
 
-Plugin specifies a plugin name and its weight when applicable. Weight is used only for Score plugins.
+<p>Plugin specifies a plugin name and its weight when applicable. Weight is used only for Score plugins.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name defines the name of plugin</td>
+   <p>Name defines the name of plugin</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>weight</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   Weight defines the weight of plugin, only used for Score plugins.</td>
+   <p>Weight defines the weight of plugin, only used for Score plugins.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PluginConfig`     {#kubescheduler-config-k8s-io-v1beta3-PluginConfig}
     
-
-
 
 **Appears in:**
 
 - [KubeSchedulerProfile](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerProfile)
 
 
-PluginConfig specifies arguments that should be passed to a plugin at the time of initialization.
+<p>PluginConfig specifies arguments that should be passed to a plugin at the time of initialization.
 A plugin that is invoked at multiple extension points is initialized once. Args can have arbitrary structure.
-It is up to the plugin to process these Args.
+It is up to the plugin to process these Args.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name defines the name of plugin being configured</td>
+   <p>Name defines the name of plugin being configured</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>args</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
 </td>
 <td>
-   Args defines the arguments passed to the plugins at the time of initialization. Args can have arbitrary structure.</td>
+   <p>Args defines the arguments passed to the plugins at the time of initialization. Args can have arbitrary structure.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PluginSet`     {#kubescheduler-config-k8s-io-v1beta3-PluginSet}
     
-
-
 
 **Appears in:**
 
 - [Plugins](#kubescheduler-config-k8s-io-v1beta3-Plugins)
 
 
-PluginSet specifies enabled and disabled plugins for an extension point.
-If an array is empty, missing, or nil, default plugins at that extension point will be used.
+<p>PluginSet specifies enabled and disabled plugins for an extension point.
+If an array is empty, missing, or nil, default plugins at that extension point will be used.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>enabled</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-Plugin"><code>[]Plugin</code></a>
 </td>
 <td>
-   Enabled specifies plugins that should be enabled in addition to default plugins.
+   <p>Enabled specifies plugins that should be enabled in addition to default plugins.
 If the default plugin is also configured in the scheduler config file, the weight of plugin will
 be overridden accordingly.
-These are called after default plugins and in the same order specified here.</td>
+These are called after default plugins and in the same order specified here.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>disabled</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-Plugin"><code>[]Plugin</code></a>
 </td>
 <td>
-   Disabled specifies default plugins that should be disabled.
-When all default plugins need to be disabled, an array containing only one "&lowast;" should be provided.</td>
+   <p>Disabled specifies default plugins that should be disabled.
+When all default plugins need to be disabled, an array containing only one &quot;&lowast;&quot; should be provided.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Plugins`     {#kubescheduler-config-k8s-io-v1beta3-Plugins}
     
-
-
 
 **Appears in:**
 
 - [KubeSchedulerProfile](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerProfile)
 
 
-Plugins include multiple extension points. When specified, the list of plugins for
+<p>Plugins include multiple extension points. When specified, the list of plugins for
 a particular extension point are the only ones enabled. If an extension point is
 omitted from the config, then the default set of plugins is used for that extension point.
 Enabled plugins are called in the order specified here, after default plugins. If they need to
-be invoked before default plugins, default plugins must be disabled and re-enabled here in desired order.
+be invoked before default plugins, default plugins must be disabled and re-enabled here in desired order.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>queueSort</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   QueueSort is a list of plugins that should be invoked when sorting pods in the scheduling queue.</td>
+   <p>QueueSort is a list of plugins that should be invoked when sorting pods in the scheduling queue.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>preFilter</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PreFilter is a list of plugins that should be invoked at "PreFilter" extension point of the scheduling framework.</td>
+   <p>PreFilter is a list of plugins that should be invoked at &quot;PreFilter&quot; extension point of the scheduling framework.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>filter</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.</td>
+   <p>Filter is a list of plugins that should be invoked when filtering out nodes that cannot run the Pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>postFilter</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PostFilter is a list of plugins that are invoked after filtering phase, but only when no feasible nodes were found for the pod.</td>
+   <p>PostFilter is a list of plugins that are invoked after filtering phase, but only when no feasible nodes were found for the pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>preScore</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PreScore is a list of plugins that are invoked before scoring.</td>
+   <p>PreScore is a list of plugins that are invoked before scoring.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>score</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Score is a list of plugins that should be invoked when ranking nodes that have passed the filtering phase.</td>
+   <p>Score is a list of plugins that should be invoked when ranking nodes that have passed the filtering phase.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>reserve</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Reserve is a list of plugins invoked when reserving/unreserving resources
-after a node is assigned to run the pod.</td>
+   <p>Reserve is a list of plugins invoked when reserving/unreserving resources
+after a node is assigned to run the pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>permit</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Permit is a list of plugins that control binding of a Pod. These plugins can prevent or delay binding of a Pod.</td>
+   <p>Permit is a list of plugins that control binding of a Pod. These plugins can prevent or delay binding of a Pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>preBind</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PreBind is a list of plugins that should be invoked before a pod is bound.</td>
+   <p>PreBind is a list of plugins that should be invoked before a pod is bound.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>bind</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   Bind is a list of plugins that should be invoked at "Bind" extension point of the scheduling framework.
-The scheduler call these plugins in order. Scheduler skips the rest of these plugins as soon as one returns success.</td>
+   <p>Bind is a list of plugins that should be invoked at &quot;Bind&quot; extension point of the scheduling framework.
+The scheduler call these plugins in order. Scheduler skips the rest of these plugins as soon as one returns success.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>postBind</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   PostBind is a list of plugins that should be invoked after a pod is successfully bound.</td>
+   <p>PostBind is a list of plugins that should be invoked after a pod is successfully bound.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>multiPoint</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-PluginSet"><code>PluginSet</code></a>
 </td>
 <td>
-   MultiPoint is a simplified config section to enable plugins for all valid extension points.
+   <p>MultiPoint is a simplified config section to enable plugins for all valid extension points.
 Plugins enabled through MultiPoint will automatically register for every individual extension
 point the plugin has implemented. Disabling a plugin through MultiPoint disables that behavior.
-The same is true for disabling "&lowast;" through MultiPoint (no default plugins will be automatically registered).
-Plugins can still be disabled through their individual extension points.
-
-In terms of precedence, plugin config follows this basic hierarchy
-  1. Specific extension points
-  2. Explicitly configured MultiPoint plugins
-  3. The set of default plugins, as MultiPoint plugins
+The same is true for disabling &quot;&lowast;&quot; through MultiPoint (no default plugins will be automatically registered).
+Plugins can still be disabled through their individual extension points.</p>
+<p>In terms of precedence, plugin config follows this basic hierarchy</p>
+<ol>
+<li>Specific extension points</li>
+<li>Explicitly configured MultiPoint plugins</li>
+<li>The set of default plugins, as MultiPoint plugins
 This implies that a higher precedence plugin will run first and overwrite any settings within MultiPoint.
 Explicitly user-configured plugins also take a higher precedence over default plugins.
 Within this hierarchy, an Enabled setting takes precedence over Disabled. For example, if a plugin is
-set in both `multiPoint.Enabled` and `multiPoint.Disabled`, the plugin will be enabled. Similarly,
-including `multiPoint.Disabled = '&lowast;'` and `multiPoint.Enabled = pluginA` will still register that specific
-plugin through MultiPoint. This follows the same behavior as all other extension point configurations.</td>
+set in both <code>multiPoint.Enabled</code> and <code>multiPoint.Disabled</code>, the plugin will be enabled. Similarly,
+including <code>multiPoint.Disabled = '&lowast;'</code> and <code>multiPoint.Enabled = pluginA</code> will still register that specific
+plugin through MultiPoint. This follows the same behavior as all other extension point configurations.</li>
+</ol>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PodTopologySpreadConstraintsDefaulting`     {#kubescheduler-config-k8s-io-v1beta3-PodTopologySpreadConstraintsDefaulting}
     
 (Alias of `string`)
-
 
 **Appears in:**
 
 - [PodTopologySpreadArgs](#kubescheduler-config-k8s-io-v1beta3-PodTopologySpreadArgs)
 
 
-PodTopologySpreadConstraintsDefaulting defines how to set default constraints
-for the PodTopologySpread plugin.
+<p>PodTopologySpreadConstraintsDefaulting defines how to set default constraints
+for the PodTopologySpread plugin.</p>
 
 
-    
 
 
 ## `RequestedToCapacityRatioParam`     {#kubescheduler-config-k8s-io-v1beta3-RequestedToCapacityRatioParam}
     
-
-
 
 **Appears in:**
 
 - [ScoringStrategy](#kubescheduler-config-k8s-io-v1beta3-ScoringStrategy)
 
 
-RequestedToCapacityRatioParam define RequestedToCapacityRatio parameters
+<p>RequestedToCapacityRatioParam define RequestedToCapacityRatio parameters</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>shape</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-UtilizationShapePoint"><code>[]UtilizationShapePoint</code></a>
 </td>
 <td>
-   Shape is a list of points defining the scoring function shape.</td>
+   <p>Shape is a list of points defining the scoring function shape.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ResourceSpec`     {#kubescheduler-config-k8s-io-v1beta3-ResourceSpec}
     
-
-
 
 **Appears in:**
 
@@ -1085,105 +944,90 @@ RequestedToCapacityRatioParam define RequestedToCapacityRatio parameters
 - [ScoringStrategy](#kubescheduler-config-k8s-io-v1beta3-ScoringStrategy)
 
 
-ResourceSpec represents a single resource.
+<p>ResourceSpec represents a single resource.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name of the resource.</td>
+   <p>Name of the resource.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>weight</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   Weight of the resource.</td>
+   <p>Weight of the resource.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ScoringStrategy`     {#kubescheduler-config-k8s-io-v1beta3-ScoringStrategy}
     
-
-
 
 **Appears in:**
 
 - [NodeResourcesFitArgs](#kubescheduler-config-k8s-io-v1beta3-NodeResourcesFitArgs)
 
 
-ScoringStrategy define ScoringStrategyType for node resource plugin
+<p>ScoringStrategy define ScoringStrategyType for node resource plugin</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>type</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-ScoringStrategyType"><code>ScoringStrategyType</code></a>
 </td>
 <td>
-   Type selects which strategy to run.</td>
+   <p>Type selects which strategy to run.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resources</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-ResourceSpec"><code>[]ResourceSpec</code></a>
 </td>
 <td>
-   Resources to consider when scoring.
-The default resource set includes "cpu" and "memory" with an equal weight.
+   <p>Resources to consider when scoring.
+The default resource set includes &quot;cpu&quot; and &quot;memory&quot; with an equal weight.
 Allowed weights go from 1 to 100.
-Weight defaults to 1 if not specified or explicitly set to 0.</td>
+Weight defaults to 1 if not specified or explicitly set to 0.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>requestedToCapacityRatio</code> <B>[Required]</B><br/>
 <a href="#kubescheduler-config-k8s-io-v1beta3-RequestedToCapacityRatioParam"><code>RequestedToCapacityRatioParam</code></a>
 </td>
 <td>
-   Arguments specific to RequestedToCapacityRatio strategy.</td>
+   <p>Arguments specific to RequestedToCapacityRatio strategy.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ScoringStrategyType`     {#kubescheduler-config-k8s-io-v1beta3-ScoringStrategyType}
     
 (Alias of `string`)
-
 
 **Appears in:**
 
 - [ScoringStrategy](#kubescheduler-config-k8s-io-v1beta3-ScoringStrategy)
 
 
-ScoringStrategyType the type of scoring strategy used in NodeResourcesFit plugin.
+<p>ScoringStrategyType the type of scoring strategy used in NodeResourcesFit plugin.</p>
 
 
-    
 
 
 ## `UtilizationShapePoint`     {#kubescheduler-config-k8s-io-v1beta3-UtilizationShapePoint}
     
-
-
 
 **Appears in:**
 
@@ -1192,33 +1036,30 @@ ScoringStrategyType the type of scoring strategy used in NodeResourcesFit plugin
 - [RequestedToCapacityRatioParam](#kubescheduler-config-k8s-io-v1beta3-RequestedToCapacityRatioParam)
 
 
-UtilizationShapePoint represents single point of priority function shape.
+<p>UtilizationShapePoint represents single point of priority function shape.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>utilization</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.</td>
+   <p>Utilization (x axis). Valid values are 0 to 100. Fully utilized node maps to 100.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>score</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   Score assigned to given utilization (y axis). Valid values are 0 to 10.</td>
+   <p>Score assigned to given utilization (y axis). Valid values are 0 to 10.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   
   
     
@@ -1226,181 +1067,161 @@ UtilizationShapePoint represents single point of priority function shape.
 ## `ClientConnectionConfiguration`     {#ClientConnectionConfiguration}
     
 
-
-
 **Appears in:**
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
 
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
 
-ClientConnectionConfiguration contains details for constructing a client.
+
+<p>ClientConnectionConfiguration contains details for constructing a client.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>kubeconfig</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   kubeconfig is the path to a KubeConfig file.</td>
+   <p>kubeconfig is the path to a KubeConfig file.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>acceptContentTypes</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
+   <p>acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
 default value of 'application/json'. This field will control all connections to the server used by a particular
-client.</td>
+client.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>contentType</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   contentType is the content type used when sending data to the server from this client.</td>
+   <p>contentType is the content type used when sending data to the server from this client.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>qps</code> <B>[Required]</B><br/>
 <code>float32</code>
 </td>
 <td>
-   qps controls the number of queries per second allowed for this connection.</td>
+   <p>qps controls the number of queries per second allowed for this connection.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>burst</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   burst allows extra queries to accumulate when a client is exceeding its rate.</td>
+   <p>burst allows extra queries to accumulate when a client is exceeding its rate.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `DebuggingConfiguration`     {#DebuggingConfiguration}
     
 
-
-
 **Appears in:**
-
-- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
 
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration)
 
+- [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
 
-DebuggingConfiguration holds configuration for Debugging related features.
+
+<p>DebuggingConfiguration holds configuration for Debugging related features.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>enableProfiling</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   enableProfiling enables profiling via web interface host:port/debug/pprof/</td>
+   <p>enableProfiling enables profiling via web interface host:port/debug/pprof/</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableContentionProfiling</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   enableContentionProfiling enables lock contention profiling, if
-enableProfiling is true.</td>
+   <p>enableContentionProfiling enables lock contention profiling, if
+enableProfiling is true.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `FormatOptions`     {#FormatOptions}
     
 
-
-
 **Appears in:**
 
 - [LoggingConfiguration](#LoggingConfiguration)
 
 
-FormatOptions contains options for the different logging formats.
+<p>FormatOptions contains options for the different logging formats.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>json</code> <B>[Required]</B><br/>
 <a href="#JSONOptions"><code>JSONOptions</code></a>
 </td>
 <td>
-   [Experimental] JSON contains options for logging format "json".</td>
+   <p>[Experimental] JSON contains options for logging format &quot;json&quot;.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `JSONOptions`     {#JSONOptions}
     
 
-
-
 **Appears in:**
 
 - [FormatOptions](#FormatOptions)
 
 
-JSONOptions contains options for logging format "json".
+<p>JSONOptions contains options for logging format &quot;json&quot;.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>splitStream</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   [Experimental] SplitStream redirects error messages to stderr while
+   <p>[Experimental] SplitStream redirects error messages to stderr while
 info messages go to stdout, with buffering. The default is to write
-both to stdout, without buffering.</td>
+both to stdout, without buffering.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>infoBufferSize</code> <B>[Required]</B><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue"><code>k8s.io/apimachinery/pkg/api/resource.QuantityValue</code></a>
 </td>
 <td>
-   [Experimental] InfoBufferSize sets the size of the info stream when
-using split streams. The default is zero, which disables buffering.</td>
+   <p>[Experimental] InfoBufferSize sets the size of the info stream when
+using split streams. The default is zero, which disables buffering.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `LeaderElectionConfiguration`     {#LeaderElectionConfiguration}
     
-
-
 
 **Appears in:**
 
@@ -1409,165 +1230,150 @@ using split streams. The default is zero, which disables buffering.</td>
 - [KubeSchedulerConfiguration](#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration)
 
 
-LeaderElectionConfiguration defines the configuration of leader election
-clients for components that can run with leader election enabled.
+<p>LeaderElectionConfiguration defines the configuration of leader election
+clients for components that can run with leader election enabled.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>leaderElect</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   leaderElect enables a leader election client to gain leadership
+   <p>leaderElect enables a leader election client to gain leadership
 before executing the main loop. Enable this when running replicated
-components for high availability.</td>
+components for high availability.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>leaseDuration</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   leaseDuration is the duration that non-leader candidates will wait
+   <p>leaseDuration is the duration that non-leader candidates will wait
 after observing a leadership renewal until attempting to acquire
 leadership of a led but unrenewed leader slot. This is effectively the
 maximum duration that a leader can be stopped before it is replaced
 by another candidate. This is only applicable if leader election is
-enabled.</td>
+enabled.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>renewDeadline</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   renewDeadline is the interval between attempts by the acting master to
+   <p>renewDeadline is the interval between attempts by the acting master to
 renew a leadership slot before it stops leading. This must be less
 than or equal to the lease duration. This is only applicable if leader
-election is enabled.</td>
+election is enabled.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>retryPeriod</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   retryPeriod is the duration the clients should wait between attempting
+   <p>retryPeriod is the duration the clients should wait between attempting
 acquisition and renewal of a leadership. This is only applicable if
-leader election is enabled.</td>
+leader election is enabled.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceLock</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   resourceLock indicates the resource object type that will be used to lock
-during leader election cycles.</td>
+   <p>resourceLock indicates the resource object type that will be used to lock
+during leader election cycles.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   resourceName indicates the name of resource object that will be used to lock
-during leader election cycles.</td>
+   <p>resourceName indicates the name of resource object that will be used to lock
+during leader election cycles.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resourceNamespace</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   resourceName indicates the namespace of resource object that will be used to lock
-during leader election cycles.</td>
+   <p>resourceName indicates the namespace of resource object that will be used to lock
+during leader election cycles.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `LoggingConfiguration`     {#LoggingConfiguration}
     
 
-
-
 **Appears in:**
 
 - [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
 
 
-LoggingConfiguration contains logging options
-Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
+<p>LoggingConfiguration contains logging options
+Refer <a href="https://github.com/kubernetes/component-base/blob/master/logs/options.go">Logs Options</a> for more information.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>format</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Format Flag specifies the structure of log messages.
-default value of format is `text`</td>
+   <p>Format Flag specifies the structure of log messages.
+default value of format is <code>text</code></p>
+</td>
 </tr>
-    
-  
 <tr><td><code>flushFrequency</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/time#Duration"><code>time.Duration</code></a>
+<a href="https://pkg.go.dev/time#Duration"><code>time.Duration</code></a>
 </td>
 <td>
-   Maximum number of seconds between log flushes. Ignored if the
-selected logging backend writes log messages without buffering.</td>
+   <p>Maximum number of seconds between log flushes. Ignored if the
+selected logging backend writes log messages without buffering.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>verbosity</code> <B>[Required]</B><br/>
 <code>uint32</code>
 </td>
 <td>
-   Verbosity is the threshold that determines which log messages are
+   <p>Verbosity is the threshold that determines which log messages are
 logged. Default is zero which logs only the most important
 messages. Higher values enable additional messages. Error messages
-are always logged.</td>
+are always logged.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>vmodule</code> <B>[Required]</B><br/>
 <a href="#VModuleConfiguration"><code>VModuleConfiguration</code></a>
 </td>
 <td>
-   VModule overrides the verbosity threshold for individual files.
-Only supported for "text" log format.</td>
+   <p>VModule overrides the verbosity threshold for individual files.
+Only supported for &quot;text&quot; log format.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>sanitization</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
-Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</td>
+   <p>[Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>options</code> <B>[Required]</B><br/>
 <a href="#FormatOptions"><code>FormatOptions</code></a>
 </td>
 <td>
-   [Experimental] Options holds additional parameters that are specific
+   <p>[Experimental] Options holds additional parameters that are specific
 to the different logging formats. Only the options for the selected
-format get used, but all of them get validated.</td>
+format get used, but all of them get validated.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
@@ -1575,13 +1381,13 @@ format get used, but all of them get validated.</td>
     
 (Alias of `[]k8s.io/component-base/config/v1alpha1.VModuleItem`)
 
-
 **Appears in:**
 
 - [LoggingConfiguration](#LoggingConfiguration)
 
 
-VModuleConfiguration is a collection of individual file names or patterns
-and the corresponding verbosity threshold.
+<p>VModuleConfiguration is a collection of individual file names or patterns
+and the corresponding verbosity threshold.</p>
+
 
 

--- a/genref/output/md/kube-scheduler-extender.v1.md
+++ b/genref/output/md/kube-scheduler-extender.v1.md
@@ -10,12 +10,11 @@
     
 (Alias of `map[string]string`)
 
-
 **Appears in:**
 
-- [ExtenderFilterResult](#ExtenderFilterResult)
 
 
-FailedNodesMap represents the filtered out nodes, with node names and failure messages
+<p>FailedNodesMap represents the filtered out nodes, with node names and failure messages</p>
+
 
 

--- a/genref/output/md/kubeadm-config.v1beta2.md
+++ b/genref/output/md/kubeadm-config.v1beta2.md
@@ -4,280 +4,245 @@ content_type: tool-reference
 package: kubeadm.k8s.io/v1beta2
 auto_generated: true
 ---
-## Overview
-
-Package v1beta2 defines the v1beta2 version of the kubeadm configuration file format.
-This version improves on the v1beta1 format by fixing some minor issues and adding a few new fields.
-
-A list of changes since v1beta1:
-
-- "certificateKey" field is added to InitConfiguration and JoinConfiguration.
-- "ignorePreflightErrors" field is added to the NodeRegistrationOptions.
-- The JSON "omitempty" tag is used in a more places where appropriate.
-- The JSON "omitempty" tag of the "taints" field (inside NodeRegistrationOptions) is removed.
-
-See the Kubernetes 1.15 changelog for further details.
-
-Migration from old kubeadm config versions
-
-Please convert your v1beta1 configuration files to v1beta2 using the "kubeadm config migrate" command of kubeadm v1.15.x
-(conversion from older releases of kubeadm config files requires older release of kubeadm as well e.g.
-
-- kubeadm v1.11 should be used to migrate v1alpha1 to v1alpha2; kubeadm v1.12 should be used to translate v1alpha2 to v1alpha3;
-- kubeadm v1.13 or v1.14 should be used to translate v1alpha3 to v1beta1)
-
-Nevertheless, kubeadm v1.15.x will support reading from v1beta1 version of the kubeadm config file format.
-
-## Basics
-
-The preferred way to configure kubeadm is to pass an YAML configuration file with the `--config` option. Some of the
+<h2>Overview</h2>
+<p>Package v1beta2 defines the v1beta2 version of the kubeadm configuration file format.
+This version improves on the v1beta1 format by fixing some minor issues and adding a few new fields.</p>
+<p>A list of changes since v1beta1:</p>
+<ul>
+<li>&quot;certificateKey&quot; field is added to InitConfiguration and JoinConfiguration.</li>
+<li>&quot;ignorePreflightErrors&quot; field is added to the NodeRegistrationOptions.</li>
+<li>The JSON &quot;omitempty&quot; tag is used in a more places where appropriate.</li>
+<li>The JSON &quot;omitempty&quot; tag of the &quot;taints&quot; field (inside NodeRegistrationOptions) is removed.</li>
+</ul>
+<p>See the Kubernetes 1.15 changelog for further details.</p>
+<p>Migration from old kubeadm config versions</p>
+<p>Please convert your v1beta1 configuration files to v1beta2 using the &quot;kubeadm config migrate&quot; command of kubeadm v1.15.x
+(conversion from older releases of kubeadm config files requires older release of kubeadm as well e.g.</p>
+<ul>
+<li>kubeadm v1.11 should be used to migrate v1alpha1 to v1alpha2; kubeadm v1.12 should be used to translate v1alpha2 to v1alpha3;</li>
+<li>kubeadm v1.13 or v1.14 should be used to translate v1alpha3 to v1beta1)</li>
+</ul>
+<p>Nevertheless, kubeadm v1.15.x will support reading from v1beta1 version of the kubeadm config file format.</p>
+<h2>Basics</h2>
+<p>The preferred way to configure kubeadm is to pass an YAML configuration file with the <code>--config</code> option. Some of the
 configuration options defined in the kubeadm config file are also available as command line flags, but only
-the most common/simple use case are supported with this approach.
-
-A kubeadm config file could contain multiple configuration types separated using three dashes (`---`).
-
-kubeadm supports the following configuration types:
-
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: InitConfiguration
-
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: ClusterConfiguration
-
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-
-apiVersion: kubeproxy.config.k8s.io/v1alpha1
-kind: KubeProxyConfiguration
-
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: JoinConfiguration
-```
-
-To print the defaults for "init" and "join" actions use the following commands:
-
-```shell
-kubeadm config print init-defaults
+the most common/simple use case are supported with this approach.</p>
+<p>A kubeadm config file could contain multiple configuration types separated using three dashes (<code>---</code>).</p>
+<p>kubeadm supports the following configuration types:</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta2<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>InitConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta2<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>ClusterConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeletConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeproxy.config.k8s.io/v1alpha1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeProxyConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta2<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>JoinConfiguration<span style="color:#bbb">
+</span></pre><p>To print the defaults for &quot;init&quot; and &quot;join&quot; actions use the following commands:</p>
+<pre style="background-color:#fff">kubeadm config print init-defaults
 kubeadm config print join-defaults
-```
-
-The list of configuration types that must be included in a configuration file depends by the action you are
-performing (`init` or `join`) and by the configuration options you are going to use (defaults or advanced customization).
-
-If some configuration types are not provided, or provided only partially, kubeadm will use default values; defaults
+</pre><p>The list of configuration types that must be included in a configuration file depends by the action you are
+performing (<code>init</code> or <code>join</code>) and by the configuration options you are going to use (defaults or advanced customization).</p>
+<p>If some configuration types are not provided, or provided only partially, kubeadm will use default values; defaults
 provided by kubeadm includes also enforcing consistency of values across components when required (e.g.
-`--cluster-cidr` flag on controller manager and `clusterCIDR` on kube-proxy).
-
-Users are always allowed to override default values, with the only exception of a small subset of setting with
-relevance for security (e.g. enforce authorization-mode Node and RBAC on API server)
-
-If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
-ignore those types and print a warning.
-
-## Kubeadm init configuration types
-
-When executing kubeadm init with the `--config` option, the following configuration types could be used:
+<code>--cluster-cidr</code> flag on controller manager and <code>clusterCIDR</code> on kube-proxy).</p>
+<p>Users are always allowed to override default values, with the only exception of a small subset of setting with
+relevance for security (e.g. enforce authorization-mode Node and RBAC on API server)</p>
+<p>If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
+ignore those types and print a warning.</p>
+<h2>Kubeadm init configuration types</h2>
+<p>When executing kubeadm init with the <code>--config</code> option, the following configuration types could be used:
 InitConfiguration, ClusterConfiguration, KubeProxyConfiguration, KubeletConfiguration, but only one
-between InitConfiguration and ClusterConfiguration is mandatory.
-
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: InitConfiguration
-bootstrapTokens:
-  ...
-nodeRegistration:
-  ...
-```
-
-The InitConfiguration type should be used to configure runtime settings, that in case of `kubeadm init`
+between InitConfiguration and ClusterConfiguration is mandatory.</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta2<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>InitConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">bootstrapTokens</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">nodeRegistration</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span></pre><p>The InitConfiguration type should be used to configure runtime settings, that in case of <code>kubeadm init</code>
 are the configuration of the bootstrap token and all the setting which are specific to the node where kubeadm
-is executed, including:
-
-- `nodeRegistration`, that holds fields that relate to registering the new node to the cluster;
-  use it to customize the node name, the CRI socket to use or any other settings that should apply to this
-  node only (e.g. the node ip).
-
-- `apiServer`, that represents the endpoint of the instance of the API server to be deployed on this node;
-  use it e.g. to customize the API server advertise address.
-
-  ```yaml
-  apiVersion: kubeadm.k8s.io/v1beta2
-  kind: ClusterConfiguration
-  networking:
-      ...
-  etcd:
-      ...
-  apiServer:
-    extraArgs:
-      ...
-    extraVolumes:
-      ...
-  ...
-  ```
-
-The ClusterConfiguration type should be used to configure cluster-wide settings,
-including settings for:
-
-- Networking, that holds configuration for the networking topology of the cluster; use it e.g. to customize
-  pod subnet or services subnet.
-
-- Etcd configurations; use it e.g. to customize the local etcd or to configure the API server
-  for using an external etcd cluster.
-
-- kube-apiserver, kube-scheduler, kube-controller-manager configurations; use it to customize control-plane
-  components by adding customized setting or overriding kubeadm default settings.
-
-  ```yaml
-  apiVersion: kubeproxy.config.k8s.io/v1alpha1
-  kind: KubeProxyConfiguration
-    ...
-  ```
-
-The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances deployed
-in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
-
-See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or
+is executed, including:</p>
+<ul>
+<li>
+<p><code>nodeRegistration</code>, that holds fields that relate to registering the new node to the cluster;
+use it to customize the node name, the CRI socket to use or any other settings that should apply to this
+node only (e.g. the node ip).</p>
+</li>
+<li>
+<p><code>apiServer</code>, that represents the endpoint of the instance of the API server to be deployed on this node;
+use it e.g. to customize the API server advertise address.</p>
+</li>
+</ul>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta2<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>ClusterConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">networking</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>...<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">etcd</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>...<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiServer</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>...<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraVolumes</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>...<span style="color:#bbb">
+</span><span style="color:#bbb"></span>...<span style="color:#bbb">
+</span></pre><p>The ClusterConfiguration type should be used to configure cluster-wide settings,
+including settings for:</p>
+<ul>
+<li>
+<p>Networking, that holds configuration for the networking topology of the cluster; use it e.g. to customize
+pod subnet or services subnet.</p>
+</li>
+<li>
+<p>Etcd configurations; use it e.g. to customize the local etcd or to configure the API server
+for using an external etcd cluster.</p>
+</li>
+<li>
+<p>kube-apiserver, kube-scheduler, kube-controller-manager configurations; use it to customize control-plane
+components by adding customized setting or overriding kubeadm default settings.</p>
+</li>
+</ul>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeproxy.config.k8s.io/v1alpha1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeProxyConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span></pre><p>The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances deployed
+in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.</p>
+<p>See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or
 https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
-for kube proxy official documentation.
-
-```yaml
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-  ...
-```
-
-The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
-deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
-
-See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or
+for kube proxy official documentation.</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeletConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span></pre><p>The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
+deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.</p>
+<p>See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or
 https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
-for kubelet official documentation.
-
-Here is a fully populated example of a single YAML file containing multiple
-configuration types to be used during a `kubeadm init` run.
-
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: InitConfiguration
-bootstrapTokens:
-  - token: "9a08jv.c0izixklcxtmnze7"
-    description: "kubeadm bootstrap token"
-    ttl: "24h"
-  - token: "783bde.3f89s0fje9f38fhf"
-    description: "another bootstrap token"
-    usages:
-      - authentication
-      - signing
-    groups:
-      - system:bootstrappers:kubeadm:default-node-token
-nodeRegistration:
-  name: "ec2-10-100-0-1"
-  criSocket: "/var/run/dockershim.sock"
-  taints:
-    - key: "kubeadmNode"
-      value: "master"
-      effect: "NoSchedule"
-  kubeletExtraArgs:
-    v: 4
-  ignorePreflightErrors:
-    - IsPrivilegedUser
-localAPIEndpoint:
-  advertiseAddress: "10.100.0.1"
-  bindPort: 6443
-certificateKey: "e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204"
----
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: ClusterConfiguration
-etcd:
-  # one of local or external
-local:
-  imageRepository: "k8s.gcr.io"
-  imageTag: "3.2.24"
-  dataDir: "/var/lib/etcd"
-  extraArgs:
-    listen-client-urls: "http://10.100.0.1:2379"
-  serverCertSANs:
-    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
-  peerCertSANs:
-    - "10.100.0.1"
-# external:
-#   endpoints:
-#     - "10.100.0.1:2379"
-#     - "10.100.0.2:2379"
-#   caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
-#   certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
-#   keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
-networking:
-  serviceSubnet: "10.96.0.0/16"
-  podSubnet: "10.244.0.0/24"
-  dnsDomain: "cluster.local"
-kubernetesVersion: "v1.12.0"
-controlPlaneEndpoint: "10.100.0.1:6443"
-apiServer:
-  extraArgs:
-    authorization-mode: "Node,RBAC"
-  extraVolumes:
-    - name: "some-volume"
-      hostPath: "/etc/some-path"
-      mountPath: "/etc/some-pod-path"
-      readOnly: false
-      pathType: File
-  certSANs:
-    - "10.100.1.1"
-    - "ec2-10-100-0-1.compute-1.amazonaws.com"
-  timeoutForControlPlane: 4m0s
-controllerManager:
-  extraArgs:
-    "node-cidr-mask-size": "20"
-  extraVolumes:
-    - name: "some-volume"
-      hostPath: "/etc/some-path"
-      mountPath: "/etc/some-pod-path"
-      readOnly: false
-      pathType: File
-scheduler:
-  extraArgs:
-    address: "10.100.0.1"
-  extraVolumes:
-    - name: "some-volume"
-      hostPath: "/etc/some-path"
-      mountPath: "/etc/some-pod-path"
-      readOnly: false
-      pathType: File
-certificatesDir: "/etc/kubernetes/pki"
-imageRepository: "k8s.gcr.io"
-useHyperKubeImage: false
-clusterName: "example-cluster"
----
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-# kubelet specific options here
----
-apiVersion: kubeproxy.config.k8s.io/v1alpha1
-kind: KubeProxyConfiguration
-# kube-proxy specific options here
-```
-
-## Kubeadm join configuration types
-
-When executing kubeadm join with the `--config` option, the JoinConfiguration type should be provided.
-
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: JoinConfiguration
-  ...
-```
-
-The JoinConfiguration type should be used to configure runtime settings, that in case of `kubeadm join`
+for kubelet official documentation.</p>
+<p>Here is a fully populated example of a single YAML file containing multiple
+configuration types to be used during a <code>kubeadm init</code> run.</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta2<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>InitConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">bootstrapTokens</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- <span style="color:#000;font-weight:bold">token</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;9a08jv.c0izixklcxtmnze7&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">description</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;kubeadm bootstrap token&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">ttl</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;24h&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- <span style="color:#000;font-weight:bold">token</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;783bde.3f89s0fje9f38fhf&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">description</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;another bootstrap token&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">usages</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">      </span>- authentication<span style="color:#bbb">
+</span><span style="color:#bbb">      </span>- signing<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">groups</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">      </span>- system:bootstrappers:kubeadm:default-node-token<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">nodeRegistration</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">name</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;ec2-10-100-0-1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">criSocket</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/var/run/dockershim.sock&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">taints</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- <span style="color:#000;font-weight:bold">key</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;kubeadmNode&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">value</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;master&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">effect</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;NoSchedule&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">kubeletExtraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">v</span>:<span style="color:#bbb"> </span><span style="color:#099">4</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">ignorePreflightErrors</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- IsPrivilegedUser<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">localAPIEndpoint</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">advertiseAddress</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.100.0.1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">bindPort</span>:<span style="color:#bbb"> </span><span style="color:#099">6443</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">certificateKey</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span>---<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta2<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>ClusterConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">etcd</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># one of local or external</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">local</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageTag</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;3.2.24&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">dataDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/var/lib/etcd&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">listen-client-urls</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;http://10.100.0.1:2379&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">serverCertSANs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">      </span>- <span style="color:#bbb"> </span><span style="color:#d14">&#34;ec2-10-100-0-1.compute-1.amazonaws.com&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">peerCertSANs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">      </span>- <span style="color:#d14">&#34;10.100.0.1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># external:</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic">#   endpoints:</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic">#     - &#34;10.100.0.1:2379&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic">#     - &#34;10.100.0.2:2379&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic">#   caFile: &#34;/etcd/kubernetes/pki/etcd/etcd-ca.crt&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic">#   certFile: &#34;/etcd/kubernetes/pki/etcd/etcd.crt&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic">#   keyFile: &#34;/etcd/kubernetes/pki/etcd/etcd.key&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">networking</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">serviceSubnet</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.96.0.0/16&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">podSubnet</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.244.0.0/24&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">dnsDomain</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;cluster.local&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kubernetesVersion</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;v1.12.0&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">controlPlaneEndpoint</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.100.0.1:6443&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiServer</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">authorization-mode</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;Node,RBAC&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraVolumes</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- <span style="color:#000;font-weight:bold">name</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;some-volume&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">hostPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">mountPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-pod-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">certSANs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- <span style="color:#d14">&#34;10.100.1.1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- <span style="color:#d14">&#34;ec2-10-100-0-1.compute-1.amazonaws.com&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">timeoutForControlPlane</span>:<span style="color:#bbb"> </span>4m0s<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">controllerManager</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">&#34;node-cidr-mask-size&#34;: </span><span style="color:#d14">&#34;20&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraVolumes</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- <span style="color:#000;font-weight:bold">name</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;some-volume&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">hostPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">mountPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-pod-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">scheduler</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">address</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.100.0.1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraVolumes</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- <span style="color:#000;font-weight:bold">name</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;some-volume&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">hostPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">mountPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-pod-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">certificatesDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/kubernetes/pki&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">useHyperKubeImage</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">clusterName</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;example-cluster&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span>---<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeletConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#998;font-style:italic"># kubelet specific options here</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span>---<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeproxy.config.k8s.io/v1alpha1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeProxyConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#998;font-style:italic"># kube-proxy specific options here</span><span style="color:#bbb">
+</span></pre><h2>Kubeadm join configuration types</h2>
+<p>When executing kubeadm join with the <code>--config</code> option, the JoinConfiguration type should be provided.</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta2<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>JoinConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span></pre><p>The JoinConfiguration type should be used to configure runtime settings, that in case of <code>kubeadm join</code>
 are the discovery method used for accessing the cluster info and all the setting which are specific
-to the node where kubeadm is executed, including:
+to the node where kubeadm is executed, including:</p>
+<ul>
+<li>
+<p><code>NodeRegistration</code>, that holds fields that relate to registering the new node to the cluster;
+use it to customize the node name, the CRI socket to use or any other settings that should apply to this
+node only (e.g. the node IP).</p>
+</li>
+<li>
+<p><code>APIEndpoint</code>, that represents the endpoint of the instance of the API server to be eventually deployed on this node.</p>
+</li>
+</ul>
 
-- `NodeRegistration`, that holds fields that relate to registering the new node to the cluster;
-  use it to customize the node name, the CRI socket to use or any other settings that should apply to this
-  node only (e.g. the node IP).
-
-- `APIEndpoint`, that represents the endpoint of the instance of the API server to be eventually deployed on this node.
 
 ## Resource Types 
 
@@ -289,14 +254,12 @@ to the node where kubeadm is executed, including:
   
     
 
-
 ## `ClusterConfiguration`     {#kubeadm-k8s-io-v1beta2-ClusterConfiguration}
     
 
 
+<p>ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster</p>
 
-
-ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -305,141 +268,129 @@ ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>ClusterConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>etcd</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-Etcd"><code>Etcd</code></a>
 </td>
 <td>
-   Etcd holds configuration for etcd.</td>
+   <p><code>etcd</code> holds configuration for etcd.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>networking</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-Networking"><code>Networking</code></a>
 </td>
 <td>
-   Networking holds configuration for the networking topology of the cluster.</td>
+   <p><code>networking</code> holds configuration for the networking topology of the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubernetesVersion</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   KubernetesVersion is the target version of the control plane.</td>
+   <p><code>kubernetesVersion</code> is the target version of the control plane.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>controlPlaneEndpoint</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+   <p><code>controlPlaneEndpoint</code> sets a stable IP address or DNS name for the control plane; it
 can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
-In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
-are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
-the BindPort is used.
-Possible usages are:
-e.g. In a cluster with more than one control plane instances, this field should be
+In case the <code>controlPlaneEndpoint</code> is not specified, the <code>advertiseAddress</code> + <code>bindPort</code>
+are used; in case the <code>controlPlaneEndpoint</code> is specified but without a TCP port,
+the <code>bindPort</code> is used.
+Possible usages are:</p>
+<ul>
+<li>In a cluster with more than one control plane instances, this field should be
 assigned the address of the external load balancer in front of the
-control plane instances.
-e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
-could be used for assigning a stable DNS to the control plane.</td>
+control plane instances.</li>
+<li>In environments with enforced node recycling, the <code>controlPlaneEndpoint</code>
+could be used for assigning a stable DNS to the control plane.</li>
+</ul>
+</td>
 </tr>
-    
-  
 <tr><td><code>apiServer</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-APIServer"><code>APIServer</code></a>
 </td>
 <td>
-   APIServer contains extra settings for the API server control plane component</td>
+   <p><code>apiServer</code> contains extra settings for the API server.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>controllerManager</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
 </td>
 <td>
-   ControllerManager contains extra settings for the controller manager control plane component</td>
+   <p><code>controllerManager</code> contains extra settings for the controller manager.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>scheduler</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
 </td>
 <td>
-   Scheduler contains extra settings for the scheduler control plane component</td>
+   <p><code>scheduler</code> contains extra settings for the scheduler.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>dns</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-DNS"><code>DNS</code></a>
 </td>
 <td>
-   DNS defines the options for the DNS add-on installed in the cluster.</td>
+   <p><code>dns</code> defines the options for the DNS add-on installed in the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certificatesDir</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CertificatesDir specifies where to store or look for all required certificates.</td>
+   <p><code>certificatesDir</code> specifies where to store or look for all required certificates.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>imageRepository</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ImageRepository sets the container registry to pull images from.
-If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/`)
-`gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
-will be used for all the other images.</td>
+   <p><code>mageRepository</code> sets the container registry to pull images from.
+If empty, <code>k8s.gcr.io</code> will be used by default; in case of kubernetes version is
+a CI build (kubernetes version starts with <code>ci/</code>) <code>gcr.io/k8s-staging-ci-images</code>
+is used as a default for control plane components and for kube-proxy, while
+<code>k8s.gcr.io</code> will be used for all the other images.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>useHyperKubeImage</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images
-DEPRECATED: As hyperkube is itself deprecated, this fields is too. It will be removed in future kubeadm config versions, kubeadm
-will print multiple warnings when set to true, and at some point it may become ignored.</td>
+   <p><code>useHyperKubeImage</code> controls if hyperkube should be used for Kubernetes components
+instead of their respective separate images.
+DEPRECATED: As <code>hyperkube</code> is itself deprecated, this fields is too. It will be
+removed in future kubeadm config versions, kubeadm will print multiple warnings
+when this set to true, and at some point it may become ignored.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>featureGates</code> <B>[Required]</B><br/>
 <code>map[string]bool</code>
 </td>
 <td>
-   FeatureGates enabled by the user.</td>
+   <p><code>featureGates</code> contains the feature gates enabled by the user.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clusterName</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   The cluster name</td>
+   <p>The cluster name.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ClusterStatus`     {#kubeadm-k8s-io-v1beta2-ClusterStatus}
     
 
 
+<p>ClusterStatus contains the cluster status. The ClusterStatus will be stored in
+the kubeadm-config ConfigMap in the cluster, and then updated by kubeadm when
+additional control plane instance joins or leaves the cluster.</p>
 
-
-ClusterStatus contains the cluster status. The ClusterStatus will be stored in the kubeadm-config
-ConfigMap in the cluster, and then updated by kubeadm when additional control plane instance joins or leaves the cluster.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -448,31 +399,26 @@ ConfigMap in the cluster, and then updated by kubeadm when additional control pl
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>ClusterStatus</code></td></tr>
     
-
-  
   
 <tr><td><code>apiEndpoints</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-APIEndpoint"><code>map[string]github.com/tengqm/kubeconfig/config/kubeadm/v1beta2.APIEndpoint</code></a>
 </td>
 <td>
-   APIEndpoints currently available in the cluster, one for each control plane/api server instance.
-The key of the map is the IP of the host's default interface</td>
+   <p><code>apiEndpoints</code> currently available in the cluster, one for each control
+plane/API server instance.
+The key of the map is the IP of the host's default interface.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `InitConfiguration`     {#kubeadm-k8s-io-v1beta2-InitConfiguration}
     
 
 
+<p>InitConfiguration contains a list of elements that is specific &quot;kubeadm init&quot;-only runtime
+information.</p>
 
-
-InitConfiguration contains a list of elements that is specific "kubeadm init"-only runtime
-information.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -481,60 +427,51 @@ information.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>InitConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>bootstrapTokens</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-BootstrapToken"><code>[]BootstrapToken</code></a>
 </td>
 <td>
-   BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
-This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature</td>
+   <p><code>bootstrapTokens</code> is respected at <code>kubeadm init</code> time and describes a set of bootstrap tokens to create.
+This information IS NOT uploaded to the kubeadm cluster ConfigMap, partly because of its sensitive nature.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodeRegistration</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-NodeRegistrationOptions"><code>NodeRegistrationOptions</code></a>
 </td>
 <td>
-   NodeRegistration holds fields that relate to registering the new control-plane node to the cluster</td>
+   <p><code>nodeRegistration</code> holds fields that relate to registering the new control-plane node to the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>localAPIEndpoint</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-APIEndpoint"><code>APIEndpoint</code></a>
 </td>
 <td>
-   LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
-In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
-is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+   <p><code>localAPIEndpoint</code> represents the endpoint of the API server instance that's deployed on this control plane node.
+In HA setups, this differs from <code>ClusterConfiguration.controlPlaneEndpoint</code> in the sense that ControlPlaneEndpoint
+is the global endpoint for the cluster, which then load-balances the requests to each individual API server. This
 configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
 on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
-fails you may set the desired value here.</td>
+fails you may set the desired value here.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certificateKey</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CertificateKey sets the key with which certificates and keys are encrypted prior to being uploaded in
-a secret in the cluster during the uploadcerts init phase.</td>
+   <p><code>certificateKey</code> sets the key with which certificates and keys are encrypted prior to being uploaded in
+a secret in the cluster during the <code>uploadcerts init</code> phase.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `JoinConfiguration`     {#kubeadm-k8s-io-v1beta2-JoinConfiguration}
     
 
 
+<p>JoinConfiguration contains elements describing a particular node.</p>
 
-
-JoinConfiguration contains elements describing a particular node.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -543,53 +480,45 @@ JoinConfiguration contains elements describing a particular node.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta2</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>JoinConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>nodeRegistration</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-NodeRegistrationOptions"><code>NodeRegistrationOptions</code></a>
 </td>
 <td>
-   NodeRegistration holds fields that relate to registering the new control-plane node to the cluster</td>
+   <p><code>nodeRegistration</code> holds fields that relate to registering the new
+control-plane node to the cluster</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caCertPath</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CACertPath is the path to the SSL certificate authority used to
-secure comunications between node and control-plane.
-Defaults to "/etc/kubernetes/pki/ca.crt".</td>
+   <p><code>caCertPath</code> is the path to the SSL certificate authority used to
+secure comunications between a node and the control-plane.
+Defaults to &quot;/etc/kubernetes/pki/ca.crt&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>discovery</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-Discovery"><code>Discovery</code></a>
 </td>
 <td>
-   Discovery specifies the options for the kubelet to use during the TLS Bootstrap process</td>
+   <p><code>discovery</code> specifies the options for the kubelet to use during the TLS
+bootstrap process.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>controlPlane</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-JoinControlPlane"><code>JoinControlPlane</code></a>
 </td>
 <td>
-   ControlPlane defines the additional control plane instance to be deployed on the joining node.
-If nil, no additional control plane instance will be deployed.</td>
+   <p><code>controlPlane</code> defines the additional control plane instance to be deployed
+on the joining node. If nil, no additional control plane instance will be deployed.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `APIEndpoint`     {#kubeadm-k8s-io-v1beta2-APIEndpoint}
     
-
-
 
 **Appears in:**
 
@@ -600,273 +529,232 @@ If nil, no additional control plane instance will be deployed.</td>
 - [JoinControlPlane](#kubeadm-k8s-io-v1beta2-JoinControlPlane)
 
 
-APIEndpoint struct contains elements of API server instance deployed on a node.
+<p>APIEndpoint struct contains elements of API server instance deployed on a node.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>advertiseAddress</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   AdvertiseAddress sets the IP address for the API server to advertise.</td>
+   <p><code>advertiseAddress</code> sets the IP address for the API server to advertise.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>bindPort</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   BindPort sets the secure port for the API Server to bind to.
-Defaults to 6443.</td>
+   <p><code>bindPort</code> sets the secure port for the API Server to bind to.
+Defaults to 6443.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `APIServer`     {#kubeadm-k8s-io-v1beta2-APIServer}
     
-
-
 
 **Appears in:**
 
 - [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
 
 
-APIServer holds settings necessary for API server deployments in the cluster
+<p>APIServer holds settings necessary for API server deployments in the cluster.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>ControlPlaneComponent</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
 </td>
 <td>(Members of <code>ControlPlaneComponent</code> are embedded into this type.)
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>certSANs</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   CertSANs sets extra Subject Alternative Names for the API Server signing cert.</td>
+   <p><code>certSANs</code> sets extra Subject Alternative Names (SANs) for the API Server
+signing certificate.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>timeoutForControlPlane</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   TimeoutForControlPlane controls the timeout that we use for API server to appear</td>
+   <p><code>timeoutForControlPlane</code> controls the timeout that we wait for the API server
+to appear.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `BootstrapToken`     {#kubeadm-k8s-io-v1beta2-BootstrapToken}
     
-
-
 
 **Appears in:**
 
 - [InitConfiguration](#kubeadm-k8s-io-v1beta2-InitConfiguration)
 
 
-BootstrapToken describes one bootstrap token, stored as a Secret in the cluster
+<p>BootstrapToken describes one bootstrap token, stored as a Secret in the cluster</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>token</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-BootstrapTokenString"><code>BootstrapTokenString</code></a>
 </td>
 <td>
-   Token is used for establishing bidirectional trust between nodes and control-planes.
-Used for joining nodes in the cluster.</td>
+   <p><code>token</code> is used for establishing bidirectional trust between nodes and control-planes.
+Used for joining nodes in the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>description</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Description sets a human-friendly message why this token exists and what it's used
-for, so other administrators can know its purpose.</td>
+   <p><code>description</code> sets a human-friendly message why this token exists and what it's used
+for, so other administrators can know its purpose.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ttl</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   TTL defines the time to live for this token. Defaults to 24h.
-Expires and TTL are mutually exclusive.</td>
+   <p><code>ttl</code> defines the time to live for this token. Defaults to '24h'.
+<code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>expires</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
-   Expires specifies the timestamp when this token expires. Defaults to being set
-dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.</td>
+   <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
+dynamically at runtime based on the <code>ttl</code>. <code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>usages</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   Usages describes the ways in which this token can be used. Can by default be used
-for establishing bidirectional trust, but that can be changed here.</td>
+   <p><code>usages</code> describes the ways in which this token can be used. Can by default be used
+for establishing bidirectional trust, but that can be changed here.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>groups</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   Groups specifies the extra groups that this token will authenticate as when/if
-used for authentication</td>
+   <p><code>groups</code> specifies the extra groups that this token will authenticate as when/if
+used for authentication.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `BootstrapTokenDiscovery`     {#kubeadm-k8s-io-v1beta2-BootstrapTokenDiscovery}
     
-
-
 
 **Appears in:**
 
 - [Discovery](#kubeadm-k8s-io-v1beta2-Discovery)
 
 
-BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery
+<p>BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>token</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Token is a token used to validate cluster information
-fetched from the control-plane.</td>
+   <p><code>token</code> is a token used to validate cluster information fetched from
+the control-plane.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>apiServerEndpoint</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.</td>
+   <p><code>apiServerEndpoint</code> is an IP or domain name to the API server from which information
+will be fetched.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caCertHashes</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   CACertHashes specifies a set of public key pins to verify
-when token-based discovery is used. The root CA found during discovery
-must match one of these values. Specifying an empty set disables root CA
-pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
-where the only currently supported type is "sha256". This is a hex-encoded
-SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
-ASN.1. These hashes can be calculated using, for example, OpenSSL.</td>
+   <p><code>caCertHashes</code> specifies a set of public key pins to verify when token-based discovery
+is used. The root CA found during discovery must match one of these values.
+Specifying an empty set disables root CA pinning, which can be unsafe.
+Each hash is specified as &quot;<!-- raw HTML omitted -->:<!-- raw HTML omitted -->&quot;, where the only currently supported type is &quot;sha256&quot;.
+This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in
+DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>unsafeSkipCAVerification</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   UnsafeSkipCAVerification allows token-based discovery
-without CA verification via CACertHashes. This can weaken
-the security of kubeadm since other nodes can impersonate the control-plane.</td>
+   <p><code>unsafeSkipCAVerification</code> allows token-based discovery without CA verification via
+<code>caCertHashes</code>. This can weaken the security of kubeadm since other nodes can
+impersonate the control-plane.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `BootstrapTokenString`     {#kubeadm-k8s-io-v1beta2-BootstrapTokenString}
     
-
-
 
 **Appears in:**
 
 - [BootstrapToken](#kubeadm-k8s-io-v1beta2-BootstrapToken)
 
 
-BootstrapTokenString is a token of the format abcdef.abcdef0123456789 that is used
+<p>BootstrapTokenString is a token of the format abcdef.abcdef0123456789 that is used
 for both validation of the practically of the API server from a joining node's point
 of view and as an authentication method for the node in the bootstrap phase of
-"kubeadm join". This token is and should be short-lived
+&quot;kubeadm join&quot;. This token is and should be short-lived</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>-</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>-</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ControlPlaneComponent`     {#kubeadm-k8s-io-v1beta2-ControlPlaneComponent}
     
-
-
 
 **Appears in:**
 
@@ -875,353 +763,302 @@ of view and as an authentication method for the node in the bootstrap phase of
 - [APIServer](#kubeadm-k8s-io-v1beta2-APIServer)
 
 
-ControlPlaneComponent holds settings common to control plane component of the cluster
+<p>ControlPlaneComponent holds settings common to control plane component of the cluster</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>extraArgs</code> <B>[Required]</B><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   ExtraArgs is an extra set of flags to pass to the control plane component.
-A key in this map is the flag name as it appears on the
-command line except without leading dash(es).
-TODO: This is temporary and ideally we would like to switch all components to
-use ComponentConfig + ConfigMaps.</td>
+   <p><code>extraArgs</code> is an extra set of flags to pass to a control plane component.
+A key in this map is the flag name as it appears on the command line except
+without leading dash(es).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>extraVolumes</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-HostPathMount"><code>[]HostPathMount</code></a>
 </td>
 <td>
-   ExtraVolumes is an extra set of host volumes, mounted to the control plane component.</td>
+   <p><code>extraVolumes</code> is an extra set of host volumes mounted to the control plane
+component.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `DNS`     {#kubeadm-k8s-io-v1beta2-DNS}
     
-
-
 
 **Appears in:**
 
 - [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
 
 
-DNS defines the DNS addon that should be used in the cluster
+<p>DNS defines the DNS addon that should be used in the cluster</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>type</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-DNSAddOnType"><code>DNSAddOnType</code></a>
 </td>
 <td>
-   Type defines the DNS add-on to be used</td>
+   <p><code>type</code> defines the DNS add-on to be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ImageMeta</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-ImageMeta"><code>ImageMeta</code></a>
 </td>
 <td>(Members of <code>ImageMeta</code> are embedded into this type.)
-   ImageMeta allows to customize the image used for the DNS component</td>
+   <p>ImageMeta allows to customize the image used for the DNS component</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `DNSAddOnType`     {#kubeadm-k8s-io-v1beta2-DNSAddOnType}
     
 (Alias of `string`)
-
 
 **Appears in:**
 
 - [DNS](#kubeadm-k8s-io-v1beta2-DNS)
 
 
-DNSAddOnType defines string identifying DNS add-on types
+<p>DNSAddOnType defines string identifying DNS add-on types.</p>
 
 
-    
 
 
 ## `Discovery`     {#kubeadm-k8s-io-v1beta2-Discovery}
     
-
-
 
 **Appears in:**
 
 - [JoinConfiguration](#kubeadm-k8s-io-v1beta2-JoinConfiguration)
 
 
-Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+<p>Discovery specifies the options for the kubelet to use during the TLS Bootstrap process</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>bootstrapToken</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-BootstrapTokenDiscovery"><code>BootstrapTokenDiscovery</code></a>
 </td>
 <td>
-   BootstrapToken is used to set the options for bootstrap token based discovery
-BootstrapToken and File are mutually exclusive</td>
+   <p><code>bootstrapToken</code> is used to set the options for bootstrap token based discovery.
+<code>bootstrapToken</code> and <code>file</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>file</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-FileDiscovery"><code>FileDiscovery</code></a>
 </td>
 <td>
-   File is used to specify a file or URL to a kubeconfig file from which to load cluster information
-BootstrapToken and File are mutually exclusive</td>
+   <p><code>file</code> is used to specify a file or URL to a kubeconfig file from which to load
+cluster information.
+<code>bootstrapToken</code> and <code>file</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tlsBootstrapToken</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   TLSBootstrapToken is a token used for TLS bootstrapping.
-If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
-If .File is set, this field &lowast;&lowast;must be set&lowast;&lowast; in case the KubeConfigFile does not contain any other authentication information</td>
+   <p><code>tlsBootstrapToken</code> is a token used for TLS bootstrapping.
+If <code>bootstrapToken</code> is set, this field is defaulted to <code>.bootstrapToken.token, but can be overridden. If </code>file` is set, this field <strong>must be set</strong> in case the KubeConfigFile does not
+contain any other authentication information.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>timeout</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   Timeout modifies the discovery timeout</td>
+   <p><code>timeout</code> modifies the discovery timeout.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Etcd`     {#kubeadm-k8s-io-v1beta2-Etcd}
     
-
-
 
 **Appears in:**
 
 - [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
 
 
-Etcd contains elements describing Etcd configuration.
+<p>Etcd contains elements describing Etcd configuration.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>local</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-LocalEtcd"><code>LocalEtcd</code></a>
 </td>
 <td>
-   Local provides configuration knobs for configuring the local etcd instance
-Local and External are mutually exclusive</td>
+   <p><code>local</code> provides configuration knobs for configuring the local etcd instance.
+<code>local</code> and <code>external</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>external</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-ExternalEtcd"><code>ExternalEtcd</code></a>
 </td>
 <td>
-   External describes how to connect to an external etcd cluster
-Local and External are mutually exclusive</td>
+   <p><code>external</code> describes how to connect to an external etcd cluster.
+<code>local</code> and <code>external</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExternalEtcd`     {#kubeadm-k8s-io-v1beta2-ExternalEtcd}
     
-
-
 
 **Appears in:**
 
 - [Etcd](#kubeadm-k8s-io-v1beta2-Etcd)
 
 
-ExternalEtcd describes an external etcd cluster.
-Kubeadm has no knowledge of where certificate files live and they must be supplied.
+<p>ExternalEtcd describes an external etcd cluster.
+Kubeadm has no knowledge of where certificate files live and they must be supplied.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>endpoints</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   Endpoints of etcd members. Required for ExternalEtcd.</td>
+   <p><code>endpoints</code> of etcd members.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CAFile is an SSL Certificate Authority file used to secure etcd communication.
-Required if using a TLS connection.</td>
+   <p><code>caFile</code> is an SSL Certificate Authority (CA) file used to secure etcd communication.
+Required if using a TLS connection.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CertFile is an SSL certification file used to secure etcd communication.
-Required if using a TLS connection.</td>
+   <p><code>certFile</code> is an SSL certification file used to secure etcd communication.
+Required if using a TLS connection.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>keyFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   KeyFile is an SSL key file used to secure etcd communication.
-Required if using a TLS connection.</td>
+   <p><code>keyFile</code> is an SSL key file used to secure etcd communication.
+Required if using a TLS connection.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `FileDiscovery`     {#kubeadm-k8s-io-v1beta2-FileDiscovery}
     
-
-
 
 **Appears in:**
 
 - [Discovery](#kubeadm-k8s-io-v1beta2-Discovery)
 
 
-FileDiscovery is used to specify a file or URL to a kubeconfig file from which to load cluster information
+<p>FileDiscovery is used to specify a file or URL to a kubeconfig file from which to load cluster information</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>kubeConfigPath</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information</td>
+   <p><code>kubeConfigPath</code> is used to specify the actual file path or URL to the kubeconfig file
+from which to load cluster information.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `HostPathMount`     {#kubeadm-k8s-io-v1beta2-HostPathMount}
     
-
-
 
 **Appears in:**
 
 - [ControlPlaneComponent](#kubeadm-k8s-io-v1beta2-ControlPlaneComponent)
 
 
-HostPathMount contains elements describing volumes that are mounted from the
-host.
+<p>HostPathMount contains elements describing volumes that are mounted from the host.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name of the volume inside the pod template.</td>
+   <p><code>name</code> of the volume inside the Pod template.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>hostPath</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   HostPath is the path in the host that will be mounted inside
-the pod.</td>
+   <p><code>hostPath</code> is the path in the host that will be mounted inside the Pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>mountPath</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   MountPath is the path inside the pod where hostPath will be mounted.</td>
+   <p><code>mountPath</code>is the path inside the Pod where hostPath volume will be mounted.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>readOnly</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   ReadOnly controls write access to the volume</td>
+   <p><code>readOnly</code> controls write access to the volume.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>pathType</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
 </td>
 <td>
-   PathType is the type of the HostPath.</td>
+   <p><code>pathType</code> is the type of the HostPath.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ImageMeta`     {#kubeadm-k8s-io-v1beta2-ImageMeta}
     
-
-
 
 **Appears in:**
 
@@ -1230,196 +1067,174 @@ the pod.</td>
 - [LocalEtcd](#kubeadm-k8s-io-v1beta2-LocalEtcd)
 
 
-ImageMeta allows to customize the image used for components that are not
-originated from the Kubernetes/Kubernetes release process
+<p>ImageMeta allows to customize the image used for components that are not
+originated from the Kubernetes/Kubernetes release process</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>imageRepository</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ImageRepository sets the container registry to pull images from.
-if not set, the ImageRepository defined in ClusterConfiguration will be used instead.</td>
+   <p><code>mageRepository</code> sets the container registry to pull images from.
+If not set, the <code>imageRepository</code> defined in ClusterConfiguration will be used.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>imageTag</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ImageTag allows to specify a tag for the image.
-In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.</td>
+   <p><code>imageTag</code> allows for specifying a tag for the image.
+In case this value is set, kubeadm does not change automatically the
+version of the above components during upgrades.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `JoinControlPlane`     {#kubeadm-k8s-io-v1beta2-JoinControlPlane}
     
-
-
 
 **Appears in:**
 
 - [JoinConfiguration](#kubeadm-k8s-io-v1beta2-JoinConfiguration)
 
 
-JoinControlPlane contains elements describing an additional control plane instance to be deployed on the joining node.
+<p>JoinControlPlane contains elements describing an additional control plane instance
+to be deployed on the joining node.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>localAPIEndpoint</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-APIEndpoint"><code>APIEndpoint</code></a>
 </td>
 <td>
-   LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.</td>
+   <p><code>localAPIEndpoint</code> represents the endpoint of the API server instance
+to be deployed on this node.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certificateKey</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CertificateKey is the key that is used for decryption of certificates after they are downloaded from the secret
-upon joining a new control plane node. The corresponding encryption key is in the InitConfiguration.</td>
+   <p><code>certificateKey</code> is the key that is used for decryption of certificates after
+they are downloaded from the secret upon joining a new control plane node.
+The corresponding encryption key is in the InitConfiguration.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `LocalEtcd`     {#kubeadm-k8s-io-v1beta2-LocalEtcd}
     
-
-
 
 **Appears in:**
 
 - [Etcd](#kubeadm-k8s-io-v1beta2-Etcd)
 
 
-LocalEtcd describes that kubeadm should run an etcd cluster locally
+<p>LocalEtcd describes that kubeadm should run an etcd cluster locally.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>ImageMeta</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta2-ImageMeta"><code>ImageMeta</code></a>
 </td>
 <td>(Members of <code>ImageMeta</code> are embedded into this type.)
-   ImageMeta allows to customize the container used for etcd</td>
+   <p>ImageMeta allows to customize the container used for etcd.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>dataDir</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   DataDir is the directory etcd will place its data.
-Defaults to "/var/lib/etcd".</td>
+   <p><code>dataDir</code> is the directory etcd will place its data.
+Defaults to &quot;/var/lib/etcd&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>extraArgs</code> <B>[Required]</B><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   ExtraArgs are extra arguments provided to the etcd binary
-when run inside a static pod.
+   <p><code>extraArgs</code> are extra arguments provided to the etcd binary when run
+inside a static pod.
 A key in this map is the flag name as it appears on the
-command line except without leading dash(es).</td>
+command line except without leading dash(es).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>serverCertSANs</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.</td>
+   <p><code>serverCertSANs</code> sets extra Subject Alternative Names (SANs) for the
+etcd server signing certificate.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>peerCertSANs</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.</td>
+   <p><code>peerCertSANs</code> sets extra Subject Alternative Names (SANs) for the
+etcd peer signing certificate.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Networking`     {#kubeadm-k8s-io-v1beta2-Networking}
     
-
-
 
 **Appears in:**
 
 - [ClusterConfiguration](#kubeadm-k8s-io-v1beta2-ClusterConfiguration)
 
 
-Networking contains elements describing cluster's networking configuration
+<p>Networking contains elements describing cluster's networking configuration</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>serviceSubnet</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   ServiceSubnet is the subnet used by k8s services. Defaults to "10.96.0.0/12".</td>
+   <p><code>serviceSubnet</code> is the subnet used by kubernetes Services. Defaults to &quot;10.96.0.0/12&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podSubnet</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   PodSubnet is the subnet used by pods.</td>
+   <p><code>podSubnet</code> is the subnet used by Pods.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>dnsDomain</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".</td>
+   <p><code>dnsDomain</code> is the DNS domain used by kubernetes Services. Defaults to &quot;cluster.local&quot;.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeRegistrationOptions`     {#kubeadm-k8s-io-v1beta2-NodeRegistrationOptions}
     
-
-
 
 **Appears in:**
 
@@ -1428,63 +1243,66 @@ Networking contains elements describing cluster's networking configuration
 - [JoinConfiguration](#kubeadm-k8s-io-v1beta2-JoinConfiguration)
 
 
-NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either via "kubeadm init" or "kubeadm join"
+<p>NodeRegistrationOptions holds fields that relate to registering a new control-plane
+or node to the cluster, either via &quot;kubeadm init&quot; or &quot;kubeadm join&quot;.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
-This field is also used in the CommonName field of the kubelet's client certificate to the API server.
-Defaults to the hostname of the node if not provided.</td>
+   <p><code>name</code> is the <code>.Metadata.Name</code> field of the Node API object that will be created
+in this <code>kubeadm init</code> or <code>kubeadm join</code> operation.
+This field is also used in the <code>CommonName</code> field of the kubelet's client certificate
+to the API server.
+Defaults to the hostname of the node if not provided.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>criSocket</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use</td>
+   <p>`criSocket is used to retrieve container runtime information. This information will
+be annotated to the Node API object, for later re-use.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>taints</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
-   Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
-it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
-empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.</td>
+   <p><code>taints</code> specifies the taints the Node API object should be registered with.
+If this field is unset, i.e. nil, in the <code>kubeadm init</code> process it will be defaulted to
+<code>'node-role.kubernetes.io/master=&quot;&quot;'</code>. If you don't want to taint your control-plane node,
+set this field to an empty list, i.e. <code>taints: []</code> in the YAML file. This field is
+solely used for Node registration.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubeletExtraArgs</code> <B>[Required]</B><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
-kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
-Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
-A key in this map is the flag name as it appears on the
-command line except without leading dash(es).</td>
+   <p><code>kubeletExtraArgs</code> passes through extra arguments to the kubelet. The arguments here are
+passed to the kubelet command line via the environment file kubeadm writes at runtime for
+the kubelet to source. This overrides the generic base-level configuration in the
+'kubelet-config-1.X' ConfigMap.
+Flags have higher priority when parsing. These values are local and specific to the node
+kubeadm is executing on.
+A key in this map is the flag name as it appears on the command line except without leading dash(es).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ignorePreflightErrors</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.</td>
+   <p><code>ignorePreflightErrors</code> provides a list of pre-flight errors to be ignored when the
+current node is registered.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   

--- a/genref/output/md/kubeadm-config.v1beta3.md
+++ b/genref/output/md/kubeadm-config.v1beta3.md
@@ -4,286 +4,256 @@ content_type: tool-reference
 package: kubeadm.k8s.io/v1beta3
 auto_generated: true
 ---
-## Overview
-
-Package v1beta3 defines the v1beta3 version of the kubeadm configuration file format.
-This version improves on the v1beta2 format by fixing some minor issues and adding a few new fields.
-
-A list of changes since v1beta2:
-
-- The deprecated "ClusterConfiguration.useHyperKubeImage" field has been removed.
-  Kubeadm no longer supports the hyperkube image.
-- The "ClusterConfiguration.DNS.Type" field has been removed since CoreDNS is the only supported
-  DNS server type by kubeadm.
-- Include "datapolicy" tags on the fields that hold secrets.
-  This would result in the field values to be omitted when API structures are printed with klog.
-- Add "InitConfiguration.SkipPhases", "JoinConfiguration.SkipPhases" to allow skipping
-  a list of phases during kubeadm init/join command execution.
-- Add "InitConfiguration.NodeRegistration.ImagePullPolicy" and "JoinConfiguration.NodeRegistration.ImagePullPolicy"
-  to allow specifying the images pull policy during kubeadm "init" and "join".
-  The value must be one of "Always", "Never" or "IfNotPresent".
-  "IfNotPresent" is the default, which has been the existing behavior prior to this addition.
-- Add "InitConfiguration.Patches.Directory", "JoinConfiguration.Patches.Directory" to allow
-  the user to configure a directory from which to take patches for components deployed by kubeadm.
-- Move the BootstrapToken&lowast; API and related utilities out of the "kubeadm" API group to a new group
-  "bootstraptoken". The kubeadm API version v1beta3 no longer contains the BootstrapToken&lowast; structures.
-
-Migration from old kubeadm config versions
-
-- kubeadm v1.15.x and newer can be used to migrate from v1beta1 to v1beta2.
-- kubeadm v1.22.x and newer no longer support v1beta1 and older APIs, but can be used to migrate v1beta2 to v1beta3.
-
-## Basics
-
-The preferred way to configure kubeadm is to pass an YAML configuration file with the `--config` option. Some of the
+<h2>Overview</h2>
+<p>Package v1beta3 defines the v1beta3 version of the kubeadm configuration file format.
+This version improves on the v1beta2 format by fixing some minor issues and adding a few new fields.</p>
+<p>A list of changes since v1beta2:</p>
+<ul>
+<li>The deprecated &quot;ClusterConfiguration.useHyperKubeImage&quot; field has been removed.
+Kubeadm no longer supports the hyperkube image.</li>
+<li>The &quot;ClusterConfiguration.DNS.Type&quot; field has been removed since CoreDNS is the only supported
+DNS server type by kubeadm.</li>
+<li>Include &quot;datapolicy&quot; tags on the fields that hold secrets.
+This would result in the field values to be omitted when API structures are printed with klog.</li>
+<li>Add &quot;InitConfiguration.SkipPhases&quot;, &quot;JoinConfiguration.SkipPhases&quot; to allow skipping
+a list of phases during kubeadm init/join command execution.</li>
+<li>Add &quot;InitConfiguration.NodeRegistration.ImagePullPolicy&quot; and &quot;JoinConfiguration.NodeRegistration.ImagePullPolicy&quot;
+to allow specifying the images pull policy during kubeadm &quot;init&quot; and &quot;join&quot;.
+The value must be one of &quot;Always&quot;, &quot;Never&quot; or &quot;IfNotPresent&quot;.
+&quot;IfNotPresent&quot; is the default, which has been the existing behavior prior to this addition.</li>
+<li>Add &quot;InitConfiguration.Patches.Directory&quot;, &quot;JoinConfiguration.Patches.Directory&quot; to allow
+the user to configure a directory from which to take patches for components deployed by kubeadm.</li>
+<li>Move the BootstrapToken&lowast; API and related utilities out of the &quot;kubeadm&quot; API group to a new group
+&quot;bootstraptoken&quot;. The kubeadm API version v1beta3 no longer contains the BootstrapToken&lowast; structures.</li>
+</ul>
+<p>Migration from old kubeadm config versions</p>
+<ul>
+<li>kubeadm v1.15.x and newer can be used to migrate from v1beta1 to v1beta2.</li>
+<li>kubeadm v1.22.x and newer no longer support v1beta1 and older APIs, but can be used to migrate v1beta2 to v1beta3.</li>
+</ul>
+<h2>Basics</h2>
+<p>The preferred way to configure kubeadm is to pass an YAML configuration file with the <code>--config</code> option. Some of the
 configuration options defined in the kubeadm config file are also available as command line flags, but only
-the most common/simple use case are supported with this approach.
-
-A kubeadm config file could contain multiple configuration types separated using three dashes (`---`).
-
-kubeadm supports the following configuration types:
-
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
-kind: InitConfiguration
-
-apiVersion: kubeadm.k8s.io/v1beta3
-kind: ClusterConfiguration
-
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-
-apiVersion: kubeproxy.config.k8s.io/v1alpha1
-kind: KubeProxyConfiguration
-
-apiVersion: kubeadm.k8s.io/v1beta3
-kind: JoinConfiguration
-```
-
-To print the defaults for "init" and "join" actions use the following commands:
-
-```shell
-kubeadm config print init-defaults
+the most common/simple use case are supported with this approach.</p>
+<p>A kubeadm config file could contain multiple configuration types separated using three dashes (<code>---</code>).</p>
+<p>kubeadm supports the following configuration types:</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta3<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>InitConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta3<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>ClusterConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeletConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeproxy.config.k8s.io/v1alpha1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeProxyConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta3<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>JoinConfiguration<span style="color:#bbb">
+</span></pre><p>To print the defaults for &quot;init&quot; and &quot;join&quot; actions use the following commands:</p>
+<pre style="background-color:#fff">kubeadm config print init-defaults
 kubeadm config print join-defaults
-```
-
-The list of configuration types that must be included in a configuration file depends by the action you are
-performing (`init` or `join`) and by the configuration options you are going to use (defaults or advanced
-customization).
-
-If some configuration types are not provided, or provided only partially, kubeadm will use default values; defaults
+</pre><p>The list of configuration types that must be included in a configuration file depends by the action you are
+performing (<code>init</code> or <code>join</code>) and by the configuration options you are going to use (defaults or advanced
+customization).</p>
+<p>If some configuration types are not provided, or provided only partially, kubeadm will use default values; defaults
 provided by kubeadm includes also enforcing consistency of values across components when required (e.g.
-`--cluster-cidr` flag on controller manager and `clusterCIDR` on kube-proxy).
-
-Users are always allowed to override default values, with the only exception of a small subset of setting with
-relevance for security (e.g. enforce authorization-mode Node and RBAC on api server)
-
-If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
-ignore those types and print a warning.
-
-## Kubeadm init configuration types
-
-When executing kubeadm init with the `--config` option, the following configuration types could be used:
+<code>--cluster-cidr</code> flag on controller manager and <code>clusterCIDR</code> on kube-proxy).</p>
+<p>Users are always allowed to override default values, with the only exception of a small subset of setting with
+relevance for security (e.g. enforce authorization-mode Node and RBAC on api server)</p>
+<p>If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
+ignore those types and print a warning.</p>
+<h2>Kubeadm init configuration types</h2>
+<p>When executing kubeadm init with the <code>--config</code> option, the following configuration types could be used:
 InitConfiguration, ClusterConfiguration, KubeProxyConfiguration, KubeletConfiguration, but only one
-between InitConfiguration and ClusterConfiguration is mandatory.
-
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
-kind: InitConfiguration
-bootstrapTokens:
-  ...
-nodeRegistration:
-  ...
-```
-
-The InitConfiguration type should be used to configure runtime settings, that in case of kubeadm init
+between InitConfiguration and ClusterConfiguration is mandatory.</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta3<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>InitConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">bootstrapTokens</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">nodeRegistration</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span></pre><p>The InitConfiguration type should be used to configure runtime settings, that in case of kubeadm init
 are the configuration of the bootstrap token and all the setting which are specific to the node where
-kubeadm is executed, including:
-
-- NodeRegistration, that holds fields that relate to registering the new node to the cluster;
-  use it to customize the node name, the CRI socket to use or any other settings that should apply to this
-  node only (e.g. the node ip).
-
-- LocalAPIEndpoint, that represents the endpoint of the instance of the API server to be deployed on this node;
-  use it e.g. to customize the API server advertise address.
-
-  ```
-  apiVersion: kubeadm.k8s.io/v1beta3
-  kind: ClusterConfiguration
-  networking:
-    ...
-  etcd:
-    ...
-  apiServer:
-    extraArgs:
-      ...
-    extraVolumes:
-      ...
-  ...
-  ```
-
-The ClusterConfiguration type should be used to configure cluster-wide settings,
-including settings for:
-
-- Networking, that holds configuration for the networking topology of the cluster; use it e.g. to customize
-  Pod subnet or services subnet.
-
-- Etcd configurations; use it e.g. to customize the local etcd or to configure the API server
-  for using an external etcd cluster.
-
-- kube-apiserver, kube-scheduler, kube-controller-manager configurations; use it to customize control-plane
-  components by adding customized setting or overriding kubeadm default settings.
-
-  ```yaml
-  apiVersion: kubeproxy.config.k8s.io/v1alpha1
-  kind: KubeProxyConfiguration
-    ...
-  ```
-
-The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances
-deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
-
-See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or
+kubeadm is executed, including:</p>
+<ul>
+<li>
+<p>NodeRegistration, that holds fields that relate to registering the new node to the cluster;
+use it to customize the node name, the CRI socket to use or any other settings that should apply to this
+node only (e.g. the node ip).</p>
+</li>
+<li>
+<p>LocalAPIEndpoint, that represents the endpoint of the instance of the API server to be deployed on this node;
+use it e.g. to customize the API server advertise address.</p>
+</li>
+</ul>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta3<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>ClusterConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">networking</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">etcd</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiServer</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>...<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraVolumes</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>...<span style="color:#bbb">
+</span><span style="color:#bbb"></span>...<span style="color:#bbb">
+</span></pre><p>The ClusterConfiguration type should be used to configure cluster-wide settings,
+including settings for:</p>
+<ul>
+<li>
+<p><code>networking</code> that holds configuration for the networking topology of the cluster; use it e.g. to customize
+Pod subnet or services subnet.</p>
+</li>
+<li>
+<p><code>etcd</code>: use it e.g. to customize the local etcd or to configure the API server
+for using an external etcd cluster.</p>
+</li>
+<li>
+<p>kube-apiserver, kube-scheduler, kube-controller-manager configurations; use it to customize control-plane
+components by adding customized setting or overriding kubeadm default settings.</p>
+</li>
+</ul>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeproxy.config.k8s.io/v1alpha1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeProxyConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span></pre><p>The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances
+deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.</p>
+<p>See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or
 https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
-for kube-proxy official documentation.
-
-```yaml
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-  ...
-```
-
-The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
-deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
-
-See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or
+for kube-proxy official documentation.</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeletConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span></pre><p>The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
+deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.</p>
+<p>See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or
 https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
-for kubelet official documentation.
-
-Here is a fully populated example of a single YAML file containing multiple
-configuration types to be used during a `kubeadm init` run.
-
-apiVersion: kubeadm.k8s.io/v1beta3
-kind: InitConfiguration
-bootstrapTokens:
-- token: "9a08jv.c0izixklcxtmnze7"
-  description: "kubeadm bootstrap token"
-  ttl: "24h"
-- token: "783bde.3f89s0fje9f38fhf"
-  description: "another bootstrap token"
-  usages:
-  - authentication
-  - signing
-  groups:
-  - system:bootstrappers:kubeadm:default-node-token
-nodeRegistration:
-  name: "ec2-10-100-0-1"
-  criSocket: "/var/run/dockershim.sock"
-  taints:
-  - key: "kubeadmNode"
-    value: "master"
-    effect: "NoSchedule"
-  kubeletExtraArgs:
-    v: 4
-ignorePreflightErrors:
-- IsPrivilegedUser
-   imagePullPolicy: "IfNotPresent"
-localAPIEndpoint:
-  advertiseAddress: "10.100.0.1"
-  bindPort: 6443
-certificateKey: "e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204"
- skipPhases:
- - addon/kube-proxy
----
-apiVersion: kubeadm.k8s.io/v1beta3
-kind: ClusterConfiguration
-etcd:
-  # one of local or external
-  local:
-    imageRepository: "k8s.gcr.io"
-    imageTag: "3.2.24"
-    dataDir: "/var/lib/etcd"
-    extraArgs:
-      listen-client-urls: "http://10.100.0.1:2379"
-    serverCertSANs:
-    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
-    peerCertSANs:
-    - "10.100.0.1"
-  # external:
-    # endpoints:
-    # - "10.100.0.1:2379"
-    # - "10.100.0.2:2379"
-    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
-    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
-    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
-networking:
-  serviceSubnet: "10.96.0.0/16"
-  podSubnet: "10.244.0.0/24"
-  dnsDomain: "cluster.local"
-kubernetesVersion: "v1.21.0"
-controlPlaneEndpoint: "10.100.0.1:6443"
-apiServer:
-  extraArgs:
-    authorization-mode: "Node,RBAC"
-  extraVolumes:
-  - name: "some-volume"
-    hostPath: "/etc/some-path"
-    mountPath: "/etc/some-pod-path"
-    readOnly: false
-    pathType: File
-  certSANs:
-  - "10.100.1.1"
-  - "ec2-10-100-0-1.compute-1.amazonaws.com"
-  timeoutForControlPlane: 4m0s
-controllerManager:
-  extraArgs:
-    "node-cidr-mask-size": "20"
-  extraVolumes:
-  - name: "some-volume"
-    hostPath: "/etc/some-path"
-    mountPath: "/etc/some-pod-path"
-    readOnly: false
-    pathType: File
-scheduler:
-  extraArgs:
-    address: "10.100.0.1"
-  extraVolumes:
-  - name: "some-volume"
-    hostPath: "/etc/some-path"
-    mountPath: "/etc/some-pod-path"
-    readOnly: false
-    pathType: File
-certificatesDir: "/etc/kubernetes/pki"
-imageRepository: "k8s.gcr.io"
-clusterName: "example-cluster"
----
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: KubeletConfiguration
-# kubelet specific options here
----
-apiVersion: kubeproxy.config.k8s.io/v1alpha1
-kind: KubeProxyConfiguration
-# kube-proxy specific options here
-
-## Kubeadm join configuration types
-
-When executing `kubeadm join` with the `--config` option, the JoinConfiguration type should be provided.
-
-```yaml
-apiVersion: kubeadm.k8s.io/v1beta3
-kind: JoinConfiguration
-  ...
-```
-
-The JoinConfiguration type should be used to configure runtime settings, that in case of `kubeadm join`
+for kubelet official documentation.</p>
+<p>Here is a fully populated example of a single YAML file containing multiple
+configuration types to be used during a <code>kubeadm init</code> run.</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta3<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>InitConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">bootstrapTokens</span>:<span style="color:#bbb">
+</span><span style="color:#bbb"></span>- <span style="color:#000;font-weight:bold">token</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;9a08jv.c0izixklcxtmnze7&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">description</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;kubeadm bootstrap token&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">ttl</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;24h&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span>- <span style="color:#000;font-weight:bold">token</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;783bde.3f89s0fje9f38fhf&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">description</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;another bootstrap token&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">usages</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- authentication<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- signing<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">groups</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- system:bootstrappers:kubeadm:default-node-token<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">nodeRegistration</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">name</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;ec2-10-100-0-1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">criSocket</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/var/run/dockershim.sock&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">taints</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- <span style="color:#000;font-weight:bold">key</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;kubeadmNode&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">value</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;master&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">effect</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;NoSchedule&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">kubeletExtraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">v</span>:<span style="color:#bbb"> </span><span style="color:#099">4</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">ignorePreflightErrors</span>:<span style="color:#bbb">
+</span><span style="color:#bbb"></span>- IsPrivilegedUser<span style="color:#bbb">
+</span><span style="color:#bbb">   </span><span style="color:#000;font-weight:bold">imagePullPolicy</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;IfNotPresent&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">localAPIEndpoint</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">advertiseAddress</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.100.0.1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">bindPort</span>:<span style="color:#bbb"> </span><span style="color:#099">6443</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">certificateKey</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">skipPhases</span>:<span style="color:#bbb">
+</span><span style="color:#bbb"> </span>- addon/kube-proxy<span style="color:#bbb">
+</span><span style="color:#bbb"></span>---<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta3<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>ClusterConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">etcd</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># one of local or external</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">local</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">imageTag</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;3.2.24&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">dataDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/var/lib/etcd&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">      </span><span style="color:#000;font-weight:bold">listen-client-urls</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;http://10.100.0.1:2379&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">serverCertSANs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- <span style="color:#bbb"> </span><span style="color:#d14">&#34;ec2-10-100-0-1.compute-1.amazonaws.com&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">peerCertSANs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span>- <span style="color:#d14">&#34;10.100.0.1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#998;font-style:italic"># external:</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># endpoints:</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># - &#34;10.100.0.1:2379&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># - &#34;10.100.0.2:2379&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># caFile: &#34;/etcd/kubernetes/pki/etcd/etcd-ca.crt&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># certFile: &#34;/etcd/kubernetes/pki/etcd/etcd.crt&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#998;font-style:italic"># keyFile: &#34;/etcd/kubernetes/pki/etcd/etcd.key&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">networking</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">serviceSubnet</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.96.0.0/16&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">podSubnet</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.244.0.0/24&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">dnsDomain</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;cluster.local&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kubernetesVersion</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;v1.21.0&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">controlPlaneEndpoint</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.100.0.1:6443&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiServer</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">authorization-mode</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;Node,RBAC&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraVolumes</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- <span style="color:#000;font-weight:bold">name</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;some-volume&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">hostPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">mountPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-pod-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">certSANs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- <span style="color:#d14">&#34;10.100.1.1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- <span style="color:#d14">&#34;ec2-10-100-0-1.compute-1.amazonaws.com&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">timeoutForControlPlane</span>:<span style="color:#bbb"> </span>4m0s<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">controllerManager</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">&#34;node-cidr-mask-size&#34;: </span><span style="color:#d14">&#34;20&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraVolumes</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- <span style="color:#000;font-weight:bold">name</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;some-volume&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">hostPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">mountPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-pod-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">scheduler</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraArgs</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">address</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;10.100.0.1&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">  </span><span style="color:#000;font-weight:bold">extraVolumes</span>:<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>- <span style="color:#000;font-weight:bold">name</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;some-volume&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">hostPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">mountPath</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/some-pod-path&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">readOnly</span>:<span style="color:#bbb"> </span><span style="color:#000;font-weight:bold">false</span><span style="color:#bbb">
+</span><span style="color:#bbb">    </span><span style="color:#000;font-weight:bold">pathType</span>:<span style="color:#bbb"> </span>File<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">certificatesDir</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;/etc/kubernetes/pki&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">imageRepository</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;k8s.gcr.io&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">clusterName</span>:<span style="color:#bbb"> </span><span style="color:#d14">&#34;example-cluster&#34;</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span>---<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeletConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#998;font-style:italic"># kubelet specific options here</span><span style="color:#bbb">
+</span><span style="color:#bbb"></span>---<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeproxy.config.k8s.io/v1alpha1<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeProxyConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#998;font-style:italic"># kube-proxy specific options here</span><span style="color:#bbb">
+</span></pre><h2>Kubeadm join configuration types</h2>
+<p>When executing <code>kubeadm join</code> with the <code>--config</code> option, the JoinConfiguration type should be provided.</p>
+<pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubeadm.k8s.io/v1beta3<span style="color:#bbb">
+</span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>JoinConfiguration<span style="color:#bbb">
+</span><span style="color:#bbb">  </span>...<span style="color:#bbb">
+</span></pre><p>The JoinConfiguration type should be used to configure runtime settings, that in case of <code>kubeadm join</code>
 are the discovery method used for accessing the cluster info and all the setting which are specific
-to the node where kubeadm is executed, including:
+to the node where kubeadm is executed, including:</p>
+<ul>
+<li>
+<p><code>nodeRegistration</code>, that holds fields that relate to registering the new node to the cluster;
+use it to customize the node name, the CRI socket to use or any other settings that should apply to this
+node only (e.g. the node ip).</p>
+</li>
+<li>
+<p><code>apiEndpoint</code>, that represents the endpoint of the instance of the API server to be eventually deployed on this node.</p>
+</li>
+</ul>
 
-- NodeRegistration, that holds fields that relate to registering the new node to the cluster;
-  use it to customize the node name, the CRI socket to use or any other settings that should apply to this
-  node only (e.g. the node ip).
-
-- APIEndpoint, that represents the endpoint of the instance of the API server to be eventually deployed on this node.
 
 ## Resource Types 
 
@@ -294,14 +264,12 @@ to the node where kubeadm is executed, including:
   
     
 
-
 ## `ClusterConfiguration`     {#kubeadm-k8s-io-v1beta3-ClusterConfiguration}
     
 
 
+<p>ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster</p>
 
-
-ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -310,131 +278,120 @@ ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>ClusterConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>etcd</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-Etcd"><code>Etcd</code></a>
 </td>
 <td>
-   Etcd holds configuration for etcd.</td>
+   <p><code>etcd</code> holds the configuration for etcd.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>networking</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-Networking"><code>Networking</code></a>
 </td>
 <td>
-   Networking holds configuration for the networking topology of the cluster.</td>
+   <p><code>networking</code> holds configuration for the networking topology of the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubernetesVersion</code><br/>
 <code>string</code>
 </td>
 <td>
-   KubernetesVersion is the target version of the control plane.</td>
+   <p><code>kubernetesVersion</code> is the target version of the control plane.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>controlPlaneEndpoint</code><br/>
 <code>string</code>
 </td>
 <td>
-   ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
-can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
-In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
-are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
-the BindPort is used.
-Possible usages are:
-e.g. In a cluster with more than one control plane instances, this field should be
+   <p><code>controlPlaneEndpoint</code> sets a stable IP address or DNS name for the control plane.
+It can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+In case the <code>controlPlaneEndpoint</code> is not specified, the <code>advertiseAddress</code> + <code>bindPort</code>
+are used; in case the <code>controlPlaneEndpoint</code> is specified but without a TCP port,
+the <code>bindPort</code> is used.
+Possible usages are:</p>
+<ul>
+<li>In a cluster with more than one control plane instances, this field should be
 assigned the address of the external load balancer in front of the
-control plane instances.
-e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
-could be used for assigning a stable DNS to the control plane.</td>
+control plane instances.</li>
+<li>In environments with enforced node recycling, the <code>controlPlaneEndpoint</code> could
+be used for assigning a stable DNS to the control plane.</li>
+</ul>
+</td>
 </tr>
-    
-  
 <tr><td><code>apiServer</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-APIServer"><code>APIServer</code></a>
 </td>
 <td>
-   APIServer contains extra settings for the API server control plane component</td>
+   <p><code>apiServer</code> contains extra settings for the API server.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>controllerManager</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
 </td>
 <td>
-   ControllerManager contains extra settings for the controller manager control plane component</td>
+   <p><code>controllerManager</code> contains extra settings for the controller manager.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>scheduler</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
 </td>
 <td>
-   Scheduler contains extra settings for the scheduler control plane component</td>
+   <p><code>scheduler</code> contains extra settings for the scheduler.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>dns</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-DNS"><code>DNS</code></a>
 </td>
 <td>
-   DNS defines the options for the DNS add-on installed in the cluster.</td>
+   <p><code>dns</code> defines the options for the DNS add-on installed in the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certificatesDir</code><br/>
 <code>string</code>
 </td>
 <td>
-   CertificatesDir specifies where to store or look for all required certificates.</td>
+   <p><code>certificatesDir</code> specifies where to store or look for all required certificates.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>imageRepository</code><br/>
 <code>string</code>
 </td>
 <td>
-   ImageRepository sets the container registry to pull images from.
-If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/`)
-`gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
-will be used for all the other images.</td>
+   <p><code>imageRepository</code> sets the container registry to pull images from.
+If empty, <code>k8s.gcr.io</code> will be used by default.
+In case of kubernetes version is a CI build (kubernetes version starts with <code>ci/</code>)
+<code>gcr.io/k8s-staging-ci-images</code> will be used as a default for control plane components
+and for kube-proxy, while <code>k8s.gcr.io</code> will be used for all the other images.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>featureGates</code><br/>
 <code>map[string]bool</code>
 </td>
 <td>
-   FeatureGates enabled by the user.</td>
+   <p><code>featureGates</code> contains the feature gates enabled by the user.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clusterName</code><br/>
 <code>string</code>
 </td>
 <td>
-   The cluster name</td>
+   <p>The cluster name.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `InitConfiguration`     {#kubeadm-k8s-io-v1beta3-InitConfiguration}
     
 
 
-
-
-InitConfiguration contains a list of elements that is specific "kubeadm init"-only runtime
+<p>InitConfiguration contains a list of elements that is specific &quot;kubeadm init&quot;-only runtime
 information.
+<code>kubeadm init</code>-only information. These fields are solely used the first time <code>kubeadm init</code> runs.
+After that, the information in the fields IS NOT uploaded to the <code>kubeadm-config</code> ConfigMap
+that is used by <code>kubeadm upgrade</code> for instance. These fields must be omitempty.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -443,79 +400,70 @@ information.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>InitConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>bootstrapTokens</code><br/>
 <a href="#BootstrapToken"><code>[]BootstrapToken</code></a>
 </td>
 <td>
-   BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
-This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature</td>
+   <p><code>bootstrapTokens</code> is respected at <code>kubeadm init</code> time and describes a set of Bootstrap Tokens to create.
+This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodeRegistration</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-NodeRegistrationOptions"><code>NodeRegistrationOptions</code></a>
 </td>
 <td>
-   NodeRegistration holds fields that relate to registering the new control-plane node to the cluster</td>
+   <p><code>nodeRegistration</code> holds fields that relate to registering the new control-plane node
+to the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>localAPIEndpoint</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-APIEndpoint"><code>APIEndpoint</code></a>
 </td>
 <td>
-   LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
-In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
-is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
-configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
-on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
-fails you may set the desired value here.</td>
+   <p><code>localAPIEndpoint</code> represents the endpoint of the API server instance that's deployed on this
+control plane node. In HA setups, this differs from <code>ClusterConfiguration.controlPlaneEndpoint</code>
+in the sense that <code>controlPlaneEndpoint</code> is the global endpoint for the cluster, which then
+load-balances the requests to each individual API server.
+This configuration object lets you customize what IP/DNS name and port the local API server
+advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default
+interface and use that, but in case that process fails you may set the desired value here.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certificateKey</code><br/>
 <code>string</code>
 </td>
 <td>
-   CertificateKey sets the key with which certificates and keys are encrypted prior to being uploaded in
-a secret in the cluster during the uploadcerts init phase.</td>
+   <p><code>certificateKey</code> sets the key with which certificates and keys are encrypted prior to being
+uploaded in a Secret in the cluster during the <code>uploadcerts init</code> phase.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>skipPhases</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   SkipPhases is a list of phases to skip during command execution.
-The list of phases can be obtained with the "kubeadm init --help" command.
-The flag "--skip-phases" takes precedence over this field.</td>
+   <p><code>skipPhases</code> is a list of phases to skip during command execution.
+The list of phases can be obtained with the <code>kubeadm init --help</code> command.
+The flag &quot;--skip-phases&quot; takes precedence over this field.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>patches</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-Patches"><code>Patches</code></a>
 </td>
 <td>
-   Patches contains options related to applying patches to components deployed by kubeadm during
-"kubeadm init".</td>
+   <p><code>patches</code> contains options related to applying patches to components deployed by kubeadm during
+<code>kubeadm init</code>.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `JoinConfiguration`     {#kubeadm-k8s-io-v1beta3-JoinConfiguration}
     
 
 
+<p>JoinConfiguration contains elements describing a particular node.</p>
 
-
-JoinConfiguration contains elements describing a particular node.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -524,72 +472,62 @@ JoinConfiguration contains elements describing a particular node.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubeadm.k8s.io/v1beta3</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>JoinConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>nodeRegistration</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-NodeRegistrationOptions"><code>NodeRegistrationOptions</code></a>
 </td>
 <td>
-   NodeRegistration holds fields that relate to registering the new control-plane node to the cluster</td>
+   <p><code>nodeRegistration</code> holds fields that relate to registering the new
+control-plane node to the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caCertPath</code><br/>
 <code>string</code>
 </td>
 <td>
-   CACertPath is the path to the SSL certificate authority used to
-secure comunications between node and control-plane.
-Defaults to "/etc/kubernetes/pki/ca.crt".</td>
+   <p><code>caCertPath</code> is the path to the SSL certificate authority used to secure
+comunications between a node and the control-plane.
+Defaults to &quot;/etc/kubernetes/pki/ca.crt&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>discovery</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta3-Discovery"><code>Discovery</code></a>
 </td>
 <td>
-   Discovery specifies the options for the kubelet to use during the TLS Bootstrap process</td>
+   <p><code>discovery</code> specifies the options for the kubelet to use during the TLS
+bootstrap process.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>controlPlane</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-JoinControlPlane"><code>JoinControlPlane</code></a>
 </td>
 <td>
-   ControlPlane defines the additional control plane instance to be deployed on the joining node.
-If nil, no additional control plane instance will be deployed.</td>
+   <p><code>controlPlane</code> defines the additional control plane instance to be deployed
+on the joining node. If nil, no additional control plane instance will be deployed.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>skipPhases</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   SkipPhases is a list of phases to skip during command execution.
-The list of phases can be obtained with the "kubeadm join --help" command.
-The flag "--skip-phases" takes precedence over this field.</td>
+   <p><code>skipPhases</code> is a list of phases to skip during command execution.
+The list of phases can be obtained with the <code>kubeadm join --help</code> command.
+The flag <code>--skip-phases</code> takes precedence over this field.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>patches</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-Patches"><code>Patches</code></a>
 </td>
 <td>
-   Patches contains options related to applying patches to components deployed by kubeadm during
-"kubeadm join".</td>
+   <p><code>patches</code> contains options related to applying patches to components deployed
+by kubeadm during <code>kubeadm join</code>.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `APIEndpoint`     {#kubeadm-k8s-io-v1beta3-APIEndpoint}
     
-
-
 
 **Appears in:**
 
@@ -598,152 +536,130 @@ The flag "--skip-phases" takes precedence over this field.</td>
 - [JoinControlPlane](#kubeadm-k8s-io-v1beta3-JoinControlPlane)
 
 
-APIEndpoint struct contains elements of API server instance deployed on a node.
+<p>APIEndpoint struct contains elements of API server instance deployed on a node.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>advertiseAddress</code><br/>
 <code>string</code>
 </td>
 <td>
-   AdvertiseAddress sets the IP address for the API server to advertise.</td>
+   <p><code>advertiseAddress</code> sets the IP address for the API server to advertise.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>bindPort</code><br/>
 <code>int32</code>
 </td>
 <td>
-   BindPort sets the secure port for the API Server to bind to.
-Defaults to 6443.</td>
+   <p><code>bindPorti</code> sets the secure port for the API Server to bind to.
+Defaults to 6443.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `APIServer`     {#kubeadm-k8s-io-v1beta3-APIServer}
     
-
-
 
 **Appears in:**
 
 - [ClusterConfiguration](#kubeadm-k8s-io-v1beta3-ClusterConfiguration)
 
 
-APIServer holds settings necessary for API server deployments in the cluster
+<p>APIServer holds settings necessary for API server deployments in the cluster</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>ControlPlaneComponent</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta3-ControlPlaneComponent"><code>ControlPlaneComponent</code></a>
 </td>
 <td>(Members of <code>ControlPlaneComponent</code> are embedded into this type.)
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>certSANs</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   CertSANs sets extra Subject Alternative Names for the API Server signing cert.</td>
+   <p><code>certSANs</code> sets extra Subject Alternative Names (SANs) for the API Server signing
+certificate.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>timeoutForControlPlane</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   TimeoutForControlPlane controls the timeout that we use for API server to appear</td>
+   <p><code>timeoutForControlPlane</code> controls the timeout that we wait for API server to appear.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `BootstrapTokenDiscovery`     {#kubeadm-k8s-io-v1beta3-BootstrapTokenDiscovery}
     
-
-
 
 **Appears in:**
 
 - [Discovery](#kubeadm-k8s-io-v1beta3-Discovery)
 
 
-BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery
+<p>BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>token</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Token is a token used to validate cluster information
-fetched from the control-plane.</td>
+   <p><code>token</code> is a token used to validate cluster information fetched from the
+control-plane.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>apiServerEndpoint</code><br/>
 <code>string</code>
 </td>
 <td>
-   APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.</td>
+   <p><code>apiServerEndpoint</code> is an IP or domain name to the API server from which
+information will be fetched.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caCertHashes</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   CACertHashes specifies a set of public key pins to verify
-when token-based discovery is used. The root CA found during discovery
-must match one of these values. Specifying an empty set disables root CA
-pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
-where the only currently supported type is "sha256". This is a hex-encoded
-SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
-ASN.1. These hashes can be calculated using, for example, OpenSSL.</td>
+   <p><code>caCertHashes</code> specifies a set of public key pins to verify when token-based discovery
+is used. The root CA found during discovery must match one of these values.
+Specifying an empty set disables root CA pinning, which can be unsafe.
+Each hash is specified as &quot;<!-- raw HTML omitted -->:<!-- raw HTML omitted -->&quot;, where the only currently supported type is
+&quot;sha256&quot;. This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI)
+object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>unsafeSkipCAVerification</code><br/>
 <code>bool</code>
 </td>
 <td>
-   UnsafeSkipCAVerification allows token-based discovery
-without CA verification via CACertHashes. This can weaken
-the security of kubeadm since other nodes can impersonate the control-plane.</td>
+   <p><code>unsafeSkipCAVerification</code> allows token-based discovery without CA verification
+via <code>caCertHashes</code>. This can weaken the security of kubeadm since other nodes can
+impersonate the control-plane.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ControlPlaneComponent`     {#kubeadm-k8s-io-v1beta3-ControlPlaneComponent}
     
-
-
 
 **Appears in:**
 
@@ -752,341 +668,282 @@ the security of kubeadm since other nodes can impersonate the control-plane.</td
 - [APIServer](#kubeadm-k8s-io-v1beta3-APIServer)
 
 
-ControlPlaneComponent holds settings common to control plane component of the cluster
+<p>ControlPlaneComponent holds settings common to control plane component of the cluster</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>extraArgs</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   ExtraArgs is an extra set of flags to pass to the control plane component.
-A key in this map is the flag name as it appears on the
-command line except without leading dash(es).
-TODO: This is temporary and ideally we would like to switch all components to
-use ComponentConfig + ConfigMaps.</td>
+   <p><code>extraArgs</code> is an extra set of flags to pass to the control plane component.
+A key in this map is the flag name as it appears on the command line except
+without leading dash(es).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>extraVolumes</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-HostPathMount"><code>[]HostPathMount</code></a>
 </td>
 <td>
-   ExtraVolumes is an extra set of host volumes, mounted to the control plane component.</td>
+   <p><code>extraVolumes</code> is an extra set of host volumes, mounted to the control plane component.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `DNS`     {#kubeadm-k8s-io-v1beta3-DNS}
     
-
-
 
 **Appears in:**
 
 - [ClusterConfiguration](#kubeadm-k8s-io-v1beta3-ClusterConfiguration)
 
 
-DNS defines the DNS addon that should be used in the cluster
+<p>DNS defines the DNS addon that should be used in the cluster</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>ImageMeta</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta3-ImageMeta"><code>ImageMeta</code></a>
 </td>
 <td>(Members of <code>ImageMeta</code> are embedded into this type.)
-   ImageMeta allows to customize the image used for the DNS component</td>
+   <p><code>imageMeta</code> allows to customize the image used for the DNS component.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
-
-## `DNSAddOnType`     {#kubeadm-k8s-io-v1beta3-DNSAddOnType}
-    
-(Alias of `string`)
-
-
-
-DNSAddOnType defines string identifying DNS add-on types
-
-
-    
-
 
 ## `Discovery`     {#kubeadm-k8s-io-v1beta3-Discovery}
     
-
-
 
 **Appears in:**
 
 - [JoinConfiguration](#kubeadm-k8s-io-v1beta3-JoinConfiguration)
 
 
-Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+<p>Discovery specifies the options for the kubelet to use during the TLS Bootstrap process.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>bootstrapToken</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-BootstrapTokenDiscovery"><code>BootstrapTokenDiscovery</code></a>
 </td>
 <td>
-   BootstrapToken is used to set the options for bootstrap token based discovery
-BootstrapToken and File are mutually exclusive</td>
+   <p><code>bootstrapToken</code> is used to set the options for bootstrap token based discovery.
+<code>bootstrapToken</code> and <code>file</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>file</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-FileDiscovery"><code>FileDiscovery</code></a>
 </td>
 <td>
-   File is used to specify a file or URL to a kubeconfig file from which to load cluster information
-BootstrapToken and File are mutually exclusive</td>
+   <p><code>file</code> is used to specify a file or URL to a kubeconfig file from which to load
+cluster information.
+<code>bootstrapToken</code> and <code>file</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tlsBootstrapToken</code><br/>
 <code>string</code>
 </td>
 <td>
-   TLSBootstrapToken is a token used for TLS bootstrapping.
-If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
-If .File is set, this field &lowast;&lowast;must be set&lowast;&lowast; in case the KubeConfigFile does not contain any other authentication information</td>
+   <p><code>tlsBootstrapToken</code> is a token used for TLS bootstrapping.
+If <code>bootstrapToken</code> is set, this field is defaulted to <code>.bootstrapToken.token</code>, but
+can be overridden. If <code>file</code> is set, this field <strong>must be set</strong> in case the KubeConfigFile
+does not contain any other authentication information</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>timeout</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   Timeout modifies the discovery timeout</td>
+   <p><code>timeout</code> modifies the discovery timeout.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Etcd`     {#kubeadm-k8s-io-v1beta3-Etcd}
     
-
-
 
 **Appears in:**
 
 - [ClusterConfiguration](#kubeadm-k8s-io-v1beta3-ClusterConfiguration)
 
 
-Etcd contains elements describing Etcd configuration.
+<p>Etcd contains elements describing Etcd configuration.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>local</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-LocalEtcd"><code>LocalEtcd</code></a>
 </td>
 <td>
-   Local provides configuration knobs for configuring the local etcd instance
-Local and External are mutually exclusive</td>
+   <p><code>local</code> provides configuration knobs for configuring the local etcd instance.
+<code>local</code> and <code>external</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>external</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-ExternalEtcd"><code>ExternalEtcd</code></a>
 </td>
 <td>
-   External describes how to connect to an external etcd cluster
-Local and External are mutually exclusive</td>
+   <p><code>external</code> describes how to connect to an external etcd cluster.
+<code>local</code> and <code>external</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExternalEtcd`     {#kubeadm-k8s-io-v1beta3-ExternalEtcd}
     
-
-
 
 **Appears in:**
 
 - [Etcd](#kubeadm-k8s-io-v1beta3-Etcd)
 
 
-ExternalEtcd describes an external etcd cluster.
-Kubeadm has no knowledge of where certificate files live and they must be supplied.
+<p>ExternalEtcd describes an external etcd cluster.
+Kubeadm has no knowledge of where certificate files live and they must be supplied.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>endpoints</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   Endpoints of etcd members. Required for ExternalEtcd.</td>
+   <p><code>endpoints</code> contains the list of etcd members.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>caFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CAFile is an SSL Certificate Authority file used to secure etcd communication.
-Required if using a TLS connection.</td>
+   <p><code>caFile</code> is an SSL Certificate Authority (CA) file used to secure etcd communication.
+Required if using a TLS connection.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   CertFile is an SSL certification file used to secure etcd communication.
-Required if using a TLS connection.</td>
+   <p><code>certFile</code> is an SSL certification file used to secure etcd communication.
+Required if using a TLS connection.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>keyFile</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   KeyFile is an SSL key file used to secure etcd communication.
-Required if using a TLS connection.</td>
+   <p><code>keyFile</code> is an SSL key file used to secure etcd communication.
+Required if using a TLS connection.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `FileDiscovery`     {#kubeadm-k8s-io-v1beta3-FileDiscovery}
     
-
-
 
 **Appears in:**
 
 - [Discovery](#kubeadm-k8s-io-v1beta3-Discovery)
 
 
-FileDiscovery is used to specify a file or URL to a kubeconfig file from which to load cluster information
+<p>FileDiscovery is used to specify a file or URL to a kubeconfig file from which to load
+cluster information.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>kubeConfigPath</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information</td>
+   <p><code>kubeConfigPath</code> is used to specify the actual file path or URL to the kubeconfig
+file from which to load cluster information.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `HostPathMount`     {#kubeadm-k8s-io-v1beta3-HostPathMount}
     
-
-
 
 **Appears in:**
 
 - [ControlPlaneComponent](#kubeadm-k8s-io-v1beta3-ControlPlaneComponent)
 
 
-HostPathMount contains elements describing volumes that are mounted from the
-host.
+<p>HostPathMount contains elements describing volumes that are mounted from the host.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Name of the volume inside the pod template.</td>
+   <p><code>name</code> is the name of the volume inside the Pod template.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>hostPath</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   HostPath is the path in the host that will be mounted inside
-the pod.</td>
+   <p><code>hostPath</code> is the path in the host that will be mounted inside the Pod.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>mountPath</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   MountPath is the path inside the pod where hostPath will be mounted.</td>
+   <p><code>mountPath</code> is the path inside the Pod where <code>hostPath</code> will be mounted.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>readOnly</code><br/>
 <code>bool</code>
 </td>
 <td>
-   ReadOnly controls write access to the volume</td>
+   <p><code>readOnly</code> controls write access to the volume.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>pathType</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#hostpathtype-v1-core"><code>core/v1.HostPathType</code></a>
 </td>
 <td>
-   PathType is the type of the HostPath.</td>
+   <p><code>pathType</code> is the type of the <code>hostPath</code>.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ImageMeta`     {#kubeadm-k8s-io-v1beta3-ImageMeta}
     
-
-
 
 **Appears in:**
 
@@ -1095,196 +952,173 @@ the pod.</td>
 - [LocalEtcd](#kubeadm-k8s-io-v1beta3-LocalEtcd)
 
 
-ImageMeta allows to customize the image used for components that are not
-originated from the Kubernetes/Kubernetes release process
+<p>ImageMeta allows to customize the image used for components that are not
+originated from the Kubernetes/Kubernetes release process</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>imageRepository</code><br/>
 <code>string</code>
 </td>
 <td>
-   ImageRepository sets the container registry to pull images from.
-if not set, the ImageRepository defined in ClusterConfiguration will be used instead.</td>
+   <p><code>imageRepository</code> sets the container registry to pull images from.
+If not set, the <code>imageRepository</code> defined in ClusterConfiguration will be used instead.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>imageTag</code><br/>
 <code>string</code>
 </td>
 <td>
-   ImageTag allows to specify a tag for the image.
-In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.</td>
+   <p><code>imageTag</code> allows to specify a tag for the image.
+In case this value is set, kubeadm does not change automatically the version of
+the above components during upgrades.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `JoinControlPlane`     {#kubeadm-k8s-io-v1beta3-JoinControlPlane}
     
-
-
 
 **Appears in:**
 
 - [JoinConfiguration](#kubeadm-k8s-io-v1beta3-JoinConfiguration)
 
 
-JoinControlPlane contains elements describing an additional control plane instance to be deployed on the joining node.
+<p>JoinControlPlane contains elements describing an additional control plane instance
+to be deployed on the joining node.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>localAPIEndpoint</code><br/>
 <a href="#kubeadm-k8s-io-v1beta3-APIEndpoint"><code>APIEndpoint</code></a>
 </td>
 <td>
-   LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.</td>
+   <p><code>localAPIEndpoint</code> represents the endpoint of the API server instance to be
+deployed on this node.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>certificateKey</code><br/>
 <code>string</code>
 </td>
 <td>
-   CertificateKey is the key that is used for decryption of certificates after they are downloaded from the secret
-upon joining a new control plane node. The corresponding encryption key is in the InitConfiguration.</td>
+   <p><code>certificateKey</code> is the key that is used for decryption of certificates after
+they are downloaded from the secret upon joining a new control plane node.
+The corresponding encryption key is in the InitConfiguration.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `LocalEtcd`     {#kubeadm-k8s-io-v1beta3-LocalEtcd}
     
-
-
 
 **Appears in:**
 
 - [Etcd](#kubeadm-k8s-io-v1beta3-Etcd)
 
 
-LocalEtcd describes that kubeadm should run an etcd cluster locally
+<p>LocalEtcd describes that kubeadm should run an etcd cluster locally</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>ImageMeta</code> <B>[Required]</B><br/>
 <a href="#kubeadm-k8s-io-v1beta3-ImageMeta"><code>ImageMeta</code></a>
 </td>
 <td>(Members of <code>ImageMeta</code> are embedded into this type.)
-   ImageMeta allows to customize the container used for etcd</td>
+   <p>ImageMeta allows to customize the container used for etcd.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>dataDir</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   DataDir is the directory etcd will place its data.
-Defaults to "/var/lib/etcd".</td>
+   <p><code>dataDir</code> is the directory etcd will place its data.
+Defaults to &quot;/var/lib/etcd&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>extraArgs</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   ExtraArgs are extra arguments provided to the etcd binary
-when run inside a static pod.
-A key in this map is the flag name as it appears on the
-command line except without leading dash(es).</td>
+   <p><code>extraArgs</code> are extra arguments provided to the etcd binary when run
+inside a static Pod. A key in this map is the flag name as it appears on the
+command line except without leading dash(es).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>serverCertSANs</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.</td>
+   <p><code>serverCertSANs</code> sets extra Subject Alternative Names (SANs) for the etcd
+server signing certificate.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>peerCertSANs</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.</td>
+   <p><code>peerCertSANs</code> sets extra Subject Alternative Names (SANs) for the etcd peer
+signing certificate.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Networking`     {#kubeadm-k8s-io-v1beta3-Networking}
     
-
-
 
 **Appears in:**
 
 - [ClusterConfiguration](#kubeadm-k8s-io-v1beta3-ClusterConfiguration)
 
 
-Networking contains elements describing cluster's networking configuration
+<p>Networking contains elements describing cluster's networking configuration</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>serviceSubnet</code><br/>
 <code>string</code>
 </td>
 <td>
-   ServiceSubnet is the subnet used by k8s services. Defaults to "10.96.0.0/12".</td>
+   <p><code>serviceSubnet</code> is the subnet used by Kubernetes Services. Defaults to &quot;10.96.0.0/12&quot;.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podSubnet</code><br/>
 <code>string</code>
 </td>
 <td>
-   PodSubnet is the subnet used by pods.</td>
+   <p><code>podSubnet</code> is the subnet used by Pods.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>dnsDomain</code><br/>
 <code>string</code>
 </td>
 <td>
-   DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".</td>
+   <p><code>dnsDomain</code> is the DNS domain used by Kubernetes Services. Defaults to &quot;cluster.local&quot;.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeRegistrationOptions`     {#kubeadm-k8s-io-v1beta3-NodeRegistrationOptions}
     
-
-
 
 **Appears in:**
 
@@ -1293,81 +1127,82 @@ Networking contains elements describing cluster's networking configuration
 - [JoinConfiguration](#kubeadm-k8s-io-v1beta3-JoinConfiguration)
 
 
-NodeRegistrationOptions holds fields that relate to registering a new control-plane or node to the cluster, either via "kubeadm init" or "kubeadm join"
+<p>NodeRegistrationOptions holds fields that relate to registering a new control-plane or
+node to the cluster, either via &quot;kubeadm init&quot; or &quot;kubeadm join&quot;</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code><br/>
 <code>string</code>
 </td>
 <td>
-   Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
-This field is also used in the CommonName field of the kubelet's client certificate to the API server.
-Defaults to the hostname of the node if not provided.</td>
+   <p><code>name</code> is the <code>.metadata.name</code> field of the Node API object that will be created in this
+<code>kubeadm init</code> or <code>kubeadm join</code> operation.
+This field is also used in the <code>CommonName</code> field of the kubelet's client certificate to
+the API server.
+Defaults to the hostname of the node if not provided.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>criSocket</code><br/>
 <code>string</code>
 </td>
 <td>
-   CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use</td>
+   <p><code>criSocket</code> is used to retrieve container runtime info.
+This information will be annotated to the Node API object, for later re-use</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>taints</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
-   Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
-it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
-empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.</td>
+   <p><code>tains</code> specifies the taints the Node API object should be registered with.
+If this field is unset, i.e. nil, in the <code>kubeadm init</code> process it will be defaulted to
+<code>taints: [&quot;node-role.kubernetes.io/master:&quot;&quot;]</code>.
+If you don't want to taint your control-plane node, set this field to an empty slice,
+i.e. <code>taints: []</code> in the YAML file. This field is solely used for Node registration.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubeletExtraArgs</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
-kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
-Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
-A key in this map is the flag name as it appears on the
-command line except without leading dash(es).</td>
+   <p><code>kubeletExtraArgs</code> passes through extra arguments to the kubelet.
+The arguments here are passed to the kubelet command line via the environment file
+kubeadm writes at runtime for the kubelet to source.
+This overrides the generic base-level configuration in the 'kubelet-config-1.X' ConfigMap.
+Flags have higher priority when parsing. These values are local and specific to the node
+kubeadm is executing on. A key in this map is the flag name as it appears on the
+command line except without leading dash(es).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ignorePreflightErrors</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.</td>
+   <p><code>ignorePreflightErrors</code> provides a list of pre-flight errors to be ignored when
+the current node is registered.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>imagePullPolicy</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#pullpolicy-v1-core"><code>core/v1.PullPolicy</code></a>
 </td>
 <td>
-   ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
-The value of this field must be one of "Always", "IfNotPresent" or "Never".
-If this field is unset kubeadm will default it to "IfNotPresent", or pull the required images if not present on the host.</td>
+   <p><code>imagePullPolicy</code> specifies the policy for image pulling during kubeadm &quot;init&quot; and
+&quot;join&quot; operations.
+The value of this field must be one of &quot;Always&quot;, &quot;IfNotPresent&quot; or &quot;Never&quot;.
+If this field is unset kubeadm will default it to &quot;IfNotPresent&quot;, or pull the required
+images if not present on the host.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `Patches`     {#kubeadm-k8s-io-v1beta3-Patches}
     
-
-
 
 **Appears in:**
 
@@ -1376,31 +1211,31 @@ If this field is unset kubeadm will default it to "IfNotPresent", or pull the re
 - [JoinConfiguration](#kubeadm-k8s-io-v1beta3-JoinConfiguration)
 
 
-Patches contains options related to applying patches to components deployed by kubeadm.
+<p>Patches contains options related to applying patches to components deployed by kubeadm.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>directory</code><br/>
 <code>string</code>
 </td>
 <td>
-   Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
-For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
-"kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
-of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
-The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
-"suffix" is an optional string that can be used to determine which patches are applied
-first alpha-numerically.</td>
+   <p><code>directory</code> is a path to a directory that contains files named
+&quot;target[suffix][+patchtype].extension&quot;.
+For example, &quot;kube-apiserver0+merge.yaml&quot; or just &quot;etcd.json&quot;. &quot;target&quot; can be one of
+&quot;kube-apiserver&quot;, &quot;kube-controller-manager&quot;, &quot;kube-scheduler&quot;, &quot;etcd&quot;. &quot;patchtype&quot; can
+be one of &quot;strategic&quot; &quot;merge&quot; or &quot;json&quot; and they match the patch formats supported by
+kubectl.
+The default &quot;patchtype&quot; is &quot;strategic&quot;. &quot;extension&quot; must be either &quot;json&quot; or &quot;yaml&quot;.
+&quot;suffix&quot; is an optional string that can be used to determine which patches are applied
+first alpha-numerically.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   
   
     
@@ -1408,116 +1243,100 @@ first alpha-numerically.</td>
 ## `BootstrapToken`     {#BootstrapToken}
     
 
-
-
 **Appears in:**
 
 - [InitConfiguration](#kubeadm-k8s-io-v1beta3-InitConfiguration)
 
 
-BootstrapToken describes one bootstrap token, stored as a Secret in the cluster
+<p>BootstrapToken describes one bootstrap token, stored as a Secret in the cluster</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>token</code> <B>[Required]</B><br/>
 <a href="#BootstrapTokenString"><code>BootstrapTokenString</code></a>
 </td>
 <td>
-   `token` is used for establishing bidirectional trust between nodes and control-planes.
-Used for joining nodes in the cluster.</td>
+   <p><code>token</code> is used for establishing bidirectional trust between nodes and control-planes.
+Used for joining nodes in the cluster.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>description</code><br/>
 <code>string</code>
 </td>
 <td>
-   `description` sets a human-friendly message why this token exists and what it's used
-for, so other administrators can know its purpose.</td>
+   <p><code>description</code> sets a human-friendly message why this token exists and what it's used
+for, so other administrators can know its purpose.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>ttl</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   `ttl` defines the time to live for this token. Defaults to `24h`.
-`expires` and `ttl` are mutually exclusive.</td>
+   <p><code>ttl</code> defines the time to live for this token. Defaults to <code>24h</code>.
+<code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>expires</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
-   `expires` specifies the timestamp when this token expires. Defaults to being set
-dynamically at runtime based on the `ttl`. `expires` and `ttl` are mutually exclusive.</td>
+   <p><code>expires</code> specifies the timestamp when this token expires. Defaults to being set
+dynamically at runtime based on the <code>ttl</code>. <code>expires</code> and <code>ttl</code> are mutually exclusive.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>usages</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   `usages` describes the ways in which this token can be used. Can by default be used
-for establishing bidirectional trust, but that can be changed here.</td>
+   <p><code>usages</code> describes the ways in which this token can be used. Can by default be used
+for establishing bidirectional trust, but that can be changed here.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>groups</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   `groups` specifies the extra groups that this token will authenticate as when/if
-used for authentication</td>
+   <p><code>groups</code> specifies the extra groups that this token will authenticate as when/if
+used for authentication</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `BootstrapTokenString`     {#BootstrapTokenString}
     
 
-
-
 **Appears in:**
 
 - [BootstrapToken](#BootstrapToken)
 
 
-BootstrapTokenString is a token of the format `abcdef.abcdef0123456789` that is used
+<p>BootstrapTokenString is a token of the format <code>abcdef.abcdef0123456789</code> that is used
 for both validation of the practically of the API server from a joining node's point
 of view and as an authentication method for the node in the bootstrap phase of
-"kubeadm join". This token is and should be short-lived.
+&quot;kubeadm join&quot;. This token is and should be short-lived.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>-</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>-</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 </tbody>
 </table>

--- a/genref/output/md/kubelet-config.v1alpha1.md
+++ b/genref/output/md/kubelet-config.v1alpha1.md
@@ -16,69 +16,61 @@ auto_generated: true
 ## `FormatOptions`     {#FormatOptions}
     
 
-
-
 **Appears in:**
 
-- [LoggingConfiguration](#LoggingConfiguration)
 
 
-FormatOptions contains options for the different logging formats.
+<p>FormatOptions contains options for the different logging formats.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>json</code> <B>[Required]</B><br/>
 <a href="#JSONOptions"><code>JSONOptions</code></a>
 </td>
 <td>
-   [Experimental] JSON contains options for logging format "json".</td>
+   <p>[Experimental] JSON contains options for logging format &quot;json&quot;.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `JSONOptions`     {#JSONOptions}
     
 
-
-
 **Appears in:**
 
 - [FormatOptions](#FormatOptions)
 
 
-JSONOptions contains options for logging format "json".
+<p>JSONOptions contains options for logging format &quot;json&quot;.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>splitStream</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   [Experimental] SplitStream redirects error messages to stderr while
+   <p>[Experimental] SplitStream redirects error messages to stderr while
 info messages go to stdout, with buffering. The default is to write
-both to stdout, without buffering.</td>
+both to stdout, without buffering.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>infoBufferSize</code> <B>[Required]</B><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue"><code>k8s.io/apimachinery/pkg/api/resource.QuantityValue</code></a>
 </td>
 <td>
-   [Experimental] InfoBufferSize sets the size of the info stream when
-using split streams. The default is zero, which disables buffering.</td>
+   <p>[Experimental] InfoBufferSize sets the size of the info stream when
+using split streams. The default is zero, which disables buffering.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
@@ -86,29 +78,26 @@ using split streams. The default is zero, which disables buffering.</td>
     
 (Alias of `[]k8s.io/component-base/config/v1alpha1.VModuleItem`)
 
-
 **Appears in:**
 
-- [LoggingConfiguration](#LoggingConfiguration)
 
 
-VModuleConfiguration is a collection of individual file names or patterns
-and the corresponding verbosity threshold.
+<p>VModuleConfiguration is a collection of individual file names or patterns
+and the corresponding verbosity threshold.</p>
+
 
 
   
     
 
-
 ## `CredentialProviderConfig`     {#kubelet-config-k8s-io-v1alpha1-CredentialProviderConfig}
     
 
 
-
-
-CredentialProviderConfig is the configuration containing information about
+<p>CredentialProviderConfig is the configuration containing information about
 each exec credential provider. Kubelet reads this configuration from disk and enables
-each provider as specified by the CredentialProvider type.
+each provider as specified by the CredentialProvider type.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -117,165 +106,144 @@ each provider as specified by the CredentialProvider type.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubelet.config.k8s.io/v1alpha1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>CredentialProviderConfig</code></td></tr>
     
-
-  
   
 <tr><td><code>providers</code> <B>[Required]</B><br/>
 <a href="#kubelet-config-k8s-io-v1alpha1-CredentialProvider"><code>[]CredentialProvider</code></a>
 </td>
 <td>
-   providers is a list of credential provider plugins that will be enabled by the kubelet.
+   <p>providers is a list of credential provider plugins that will be enabled by the kubelet.
 Multiple providers may match against a single image, in which case credentials
 from all providers will be returned to the kubelet. If multiple providers are called
 for a single image, the results are combined. If providers return overlapping
-auth keys, the value from the provider earlier in this list is used.</td>
+auth keys, the value from the provider earlier in this list is used.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `CredentialProvider`     {#kubelet-config-k8s-io-v1alpha1-CredentialProvider}
     
-
-
 
 **Appears in:**
 
 - [CredentialProviderConfig](#kubelet-config-k8s-io-v1alpha1-CredentialProviderConfig)
 
 
-CredentialProvider represents an exec plugin to be invoked by the kubelet. The plugin is only
-invoked when an image being pulled matches the images handled by the plugin (see matchImages).
+<p>CredentialProvider represents an exec plugin to be invoked by the kubelet. The plugin is only
+invoked when an image being pulled matches the images handled by the plugin (see matchImages).</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   name is the required name of the credential provider. It must match the name of the
+   <p>name is the required name of the credential provider. It must match the name of the
 provider executable as seen by the kubelet. The executable must be in the kubelet's
-bin directory (set by the --image-credential-provider-bin-dir flag).</td>
+bin directory (set by the --image-credential-provider-bin-dir flag).</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>matchImages</code> <B>[Required]</B><br/>
 <code>[]string</code>
 </td>
 <td>
-   matchImages is a required list of strings used to match against images in order to
+   <p>matchImages is a required list of strings used to match against images in order to
 determine if this provider should be invoked. If one of the strings matches the
 requested image from the kubelet, the plugin will be invoked and given a chance
 to provide credentials. Images are expected to contain the registry domain
-and URL path.
-
-Each entry in matchImages is a pattern which can optionally contain a port and a path.
+and URL path.</p>
+<p>Each entry in matchImages is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '&lowast;.k8s.io' or 'k8s.&lowast;.io', and top-level-domains such as 'k8s.&lowast;'.
-Matching partial subdomains like 'app&lowast;.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so &lowast;.io does not match &lowast;.k8s.io.
-
-A match exists between an image and a matchImage when all of the below are true:
-- Both contain the same number of domain parts and each part matches.
-- The URL path of an imageMatch must be a prefix of the target image URL path.
-- If the imageMatch contains a port, then the port must match in the image as well.
-
-Example values of matchImages:
-  - 123456789.dkr.ecr.us-east-1.amazonaws.com
-  - &lowast;.azurecr.io
-  - gcr.io
-  - &lowast;.&lowast;.registry.io
-  - registry.io:8080/path</td>
+as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
+Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
+a single subdomain segment, so &lowast;.io does not match &lowast;.k8s.io.</p>
+<p>A match exists between an image and a matchImage when all of the below are true:</p>
+<ul>
+<li>Both contain the same number of domain parts and each part matches.</li>
+<li>The URL path of an imageMatch must be a prefix of the target image URL path.</li>
+<li>If the imageMatch contains a port, then the port must match in the image as well.</li>
+</ul>
+<p>Example values of matchImages:</p>
+<ul>
+<li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
+<li>&lowast;.azurecr.io</li>
+<li>gcr.io</li>
+<li><em>.</em>.registry.io</li>
+<li>registry.io:8080/path</li>
+</ul>
+</td>
 </tr>
-    
-  
 <tr><td><code>defaultCacheDuration</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   defaultCacheDuration is the default duration the plugin will cache credentials in-memory
-if a cache duration is not provided in the plugin response. This field is required.</td>
+   <p>defaultCacheDuration is the default duration the plugin will cache credentials in-memory
+if a cache duration is not provided in the plugin response. This field is required.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>apiVersion</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Required input version of the exec CredentialProviderRequest. The returned CredentialProviderResponse
-MUST use the same encoding version as the input. Current supported values are:
-- credentialprovider.kubelet.k8s.io/v1alpha1</td>
+   <p>Required input version of the exec CredentialProviderRequest. The returned CredentialProviderResponse
+MUST use the same encoding version as the input. Current supported values are:</p>
+<ul>
+<li>credentialprovider.kubelet.k8s.io/v1alpha1</li>
+</ul>
+</td>
 </tr>
-    
-  
 <tr><td><code>args</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   Arguments to pass to the command when executing it.</td>
+   <p>Arguments to pass to the command when executing it.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>env</code><br/>
 <a href="#kubelet-config-k8s-io-v1alpha1-ExecEnvVar"><code>[]ExecEnvVar</code></a>
 </td>
 <td>
-   Env defines additional environment variables to expose to the process. These
+   <p>Env defines additional environment variables to expose to the process. These
 are unioned with the host's environment, as well as variables client-go uses
-to pass argument to the plugin.</td>
+to pass argument to the plugin.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ExecEnvVar`     {#kubelet-config-k8s-io-v1alpha1-ExecEnvVar}
     
-
-
 
 **Appears in:**
 
 - [CredentialProvider](#kubelet-config-k8s-io-v1alpha1-CredentialProvider)
 
 
-ExecEnvVar is used for setting environment variables when executing an exec-based
-credential plugin.
+<p>ExecEnvVar is used for setting environment variables when executing an exec-based
+credential plugin.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>value</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   

--- a/genref/output/md/kubelet-config.v1beta1.md
+++ b/genref/output/md/kubelet-config.v1beta1.md
@@ -14,14 +14,12 @@ auto_generated: true
   
     
 
-
 ## `KubeletConfiguration`     {#kubelet-config-k8s-io-v1beta1-KubeletConfiguration}
     
 
 
+<p>KubeletConfiguration contains the configuration for the Kubelet</p>
 
-
-KubeletConfiguration contains the configuration for the Kubelet
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -30,149 +28,137 @@ KubeletConfiguration contains the configuration for the Kubelet
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubelet.config.k8s.io/v1beta1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>KubeletConfiguration</code></td></tr>
     
-
-  
   
 <tr><td><code>enableServer</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   enableServer enables Kubelet's secured server.
+   <p>enableServer enables Kubelet's secured server.
 Note: Kubelet's insecure port is controlled by the readOnlyPort option.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: true</td>
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>staticPodPath</code><br/>
 <code>string</code>
 </td>
 <td>
-   staticPodPath is the path to the directory containing local (static) pods to
+   <p>staticPodPath is the path to the directory containing local (static) pods to
 run, or the path to a single static pod file.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 the set of static pods specified at the new path may be different than the
 ones the Kubelet initially started with, and this may disrupt your node.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>syncFrequency</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   syncFrequency is the max period between synchronizing running
+   <p>syncFrequency is the max period between synchronizing running
 containers and config.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 shortening this duration may have a negative performance impact, especially
 as the number of Pods on the node increases. Alternatively, increasing this
 duration will result in longer refresh times for ConfigMaps and Secrets.
-Default: "1m"</td>
+Default: &quot;1m&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>fileCheckFrequency</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   fileCheckFrequency is the duration between checking config files for
+   <p>fileCheckFrequency is the duration between checking config files for
 new data.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 shortening the duration will cause the Kubelet to reload local Static Pod
 configurations more frequently, which may have a negative performance impact.
-Default: "20s"</td>
+Default: &quot;20s&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>httpCheckFrequency</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   httpCheckFrequency is the duration between checking http for new data.
+   <p>httpCheckFrequency is the duration between checking http for new data.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 shortening the duration will cause the Kubelet to poll staticPodURL more
 frequently, which may have a negative performance impact.
-Default: "20s"</td>
+Default: &quot;20s&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>staticPodURL</code><br/>
 <code>string</code>
 </td>
 <td>
-   staticPodURL is the URL for accessing static pods to run.
+   <p>staticPodURL is the URL for accessing static pods to run.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 the set of static pods specified at the new URL may be different than the
 ones the Kubelet initially started with, and this may disrupt your node.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>staticPodURLHeader</code><br/>
 <code>map[string][]string</code>
 </td>
 <td>
-   staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL.
+   <p>staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt the ability to read the latest set of static pods from StaticPodURL.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>address</code><br/>
 <code>string</code>
 </td>
 <td>
-   address is the IP address for the Kubelet to serve on (set to 0.0.0.0
+   <p>address is the IP address for the Kubelet to serve on (set to 0.0.0.0
 for all interfaces).
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: "0.0.0.0"</td>
+Default: &quot;0.0.0.0&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>port</code><br/>
 <code>int32</code>
 </td>
 <td>
-   port is the port for the Kubelet to serve on.
+   <p>port is the port for the Kubelet to serve on.
 The port number must be between 1 and 65535, inclusive.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: 10250</td>
+Default: 10250</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>readOnlyPort</code><br/>
 <code>int32</code>
 </td>
 <td>
-   readOnlyPort is the read-only port for the Kubelet to serve on with
+   <p>readOnlyPort is the read-only port for the Kubelet to serve on with
 no authentication/authorization.
 The port number must be between 1 and 65535, inclusive.
 Setting this field to 0 disables the read-only service.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: 0 (disabled)</td>
+Default: 0 (disabled)</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tlsCertFile</code><br/>
 <code>string</code>
 </td>
 <td>
-   tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,
+   <p>tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,
 if any, concatenated after server cert). If tlsCertFile and
 tlsPrivateKeyFile are not provided, a self-signed certificate
 and key are generated for the public address and saved to the directory
@@ -180,68 +166,63 @@ passed to the Kubelet's --cert-dir flag.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tlsPrivateKeyFile</code><br/>
 <code>string</code>
 </td>
 <td>
-   tlsPrivateKeyFile is the file containing x509 private key matching tlsCertFile.
+   <p>tlsPrivateKeyFile is the file containing x509 private key matching tlsCertFile.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tlsCipherSuites</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   tlsCipherSuites is the list of allowed cipher suites for the server.
+   <p>tlsCipherSuites is the list of allowed cipher suites for the server.
 Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>tlsMinVersion</code><br/>
 <code>string</code>
 </td>
 <td>
-   tlsMinVersion is the minimum TLS version supported.
+   <p>tlsMinVersion is the minimum TLS version supported.
 Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>rotateCertificates</code><br/>
 <code>bool</code>
 </td>
 <td>
-   rotateCertificates enables client certificate rotation. The Kubelet will request a
+   <p>rotateCertificates enables client certificate rotation. The Kubelet will request a
 new certificate from the certificates.k8s.io API. This requires an approver to approve the
 certificate signing requests.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 disabling it may disrupt the Kubelet's ability to authenticate with the API server
 after the current certificate expires.
-Default: false</td>
+Default: false</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>serverTLSBootstrap</code><br/>
 <code>bool</code>
 </td>
 <td>
-   serverTLSBootstrap enables server certificate bootstrap. Instead of self
+   <p>serverTLSBootstrap enables server certificate bootstrap. Instead of self
 signing a serving certificate, the Kubelet will request a certificate from
 the 'certificates.k8s.io' API. This requires an approver to approve the
 certificate signing requests (CSR). The RotateKubeletServerCertificate feature
@@ -251,63 +232,59 @@ dynamically updating this field, consider that
 disabling it will stop the renewal of Kubelet server certificates, which can
 disrupt components that interact with the Kubelet server in the long term,
 due to certificate expiration.
-Default: false</td>
+Default: false</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>authentication</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthentication"><code>KubeletAuthentication</code></a>
 </td>
 <td>
-   authentication specifies how requests to the Kubelet's server are authenticated.
+   <p>authentication specifies how requests to the Kubelet's server are authenticated.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
 Defaults:
-  anonymous:
-    enabled: false
-  webhook:
-    enabled: true
-    cacheTTL: "2m"</td>
+anonymous:
+enabled: false
+webhook:
+enabled: true
+cacheTTL: &quot;2m&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>authorization</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorization"><code>KubeletAuthorization</code></a>
 </td>
 <td>
-   authorization specifies how requests to the Kubelet's server are authorized.
+   <p>authorization specifies how requests to the Kubelet's server are authorized.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
 Defaults:
-  mode: Webhook
-  webhook:
-    cacheAuthorizedTTL: "5m"
-    cacheUnauthorizedTTL: "30s"</td>
+mode: Webhook
+webhook:
+cacheAuthorizedTTL: &quot;5m&quot;
+cacheUnauthorizedTTL: &quot;30s&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>registryPullQPS</code><br/>
 <code>int32</code>
 </td>
 <td>
-   registryPullQPS is the limit of registry pulls per second.
+   <p>registryPullQPS is the limit of registry pulls per second.
 The value must not be a negative number.
 Setting it to 0 means no limit.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact scalability by changing the amount of traffic produced
 by image pulls.
-Default: 5</td>
+Default: 5</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>registryBurst</code><br/>
 <code>int32</code>
 </td>
 <td>
-   registryBurst is the maximum size of bursty pulls, temporarily allows
+   <p>registryBurst is the maximum size of bursty pulls, temporarily allows
 pulls to burst to this number, while still not exceeding registryPullQPS.
 The value must not be a negative number.
 Only used if registryPullQPS is greater than 0.
@@ -315,151 +292,140 @@ If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact scalability by changing the amount of traffic produced
 by image pulls.
-Default: 10</td>
+Default: 10</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>eventRecordQPS</code><br/>
 <code>int32</code>
 </td>
 <td>
-   eventRecordQPS is the maximum event creations per second. If 0, there
+   <p>eventRecordQPS is the maximum event creations per second. If 0, there
 is no limit enforced. The value cannot be a negative number.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact scalability by changing the amount of traffic produced by
 event creations.
-Default: 5</td>
+Default: 5</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>eventBurst</code><br/>
 <code>int32</code>
 </td>
 <td>
-   eventBurst is the maximum size of a burst of event creations, temporarily
+   <p>eventBurst is the maximum size of a burst of event creations, temporarily
 allows event creations to burst to this number, while still not exceeding
 eventRecordQPS. This field canot be a negative number and it is only used
-when eventRecordQPS > 0.
+when eventRecordQPS &gt; 0.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact scalability by changing the amount of traffic produced by
 event creations.
-Default: 10</td>
+Default: 10</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableDebuggingHandlers</code><br/>
 <code>bool</code>
 </td>
 <td>
-   enableDebuggingHandlers enables server endpoints for log access
+   <p>enableDebuggingHandlers enables server endpoints for log access
 and local running of containers and commands, including the exec,
 attach, logs, and portforward features.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 disabling it may disrupt components that interact with the Kubelet server.
-Default: true</td>
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableContentionProfiling</code><br/>
 <code>bool</code>
 </td>
 <td>
-   enableContentionProfiling enables lock contention profiling, if enableDebuggingHandlers is true.
+   <p>enableContentionProfiling enables lock contention profiling, if enableDebuggingHandlers is true.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 enabling it may carry a performance impact.
-Default: false</td>
+Default: false</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>healthzPort</code><br/>
 <code>int32</code>
 </td>
 <td>
-   healthzPort is the port of the localhost healthz endpoint (set to 0 to disable).
+   <p>healthzPort is the port of the localhost healthz endpoint (set to 0 to disable).
 A valid number is between 1 and 65535.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that monitor Kubelet health.
-Default: 10248</td>
+Default: 10248</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>healthzBindAddress</code><br/>
 <code>string</code>
 </td>
 <td>
-   healthzBindAddress is the IP address for the healthz server to serve on.
+   <p>healthzBindAddress is the IP address for the healthz server to serve on.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that monitor Kubelet health.
-Default: "127.0.0.1"</td>
+Default: &quot;127.0.0.1&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>oomScoreAdj</code><br/>
 <code>int32</code>
 </td>
 <td>
-   oomScoreAdj is The oom-score-adj value for kubelet process. Values
+   <p>oomScoreAdj is The oom-score-adj value for kubelet process. Values
 must be within the range [-1000, 1000].
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact the stability of nodes under memory pressure.
-Default: -999</td>
+Default: -999</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clusterDomain</code><br/>
 <code>string</code>
 </td>
 <td>
-   clusterDomain is the DNS domain for this cluster. If set, kubelet will
+   <p>clusterDomain is the DNS domain for this cluster. If set, kubelet will
 configure all containers to search this domain in addition to the
 host's search domains.
 Dynamic Kubelet Config (deprecated): Dynamically updating this field is not recommended,
 as it should be kept in sync with the rest of the cluster.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>clusterDNS</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   clusterDNS is a list of IP addresses for the cluster DNS server. If set,
+   <p>clusterDNS is a list of IP addresses for the cluster DNS server. If set,
 kubelet will configure all containers to use this for DNS resolution
 instead of the host's DNS servers.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 changes will only take effect on Pods created after the update. Draining
 the node is recommended before changing this field.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>streamingConnectionIdleTimeout</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   streamingConnectionIdleTimeout is the maximum time a streaming connection
+   <p>streamingConnectionIdleTimeout is the maximum time a streaming connection
 can be idle before the connection is automatically closed.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact components that rely on infrequent updates over streaming
 connections to the Kubelet server.
-Default: "4h"</td>
+Default: &quot;4h&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodeStatusUpdateFrequency</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   nodeStatusUpdateFrequency is the frequency that kubelet computes node
+   <p>nodeStatusUpdateFrequency is the frequency that kubelet computes node
 status. If node lease feature is not enabled, it is also the frequency that
 kubelet posts node status to master.
 Note: When node lease feature is not enabled, be cautious when changing the
@@ -470,30 +436,28 @@ it may impact node scalability, and also that the node controller's
 nodeMonitorGracePeriod must be set to N&lowast;NodeStatusUpdateFrequency,
 where N is the number of retries before the node controller marks
 the node unhealthy.
-Default: "10s"</td>
+Default: &quot;10s&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodeStatusReportFrequency</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   nodeStatusReportFrequency is the frequency that kubelet posts node
+   <p>nodeStatusReportFrequency is the frequency that kubelet posts node
 status to master if node status does not change. Kubelet will ignore this
 frequency and post node status immediately if any change is detected. It is
 only used when node lease feature is enabled. nodeStatusReportFrequency's
 default value is 5m. But if nodeStatusUpdateFrequency is set explicitly,
 nodeStatusReportFrequency's default value will be set to
 nodeStatusUpdateFrequency for backward compatibility.
-Default: "5m"</td>
+Default: &quot;5m&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodeLeaseDurationSeconds</code><br/>
 <code>int32</code>
 </td>
 <td>
-   nodeLeaseDurationSeconds is the duration the Kubelet will set on its corresponding Lease.
+   <p>nodeLeaseDurationSeconds is the duration the Kubelet will set on its corresponding Lease.
 NodeLease provides an indicator of node health by having the Kubelet create and
 periodically renew a lease, named after the node, in the kube-node-lease namespace.
 If the lease expires, the node can be considered unhealthy.
@@ -504,27 +468,25 @@ If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 decreasing the duration may reduce tolerance for issues that temporarily prevent
 the Kubelet from renewing the lease (e.g. a short-lived network issue).
-Default: 40</td>
+Default: 40</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>imageMinimumGCAge</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   imageMinimumGCAge is the minimum age for an unused image before it is
+   <p>imageMinimumGCAge is the minimum age for an unused image before it is
 garbage collected. If DynamicKubeletConfig (deprecated; default off)
 is on, when dynamically updating this field, consider that  it may trigger or
 delay garbage collection, and may change the image overhead on the node.
-Default: "2m"</td>
+Default: &quot;2m&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>imageGCHighThresholdPercent</code><br/>
 <code>int32</code>
 </td>
 <td>
-   imageGCHighThresholdPercent is the percent of disk usage after which
+   <p>imageGCHighThresholdPercent is the percent of disk usage after which
 image garbage collection is always run. The percent is calculated by
 dividing this field value by 100, so this field must be between 0 and
 100, inclusive. When specified, the value must be greater than
@@ -533,15 +495,14 @@ If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may trigger or delay garbage collection, and may change the image overhead
 on the node.
-Default: 85</td>
+Default: 85</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>imageGCLowThresholdPercent</code><br/>
 <code>int32</code>
 </td>
 <td>
-   imageGCLowThresholdPercent is the percent of disk usage before which
+   <p>imageGCLowThresholdPercent is the percent of disk usage before which
 image garbage collection is never run. Lowest disk usage to garbage
 collect to. The percent is calculated by dividing this field value by 100,
 so the field value must be between 0 and 100, inclusive. When specified, the
@@ -550,227 +511,211 @@ If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may trigger or delay garbage collection, and may change the image overhead
 on the node.
-Default: 80</td>
+Default: 80</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>volumeStatsAggPeriod</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   volumeStatsAggPeriod is the frequency for calculating and caching volume
+   <p>volumeStatsAggPeriod is the frequency for calculating and caching volume
 disk usage for all pods.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 shortening the period may carry a performance impact.
-Default: "1m"</td>
+Default: &quot;1m&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubeletCgroups</code><br/>
 <code>string</code>
 </td>
 <td>
-   kubeletCgroups is the absolute name of cgroups to isolate the kubelet in
+   <p>kubeletCgroups is the absolute name of cgroups to isolate the kubelet in
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>systemCgroups</code><br/>
 <code>string</code>
 </td>
 <td>
-   systemCgroups is absolute name of cgroups in which to place
+   <p>systemCgroups is absolute name of cgroups in which to place
 all non-kernel processes that are not already in a container. Empty
 for no container. Rolling back the flag requires a reboot.
 The cgroupRoot must be specified if this field is not empty.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cgroupRoot</code><br/>
 <code>string</code>
 </td>
 <td>
-   cgroupRoot is the root cgroup to use for pods. This is handled by the
+   <p>cgroupRoot is the root cgroup to use for pods. This is handled by the
 container runtime on a best effort basis.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cgroupsPerQOS</code><br/>
 <code>bool</code>
 </td>
 <td>
-   cgroupsPerQOS enable QoS based CGroup hierarchy: top level CGroups for QoS classes
+   <p>cgroupsPerQOS enable QoS based CGroup hierarchy: top level CGroups for QoS classes
 and all Burstable and BestEffort Pods are brought up under their specific top level
 QoS CGroup.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: true</td>
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cgroupDriver</code><br/>
 <code>string</code>
 </td>
 <td>
-   cgroupDriver is the driver kubelet uses to manipulate CGroups on the host (cgroupfs
+   <p>cgroupDriver is the driver kubelet uses to manipulate CGroups on the host (cgroupfs
 or systemd).
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: "cgroupfs"</td>
+Default: &quot;cgroupfs&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cpuManagerPolicy</code><br/>
 <code>string</code>
 </td>
 <td>
-   cpuManagerPolicy is the name of the policy to use.
+   <p>cpuManagerPolicy is the name of the policy to use.
 Requires the CPUManager feature gate to be enabled.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: "None"</td>
+Default: &quot;None&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cpuManagerPolicyOptions</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   cpuManagerPolicyOptions is a set of key=value which 	allows to set extra options
+   <p>cpuManagerPolicyOptions is a set of key=value which 	allows to set extra options
 to fine tune the behaviour of the cpu manager policies.
-Requires  both the "CPUManager" and "CPUManagerPolicyOptions" feature gates to be enabled.
+Requires  both the &quot;CPUManager&quot; and &quot;CPUManagerPolicyOptions&quot; feature gates to be enabled.
 Dynamic Kubelet Config (beta): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cpuManagerReconcilePeriod</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   cpuManagerReconcilePeriod is the reconciliation period for the CPU Manager.
+   <p>cpuManagerReconcilePeriod is the reconciliation period for the CPU Manager.
 Requires the CPUManager feature gate to be enabled.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 shortening the period may carry a performance impact.
-Default: "10s"</td>
+Default: &quot;10s&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>memoryManagerPolicy</code><br/>
 <code>string</code>
 </td>
 <td>
-   memoryManagerPolicy is the name of the policy to use by memory manager.
+   <p>memoryManagerPolicy is the name of the policy to use by memory manager.
 Requires the MemoryManager feature gate to be enabled.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: "none"</td>
+Default: &quot;none&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>topologyManagerPolicy</code><br/>
 <code>string</code>
 </td>
 <td>
-   topologyManagerPolicy is the name of the topology manager policy to use.
-Valid values include:
-
-- `restricted`: kubelet only allows pods with optimal NUMA node alignment for
-  requested resources;
-- `best-effort`: kubelet will favor pods with NUMA alignment of CPU and device
-  resources;
-- `none`: kubelet has no knowledge of NUMA alignment of a pod's CPU and device resources.
-- `single-numa-node`: kubelet only allows pods with a single NUMA alignment
-  of CPU and device resources.
-
-Policies other than "none" require the TopologyManager feature gate to be enabled.
+   <p>topologyManagerPolicy is the name of the topology manager policy to use.
+Valid values include:</p>
+<ul>
+<li><code>restricted</code>: kubelet only allows pods with optimal NUMA node alignment for
+requested resources;</li>
+<li><code>best-effort</code>: kubelet will favor pods with NUMA alignment of CPU and device
+resources;</li>
+<li><code>none</code>: kubelet has no knowledge of NUMA alignment of a pod's CPU and device resources.</li>
+<li><code>single-numa-node</code>: kubelet only allows pods with a single NUMA alignment
+of CPU and device resources.</li>
+</ul>
+<p>Policies other than &quot;none&quot; require the TopologyManager feature gate to be enabled.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: "none"</td>
+Default: &quot;none&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>topologyManagerScope</code><br/>
 <code>string</code>
 </td>
 <td>
-   topologyManagerScope represents the scope of topology hint generation
-that topology manager requests and hint providers generate. Valid values include:
-
-- `container`: topology policy is applied on a per-container basis.
-- `pod`: topology policy is applied on a per-pod basis.
-
-"pod" scope requires the TopologyManager feature gate to be enabled.
-Default: "container"</td>
+   <p>topologyManagerScope represents the scope of topology hint generation
+that topology manager requests and hint providers generate. Valid values include:</p>
+<ul>
+<li><code>container</code>: topology policy is applied on a per-container basis.</li>
+<li><code>pod</code>: topology policy is applied on a per-pod basis.</li>
+</ul>
+<p>&quot;pod&quot; scope requires the TopologyManager feature gate to be enabled.
+Default: &quot;container&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>qosReserved</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   qosReserved is a set of resource name to percentage pairs that specify
+   <p>qosReserved is a set of resource name to percentage pairs that specify
 the minimum percentage of a resource reserved for exclusive use by the
 guaranteed QoS tier.
-Currently supported resources: "memory"
+Currently supported resources: &quot;memory&quot;
 Requires the QOSReserved feature gate to be enabled.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>runtimeRequestTimeout</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   runtimeRequestTimeout is the timeout for all runtime requests except long running
+   <p>runtimeRequestTimeout is the timeout for all runtime requests except long running
 requests - pull, logs, exec and attach.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may disrupt components that interact with the Kubelet server.
-Default: "2m"</td>
+Default: &quot;2m&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>hairpinMode</code><br/>
 <code>string</code>
 </td>
 <td>
-   hairpinMode specifies how the Kubelet should configure the container
+   <p>hairpinMode specifies how the Kubelet should configure the container
 bridge for hairpin packets.
 Setting this flag allows endpoints in a Service to loadbalance back to
-themselves if they should try to access their own Service. Values:
-
-- "promiscuous-bridge": make the container bridge promiscuous.
-- "hairpin-veth":       set the hairpin flag on container veth interfaces.
-- "none":               do nothing.
-
-Generally, one must set `--hairpin-mode=hairpin-veth to` achieve hairpin NAT,
+themselves if they should try to access their own Service. Values:</p>
+<ul>
+<li>&quot;promiscuous-bridge&quot;: make the container bridge promiscuous.</li>
+<li>&quot;hairpin-veth&quot;:       set the hairpin flag on container veth interfaces.</li>
+<li>&quot;none&quot;:               do nothing.</li>
+</ul>
+<p>Generally, one must set <code>--hairpin-mode=hairpin-veth to</code> achieve hairpin NAT,
 because promiscuous-bridge assumes the existence of a container bridge named cbr0.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may require a node reboot, depending on the network plugin.
-Default: "promiscuous-bridge"</td>
+Default: &quot;promiscuous-bridge&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>maxPods</code><br/>
 <code>int32</code>
 </td>
 <td>
-   maxPods is the maximum number of Pods that can run on this Kubelet.
+   <p>maxPods is the maximum number of Pods that can run on this Kubelet.
 The value must be a non-negative integer.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
@@ -778,233 +723,216 @@ changes may cause Pods to fail admission on Kubelet restart, and may change
 the value reported in Node.Status.Capacity[v1.ResourcePods], thus affecting
 future scheduling decisions. Increasing this value may also decrease performance,
 as more Pods can be packed into a single node.
-Default: 110</td>
+Default: 110</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podCIDR</code><br/>
 <code>string</code>
 </td>
 <td>
-   podCIDR is the CIDR to use for pod IP addresses, only used in standalone mode.
+   <p>podCIDR is the CIDR to use for pod IP addresses, only used in standalone mode.
 In cluster mode, this is obtained from the control plane.
 Dynamic Kubelet Config (deprecated): This field should always be set to the empty default.
 It should only set for standalone Kubelets, which cannot use Dynamic Kubelet Config.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podPidsLimit</code><br/>
 <code>int64</code>
 </td>
 <td>
-   podPidsLimit is the maximum number of PIDs in any pod.
+   <p>podPidsLimit is the maximum number of PIDs in any pod.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 lowering it may prevent container processes from forking after the change.
-Default: -1</td>
+Default: -1</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>resolvConf</code><br/>
 <code>string</code>
 </td>
 <td>
-   resolvConf is the resolver configuration file used as the basis
+   <p>resolvConf is the resolver configuration file used as the basis
 for the container DNS resolution configuration.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 changes will only take effect on Pods created after the update. Draining
 the node is recommended before changing this field.
 If set to the empty string, will override the default and effectively disable DNS lookups.
-Default: "/etc/resolv.conf"</td>
+Default: &quot;/etc/resolv.conf&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>runOnce</code><br/>
 <code>bool</code>
 </td>
 <td>
-   runOnce causes the Kubelet to check the API server once for pods,
+   <p>runOnce causes the Kubelet to check the API server once for pods,
 run those in addition to the pods specified by static pod files, and exit.
-Default: false</td>
+Default: false</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cpuCFSQuota</code><br/>
 <code>bool</code>
 </td>
 <td>
-   cpuCFSQuota enables CPU CFS quota enforcement for containers that
+   <p>cpuCFSQuota enables CPU CFS quota enforcement for containers that
 specify CPU limits.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 disabling it may reduce node stability.
-Default: true</td>
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cpuCFSQuotaPeriod</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   cpuCFSQuotaPeriod is the CPU CFS quota period value, `cpu.cfs_period_us`.
+   <p>cpuCFSQuotaPeriod is the CPU CFS quota period value, <code>cpu.cfs_period_us</code>.
 The value must be between 1 us and 1 second, inclusive.
 Requires the CustomCPUCFSQuotaPeriod feature gate to be enabled.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 limits set for containers will result in different cpu.cfs_quota settings. This
 will trigger container restarts on the node being reconfigured.
-Default: "100ms"</td>
+Default: &quot;100ms&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>nodeStatusMaxImages</code><br/>
 <code>int32</code>
 </td>
 <td>
-   nodeStatusMaxImages caps the number of images reported in Node.status.images.
+   <p>nodeStatusMaxImages caps the number of images reported in Node.status.images.
 The value must be greater than -2.
 Note: If -1 is specified, no cap will be applied. If 0 is specified, no image is returned.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 different values can be reported on node status.
-Default: 50</td>
+Default: 50</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>maxOpenFiles</code><br/>
 <code>int64</code>
 </td>
 <td>
-   maxOpenFiles is Number of files that can be opened by Kubelet process.
+   <p>maxOpenFiles is Number of files that can be opened by Kubelet process.
 The value must be a non-negative number.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact the ability of the Kubelet to interact with the node's filesystem.
-Default: 1000000</td>
+Default: 1000000</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>contentType</code><br/>
 <code>string</code>
 </td>
 <td>
-   contentType is contentType of requests sent to apiserver.
+   <p>contentType is contentType of requests sent to apiserver.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact the ability for the Kubelet to communicate with the API server.
 If the Kubelet loses contact with the API server due to a change to this field,
 the change cannot be reverted via dynamic Kubelet config.
-Default: "application/vnd.kubernetes.protobuf"</td>
+Default: &quot;application/vnd.kubernetes.protobuf&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubeAPIQPS</code><br/>
 <code>int32</code>
 </td>
 <td>
-   kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
+   <p>kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact scalability by changing the amount of traffic the Kubelet
 sends to the API server.
-Default: 5</td>
+Default: 5</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubeAPIBurst</code><br/>
 <code>int32</code>
 </td>
 <td>
-   kubeAPIBurst is the burst to allow while talking with kubernetes API server.
+   <p>kubeAPIBurst is the burst to allow while talking with kubernetes API server.
 This field cannot be a negative number.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact scalability by changing the amount of traffic the Kubelet
 sends to the API server.
-Default: 10</td>
+Default: 10</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>serializeImagePulls</code><br/>
 <code>bool</code>
 </td>
 <td>
-   serializeImagePulls when enabled, tells the Kubelet to pull images one
-at a time. We recommend &lowast;not&lowast; changing the default value on nodes that
-run docker daemon with version  < 1.9 or an Aufs storage backend.
+   <p>serializeImagePulls when enabled, tells the Kubelet to pull images one
+at a time. We recommend <em>not</em> changing the default value on nodes that
+run docker daemon with version  &lt; 1.9 or an Aufs storage backend.
 Issue #10959 has more details.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact the performance of image pulls.
-Default: true</td>
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>evictionHard</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   evictionHard is a map of signal names to quantities that defines hard eviction
-thresholds. For example: `{"memory.available": "300Mi"}`.
+   <p>evictionHard is a map of signal names to quantities that defines hard eviction
+thresholds. For example: <code>{&quot;memory.available&quot;: &quot;300Mi&quot;}</code>.
 To explicitly disable, pass a 0% or 100% threshold on an arbitrary resource.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may trigger or delay Pod evictions.
 Default:
-  memory.available:  "100Mi"
-  nodefs.available:  "10%"
-  nodefs.inodesFree: "5%"
-  imagefs.available: "15%"</td>
+memory.available:  &quot;100Mi&quot;
+nodefs.available:  &quot;10%&quot;
+nodefs.inodesFree: &quot;5%&quot;
+imagefs.available: &quot;15%&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>evictionSoft</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   evictionSoft is a map of signal names to quantities that defines soft eviction thresholds.
-For example: `{"memory.available": "300Mi"}`.
+   <p>evictionSoft is a map of signal names to quantities that defines soft eviction thresholds.
+For example: <code>{&quot;memory.available&quot;: &quot;300Mi&quot;}</code>.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may trigger or delay Pod evictions, and may change the allocatable reported
 by the node.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>evictionSoftGracePeriod</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   evictionSoftGracePeriod is a map of signal names to quantities that defines grace
-periods for each soft eviction signal. For example: `{"memory.available": "30s"}`.
+   <p>evictionSoftGracePeriod is a map of signal names to quantities that defines grace
+periods for each soft eviction signal. For example: <code>{&quot;memory.available&quot;: &quot;30s&quot;}</code>.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may trigger or delay Pod evictions.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>evictionPressureTransitionPeriod</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   evictionPressureTransitionPeriod is the duration for which the kubelet has to wait
+   <p>evictionPressureTransitionPeriod is the duration for which the kubelet has to wait
 before transitioning out of an eviction pressure condition.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 lowering it may decrease the stability of the node when the node is overcommitted.
-Default: "5m"</td>
+Default: &quot;5m&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>evictionMaxPodGracePeriod</code><br/>
 <code>int32</code>
 </td>
 <td>
-   evictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use
+   <p>evictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use
 when terminating pods in response to a soft eviction threshold being met. This value
 effectively caps the Pod's terminationGracePeriodSeconds value during soft evictions.
 Note: Due to issue #64530, the behavior has a bug where this value currently just
@@ -1014,47 +942,44 @@ If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 lowering it decreases the amount of time Pods will have to gracefully clean
 up before being killed during a soft eviction.
-Default: 0</td>
+Default: 0</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>evictionMinimumReclaim</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   evictionMinimumReclaim is a map of signal names to quantities that defines minimum reclaims,
+   <p>evictionMinimumReclaim is a map of signal names to quantities that defines minimum reclaims,
 which describe the minimum amount of a given resource the kubelet will reclaim when
 performing a pod eviction while that resource is under pressure.
-For example: `{"imagefs.available": "2Gi"}`.
+For example: <code>{&quot;imagefs.available&quot;: &quot;2Gi&quot;}</code>.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may change how well eviction can manage resource pressure.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>podsPerCore</code><br/>
 <code>int32</code>
 </td>
 <td>
-   podsPerCore is the maximum number of pods per core. Cannot exceed maxPods.
+   <p>podsPerCore is the maximum number of pods per core. Cannot exceed maxPods.
 The value must be a non-negative integer.
 If 0, there is no limit on the number of Pods.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 changes may cause Pods to fail admission on Kubelet restart, and may change
-the value reported in `Node.status.capacity.pods`, thus affecting
+the value reported in <code>Node.status.capacity.pods</code>, thus affecting
 future scheduling decisions. Increasing this value may also decrease performance,
 as more Pods can be packed into a single node.
-Default: 0</td>
+Default: 0</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableControllerAttachDetach</code><br/>
 <code>bool</code>
 </td>
 <td>
-   enableControllerAttachDetach enables the Attach/Detach controller to
+   <p>enableControllerAttachDetach enables the Attach/Detach controller to
 manage attachment/detachment of volumes scheduled to this node, and
 disables kubelet from executing any attach/detach operations.
 If DynamicKubeletConfig (deprecated; default off) is on, when
@@ -1064,45 +989,42 @@ may result in volumes refusing to detach if the node is not drained prior to
 the update, and if Pods are scheduled to the node before the
 volumes.kubernetes.io/controller-managed-attach-detach annotation is updated by the
 Kubelet. In general, it is safest to leave this value set the same as local config.
-Default: true</td>
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>protectKernelDefaults</code><br/>
 <code>bool</code>
 </td>
 <td>
-   protectKernelDefaults, if true, causes the Kubelet to error if kernel
+   <p>protectKernelDefaults, if true, causes the Kubelet to error if kernel
 flags are not as it expects. Otherwise the Kubelet will attempt to modify
 kernel flags to match its expectation.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 enabling it may cause the Kubelet to crash-loop if the Kernel is not configured as
 Kubelet expects.
-Default: false</td>
+Default: false</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>makeIPTablesUtilChains</code><br/>
 <code>bool</code>
 </td>
 <td>
-   makeIPTablesUtilChains, if true, causes the Kubelet ensures a set of iptables rules
+   <p>makeIPTablesUtilChains, if true, causes the Kubelet ensures a set of iptables rules
 are present on host.
 These rules will serve as utility rules for various components, e.g. kube-proxy.
 The rules will be created based on iptablesMasqueradeBit and iptablesDropBit.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 disabling it will prevent the Kubelet from healing locally misconfigured iptables rules.
-Default: true</td>
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>iptablesMasqueradeBit</code><br/>
 <code>int32</code>
 </td>
 <td>
-   iptablesMasqueradeBit is the bit of the iptables fwmark space to mark for SNAT.
+   <p>iptablesMasqueradeBit is the bit of the iptables fwmark space to mark for SNAT.
 Values must be within the range [0, 31]. Must be different from other mark bits.
 Warning: Please match the value of the corresponding parameter in kube-proxy.
 TODO: clean up IPTablesMasqueradeBit in kube-proxy.
@@ -1110,107 +1032,99 @@ If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it needs to be coordinated with other components, like kube-proxy, and the update
 will only be effective if MakeIPTablesUtilChains is enabled.
-Default: 14</td>
+Default: 14</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>iptablesDropBit</code><br/>
 <code>int32</code>
 </td>
 <td>
-   iptablesDropBit is the bit of the iptables fwmark space to mark for dropping packets.
+   <p>iptablesDropBit is the bit of the iptables fwmark space to mark for dropping packets.
 Values must be within the range [0, 31]. Must be different from other mark bits.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it needs to be coordinated with other components, like kube-proxy, and the update
 will only be effective if MakeIPTablesUtilChains is enabled.
-Default: 15</td>
+Default: 15</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>featureGates</code><br/>
 <code>map[string]bool</code>
 </td>
 <td>
-   featureGates is a map of feature names to bools that enable or disable experimental
+   <p>featureGates is a map of feature names to bools that enable or disable experimental
 features. This field modifies piecemeal the built-in default values from
-"k8s.io/kubernetes/pkg/features/kube_features.go".
+&quot;k8s.io/kubernetes/pkg/features/kube_features.go&quot;.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider the
 documentation for the features you are enabling or disabling. While we
 encourage feature developers to make it possible to dynamically enable
 and disable features, some changes may require node reboots, and some
 features may require careful coordination to retroactively disable.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>failSwapOn</code><br/>
 <code>bool</code>
 </td>
 <td>
-   failSwapOn tells the Kubelet to fail to start if swap is enabled on the node.
+   <p>failSwapOn tells the Kubelet to fail to start if swap is enabled on the node.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 setting it to true will cause the Kubelet to crash-loop if swap is enabled.
-Default: true</td>
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>memorySwap</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-MemorySwapConfiguration"><code>MemorySwapConfiguration</code></a>
 </td>
 <td>
-   memorySwap configures swap memory available to container workloads.</td>
+   <p>memorySwap configures swap memory available to container workloads.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>containerLogMaxSize</code><br/>
 <code>string</code>
 </td>
 <td>
-   containerLogMaxSize is a quantity defining the maximum size of the container log
-file before it is rotated. For example: "5Mi" or "256Ki".
+   <p>containerLogMaxSize is a quantity defining the maximum size of the container log
+file before it is rotated. For example: &quot;5Mi&quot; or &quot;256Ki&quot;.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may trigger log rotation.
-Default: "10Mi"</td>
+Default: &quot;10Mi&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>containerLogMaxFiles</code><br/>
 <code>int32</code>
 </td>
 <td>
-   containerLogMaxFiles specifies the maximum number of container log files that can
+   <p>containerLogMaxFiles specifies the maximum number of container log files that can
 be present for a container.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 lowering it may cause log files to be deleted.
-Default: 5</td>
+Default: 5</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>configMapAndSecretChangeDetectionStrategy</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-ResourceChangeDetectionStrategy"><code>ResourceChangeDetectionStrategy</code></a>
 </td>
 <td>
-   configMapAndSecretChangeDetectionStrategy is a mode in which ConfigMap and Secret
-managers are running. Valid values include:
-
-- `Get`: kubelet fetches necessary objects directly from the API server;
-- `Cache`: kubelet uses TTL cache for object fetched from the API server;
-- `Watch`: kubelet uses watches to observe changes to objects that are in its interest.
-
-Default: "Watch"</td>
+   <p>configMapAndSecretChangeDetectionStrategy is a mode in which ConfigMap and Secret
+managers are running. Valid values include:</p>
+<ul>
+<li><code>Get</code>: kubelet fetches necessary objects directly from the API server;</li>
+<li><code>Cache</code>: kubelet uses TTL cache for object fetched from the API server;</li>
+<li><code>Watch</code>: kubelet uses watches to observe changes to objects that are in its interest.</li>
+</ul>
+<p>Default: &quot;Watch&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>systemReserved</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   systemReserved is a set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G)
+   <p>systemReserved is a set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G)
 pairs that describe resources reserved for non-kubernetes components.
 Currently only cpu and memory are supported.
 See http://kubernetes.io/docs/user-guide/compute-resources for more detail.
@@ -1219,15 +1133,14 @@ dynamically updating this field, consider that
 it may not be possible to increase the reserved resources, because this
 requires resizing cgroups. Always look for a NodeAllocatableEnforced event
 after updating this field to ensure that the update was successful.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubeReserved</code><br/>
 <code>map[string]string</code>
 </td>
 <td>
-   kubeReserved is a set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs
+   <p>kubeReserved is a set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs
 that describe resources reserved for kubernetes system components.
 Currently cpu, memory and local storage for root file system are supported.
 See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -1237,76 +1150,71 @@ dynamically updating this field, consider that
 it may not be possible to increase the reserved resources, because this
 requires resizing cgroups. Always look for a NodeAllocatableEnforced event
 after updating this field to ensure that the update was successful.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>reservedSystemCPUs</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   The reservedSystemCPUs option specifies the CPU list reserved for the host
-level system threads and kubernetes related threads. This provide a "static"
-CPU list rather than the "dynamic" list by systemReserved and kubeReserved.
-This option does not support systemReservedCgroup or kubeReservedCgroup.</td>
+   <p>The reservedSystemCPUs option specifies the CPU list reserved for the host
+level system threads and kubernetes related threads. This provide a &quot;static&quot;
+CPU list rather than the &quot;dynamic&quot; list by systemReserved and kubeReserved.
+This option does not support systemReservedCgroup or kubeReservedCgroup.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>showHiddenMetricsForVersion</code><br/>
 <code>string</code>
 </td>
 <td>
-   showHiddenMetricsForVersion is the previous version for which you want to show
+   <p>showHiddenMetricsForVersion is the previous version for which you want to show
 hidden metrics.
 Only the previous minor version is meaningful, other values will not be allowed.
-The format is `<major>.<minor>`, e.g.: `1.16`.
+The format is <code>&lt;major&gt;.&lt;minor&gt;</code>, e.g.: <code>1.16</code>.
 The purpose of this format is make sure you have the opportunity to notice
 if the next release hides additional metrics, rather than being surprised
 when they are permanently removed in the release after that.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>systemReservedCgroup</code><br/>
 <code>string</code>
 </td>
 <td>
-   systemReservedCgroup helps the kubelet identify absolute name of top level CGroup used
-to enforce `systemReserved` compute resource reservation for OS system daemons.
-Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md)
+   <p>systemReservedCgroup helps the kubelet identify absolute name of top level CGroup used
+to enforce <code>systemReserved</code> compute resource reservation for OS system daemons.
+Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
 doc for more information.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kubeReservedCgroup</code><br/>
 <code>string</code>
 </td>
 <td>
-   kubeReservedCgroup helps the kubelet identify absolute name of top level CGroup used
-to enforce `KubeReserved` compute resource reservation for Kubernetes node system daemons.
-Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md)
+   <p>kubeReservedCgroup helps the kubelet identify absolute name of top level CGroup used
+to enforce <code>KubeReserved</code> compute resource reservation for Kubernetes node system daemons.
+Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
 doc for more information.
 Dynamic Kubelet Config (deprecated): This field should not be updated without a full node
 reboot. It is safest to keep this value the same as the local config.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enforceNodeAllocatable</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   This flag specifies the various Node Allocatable enforcements that Kubelet needs to perform.
-This flag accepts a list of options. Acceptable options are `none`, `pods`,
-`system-reserved` and `kube-reserved`.
-If `none` is specified, no other options may be specified.
-When `system-reserved` is in the list, systemReservedCgroup must be specified.
-When `kube-reserved` is in the list, kubeReservedCgroup must be specified.
-This field is supported only when `cgroupsPerQOS` is set to true.
-Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md)
+   <p>This flag specifies the various Node Allocatable enforcements that Kubelet needs to perform.
+This flag accepts a list of options. Acceptable options are <code>none</code>, <code>pods</code>,
+<code>system-reserved</code> and <code>kube-reserved</code>.
+If <code>none</code> is specified, no other options may be specified.
+When <code>system-reserved</code> is in the list, systemReservedCgroup must be specified.
+When <code>kube-reserved</code> is in the list, kubeReservedCgroup must be specified.
+This field is supported only when <code>cgroupsPerQOS</code> is set to true.
+Refer to <a href="https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md">Node Allocatable</a>
 for more information.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
@@ -1315,111 +1223,102 @@ enforcements may reduce the stability of components which were using more than
 the reserved amount of resources; for example, enforcing kube-reserved may cause
 Kubelets to OOM if it uses more than the reserved resources, and enforcing system-reserved
 may cause system daemons to OOM if they use more than the reserved resources.
-Default: ["pods"]</td>
+Default: [&quot;pods&quot;]</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>allowedUnsafeSysctls</code><br/>
 <code>[]string</code>
 </td>
 <td>
-   A comma separated whitelist of unsafe sysctls or sysctl patterns (ending in `&lowast;`).
-Unsafe sysctl groups are `kernel.shm&lowast;`, `kernel.msg&lowast;`, `kernel.sem`, `fs.mqueue.&lowast;`,
-and `net.&lowast;`. For example: "`kernel.msg&lowast;,net.ipv4.route.min_pmtu`"
-Default: []</td>
+   <p>A comma separated whitelist of unsafe sysctls or sysctl patterns (ending in <code>&lowast;</code>).
+Unsafe sysctl groups are <code>kernel.shm&lowast;</code>, <code>kernel.msg&lowast;</code>, <code>kernel.sem</code>, <code>fs.mqueue.&lowast;</code>,
+and <code>net.&lowast;</code>. For example: &quot;<code>kernel.msg&lowast;,net.ipv4.route.min_pmtu</code>&quot;
+Default: []</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>volumePluginDir</code><br/>
 <code>string</code>
 </td>
 <td>
-   volumePluginDir is the full path of the directory in which to search
+   <p>volumePluginDir is the full path of the directory in which to search
 for additional third party volume plugins.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that changing
 the volumePluginDir may disrupt workloads relying on third party volume plugins.
-Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"</td>
+Default: &quot;/usr/libexec/kubernetes/kubelet-plugins/volume/exec/&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>providerID</code><br/>
 <code>string</code>
 </td>
 <td>
-   providerID, if set, sets the unique ID of the instance that an external
+   <p>providerID, if set, sets the unique ID of the instance that an external
 provider (i.e. cloudprovider) can use to identify a specific node.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact the ability of the Kubelet to interact with cloud providers.
-Default: ""</td>
+Default: &quot;&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>kernelMemcgNotification</code><br/>
 <code>bool</code>
 </td>
 <td>
-   kernelMemcgNotification, if set, instructs the the kubelet to integrate with the
+   <p>kernelMemcgNotification, if set, instructs the the kubelet to integrate with the
 kernel memcg notification for determining if memory eviction thresholds are
 exceeded rather than polling.
 If DynamicKubeletConfig (deprecated; default off) is on, when
 dynamically updating this field, consider that
 it may impact the way Kubelet interacts with the kernel.
-Default: false</td>
+Default: false</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>logging</code> <B>[Required]</B><br/>
 <a href="#LoggingConfiguration"><code>LoggingConfiguration</code></a>
 </td>
 <td>
-   logging specifies the options of logging.
-Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go)
+   <p>logging specifies the options of logging.
+Refer to <a href="https://github.com/kubernetes/component-base/blob/master/logs/options.go">Logs Options</a>
 for more information.
 Default:
-  Format: text</td>
+Format: text</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableSystemLogHandler</code><br/>
 <code>bool</code>
 </td>
 <td>
-   enableSystemLogHandler enables system logs via web interface host:port/logs/
-Default: true</td>
+   <p>enableSystemLogHandler enables system logs via web interface host:port/logs/
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>shutdownGracePeriod</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   shutdownGracePeriod specifies the total duration that the node should delay the
+   <p>shutdownGracePeriod specifies the total duration that the node should delay the
 shutdown and total grace period for pod termination during a node shutdown.
-Default: "0s"</td>
+Default: &quot;0s&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>shutdownGracePeriodCriticalPods</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   shutdownGracePeriodCriticalPods specifies the duration used to terminate critical
+   <p>shutdownGracePeriodCriticalPods specifies the duration used to terminate critical
 pods during a node shutdown. This should be less than shutdownGracePeriod.
 For example, if shutdownGracePeriod=30s, and shutdownGracePeriodCriticalPods=10s,
 during a node shutdown the first 20 seconds would be reserved for gracefully
 terminating normal pods, and the last 10 seconds would be reserved for terminating
 critical pods.
-Default: "0s"</td>
+Default: &quot;0s&quot;</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>shutdownGracePeriodByPodPriority</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-ShutdownGracePeriodByPodPriority"><code>[]ShutdownGracePeriodByPodPriority</code></a>
 </td>
 <td>
-   shutdownGracePeriodByPodPriority specifies the shutdown grace period for Pods based
+   <p>shutdownGracePeriodByPodPriority specifies the shutdown grace period for Pods based
 on their associated priority class value.
 When a shutdown request is received, the Kubelet will initiate shutdown on all pods
 running on the node with a grace period that depends on the priority of the pod,
@@ -1427,32 +1326,31 @@ and then wait for all pods to exit.
 Each entry in the array represents the graceful shutdown time a pod with a priority
 class value that lies in the range of that value and the next higher entry in the
 list when the node is shutting down.
-For example, to allow critical pods 10s to shutdown, priority>=10000 pods 20s to
-shutdown, and all remaining pods 30s to shutdown.
-
-shutdownGracePeriodByPodPriority:
-  - priority: 2000000000
-    shutdownGracePeriodSeconds: 10
-  - priority: 10000
-    shutdownGracePeriodSeconds: 20
-  - priority: 0
-    shutdownGracePeriodSeconds: 30
-
-The time the Kubelet will wait before exiting will at most be the maximum of all
+For example, to allow critical pods 10s to shutdown, priority&gt;=10000 pods 20s to
+shutdown, and all remaining pods 30s to shutdown.</p>
+<p>shutdownGracePeriodByPodPriority:</p>
+<ul>
+<li>priority: 2000000000
+shutdownGracePeriodSeconds: 10</li>
+<li>priority: 10000
+shutdownGracePeriodSeconds: 20</li>
+<li>priority: 0
+shutdownGracePeriodSeconds: 30</li>
+</ul>
+<p>The time the Kubelet will wait before exiting will at most be the maximum of all
 shutdownGracePeriodSeconds for each priority class range represented on the node.
 When all pods have exited or reached their grace periods, the Kubelet will release
 the shutdown inhibit lock.
 Requires the GracefulNodeShutdown feature gate to be enabled.
 This configuration must be empty if either ShutdownGracePeriod or ShutdownGracePeriodCriticalPods is set.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>reservedMemory</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-MemoryReservation"><code>[]MemoryReservation</code></a>
 </td>
 <td>
-   reservedMemory specifies a comma-separated list of memory reservations for NUMA nodes.
+   <p>reservedMemory specifies a comma-separated list of memory reservations for NUMA nodes.
 The parameter makes sense only in the context of the memory manager feature.
 The memory manager will not allocate reserved memory for container workloads.
 For example, if you have a NUMA0 with 10Gi of memory and the reservedMemory was
@@ -1461,95 +1359,85 @@ only 9Gi is available for allocation.
 You can specify a different amount of NUMA node and memory types.
 You can omit this parameter at all, but you should be aware that the amount of
 reserved memory from all NUMA nodes should be equal to the amount of memory specified
-by the [node allocatable](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable).
+by the <a href="https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable">node allocatable</a>.
 If at least one node allocatable parameter has a non-zero value, you will need
 to specify at least one NUMA node.
-Also, avoid specifying:
-
-1. Duplicates, the same NUMA node, and memory type, but with a different value.
-2. zero limits for any memory type.
-3. NUMAs nodes IDs that do not exist under the machine.
-4. memory types except for memory and hugepages-<size>
-
-Default: nil</td>
+Also, avoid specifying:</p>
+<ol>
+<li>Duplicates, the same NUMA node, and memory type, but with a different value.</li>
+<li>zero limits for any memory type.</li>
+<li>NUMAs nodes IDs that do not exist under the machine.</li>
+<li>memory types except for memory and hugepages-<!-- raw HTML omitted --></li>
+</ol>
+<p>Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableProfilingHandler</code><br/>
 <code>bool</code>
 </td>
 <td>
-   enableProfilingHandler enables profiling via web interface host:port/debug/pprof/
-Default: true</td>
+   <p>enableProfilingHandler enables profiling via web interface host:port/debug/pprof/
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>enableDebugFlagsHandler</code><br/>
 <code>bool</code>
 </td>
 <td>
-   enableDebugFlagsHandler enables flags endpoint via web interface host:port/debug/flags/v
-Default: true</td>
+   <p>enableDebugFlagsHandler enables flags endpoint via web interface host:port/debug/flags/v
+Default: true</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>seccompDefault</code><br/>
 <code>bool</code>
 </td>
 <td>
-   SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+   <p>SeccompDefault enables the use of <code>RuntimeDefault</code> as the default seccomp profile for all workloads.
 This requires the corresponding SeccompDefault feature gate to be enabled as well.
-Default: false</td>
+Default: false</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>memoryThrottlingFactor</code><br/>
 <code>float64</code>
 </td>
 <td>
-   MemoryThrottlingFactor specifies the factor multiplied by the memory limit or node allocatable memory
+   <p>MemoryThrottlingFactor specifies the factor multiplied by the memory limit or node allocatable memory
 when setting the cgroupv2 memory.high value to enforce MemoryQoS.
 Decreasing this factor will set lower high limit for container cgroups and put heavier reclaim pressure
 while increasing will put less reclaim pressure.
 See http://kep.k8s.io/2570 for more details.
-Default: 0.8</td>
+Default: 0.8</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>registerWithTaints</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#taint-v1-core"><code>[]core/v1.Taint</code></a>
 </td>
 <td>
-   registerWithTaints are an array of taints to add to a node object when
+   <p>registerWithTaints are an array of taints to add to a node object when
 the kubelet registers itself. This only takes effect when registerNode
 is true and upon the initial registration of the node.
-Default: nil</td>
+Default: nil</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>registerNode</code><br/>
 <code>bool</code>
 </td>
 <td>
-   registerNode enables automatic registration with the apiserver.
-Default: true</td>
+   <p>registerNode enables automatic registration with the apiserver.
+Default: true</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `SerializedNodeConfigSource`     {#kubelet-config-k8s-io-v1beta1-SerializedNodeConfigSource}
     
 
 
-
-
-SerializedNodeConfigSource allows us to serialize v1.NodeConfigSource.
+<p>SerializedNodeConfigSource allows us to serialize v1.NodeConfigSource.
 This type is used internally by the Kubelet for tracking checkpointed dynamic configs.
-It exists in the kubeletconfig API group because it is classified as a versioned input to the Kubelet.
+It exists in the kubeletconfig API group because it is classified as a versioned input to the Kubelet.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -1558,39 +1446,19 @@ It exists in the kubeletconfig API group because it is classified as a versioned
 <tr><td><code>apiVersion</code><br/>string</td><td><code>kubelet.config.k8s.io/v1beta1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>SerializedNodeConfigSource</code></td></tr>
     
-
-  
   
 <tr><td><code>source</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#nodeconfigsource-v1-core"><code>core/v1.NodeConfigSource</code></a>
 </td>
 <td>
-   source is the source that we are serializing.</td>
+   <p>source is the source that we are serializing.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
-
-## `HairpinMode`     {#kubelet-config-k8s-io-v1beta1-HairpinMode}
-    
-(Alias of `string`)
-
-
-
-HairpinMode denotes how the kubelet should configure networking to handle
-hairpin packets.
-
-
-    
-
 
 ## `KubeletAnonymousAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletAnonymousAuthentication}
     
-
-
 
 **Appears in:**
 
@@ -1598,34 +1466,27 @@ hairpin packets.
 
 
 
-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>enabled</code><br/>
 <code>bool</code>
 </td>
 <td>
-   enabled allows anonymous requests to the kubelet server.
+   <p>enabled allows anonymous requests to the kubelet server.
 Requests that are not rejected by another authentication method are treated as
 anonymous requests.
-Anonymous requests have a username of `system:anonymous`, and a group name of
-`system:unauthenticated`.</td>
+Anonymous requests have a username of <code>system:anonymous</code>, and a group name of
+<code>system:unauthenticated</code>.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeletAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthentication}
     
-
-
 
 **Appears in:**
 
@@ -1633,46 +1494,37 @@ Anonymous requests have a username of `system:anonymous`, and a group name of
 
 
 
-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>x509</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-KubeletX509Authentication"><code>KubeletX509Authentication</code></a>
 </td>
 <td>
-   x509 contains settings related to x509 client certificate authentication.</td>
+   <p>x509 contains settings related to x509 client certificate authentication.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>webhook</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthentication"><code>KubeletWebhookAuthentication</code></a>
 </td>
 <td>
-   webhook contains settings related to webhook bearer token authentication.</td>
+   <p>webhook contains settings related to webhook bearer token authentication.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>anonymous</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-KubeletAnonymousAuthentication"><code>KubeletAnonymousAuthentication</code></a>
 </td>
 <td>
-   anonymous contains settings related to anonymous authentication.</td>
+   <p>anonymous contains settings related to anonymous authentication.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeletAuthorization`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthorization}
     
-
-
 
 **Appears in:**
 
@@ -1680,61 +1532,48 @@ Anonymous requests have a username of `system:anonymous`, and a group name of
 
 
 
-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>mode</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-KubeletAuthorizationMode"><code>KubeletAuthorizationMode</code></a>
 </td>
 <td>
-   mode is the authorization mode to apply to requests to the kubelet server.
-Valid values are `AlwaysAllow` and `Webhook`.
-Webhook mode uses the SubjectAccessReview API to determine authorization.</td>
+   <p>mode is the authorization mode to apply to requests to the kubelet server.
+Valid values are <code>AlwaysAllow</code> and <code>Webhook</code>.
+Webhook mode uses the SubjectAccessReview API to determine authorization.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>webhook</code><br/>
 <a href="#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthorization"><code>KubeletWebhookAuthorization</code></a>
 </td>
 <td>
-   webhook contains settings related to Webhook authorization.</td>
+   <p>webhook contains settings related to Webhook authorization.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeletAuthorizationMode`     {#kubelet-config-k8s-io-v1beta1-KubeletAuthorizationMode}
     
 (Alias of `string`)
 
-
 **Appears in:**
 
 - [KubeletAuthorization](#kubelet-config-k8s-io-v1beta1-KubeletAuthorization)
 
 
 
-
-
-    
 
 
 ## `KubeletWebhookAuthentication`     {#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthentication}
     
 
-
-
 **Appears in:**
 
 - [KubeletAuthentication](#kubelet-config-k8s-io-v1beta1-KubeletAuthentication)
-
 
 
 
@@ -1742,34 +1581,27 @@ Webhook mode uses the SubjectAccessReview API to determine authorization.</td>
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>enabled</code><br/>
 <code>bool</code>
 </td>
 <td>
-   enabled allows bearer token authentication backed by the
-tokenreviews.authentication.k8s.io API.</td>
+   <p>enabled allows bearer token authentication backed by the
+tokenreviews.authentication.k8s.io API.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cacheTTL</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   cacheTTL enables caching of authentication results</td>
+   <p>cacheTTL enables caching of authentication results</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeletWebhookAuthorization`     {#kubelet-config-k8s-io-v1beta1-KubeletWebhookAuthorization}
     
-
-
 
 **Appears in:**
 
@@ -1777,40 +1609,32 @@ tokenreviews.authentication.k8s.io API.</td>
 
 
 
-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>cacheAuthorizedTTL</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   cacheAuthorizedTTL is the duration to cache 'authorized' responses from the
-webhook authorizer.</td>
+   <p>cacheAuthorizedTTL is the duration to cache 'authorized' responses from the
+webhook authorizer.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cacheUnauthorizedTTL</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   cacheUnauthorizedTTL is the duration to cache 'unauthorized' responses from
-the webhook authorizer.</td>
+   <p>cacheUnauthorizedTTL is the duration to cache 'unauthorized' responses from
+the webhook authorizer.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `KubeletX509Authentication`     {#kubelet-config-k8s-io-v1beta1-KubeletX509Authentication}
     
-
-
 
 **Appears in:**
 
@@ -1818,74 +1642,57 @@ the webhook authorizer.</td>
 
 
 
-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>clientCAFile</code><br/>
 <code>string</code>
 </td>
 <td>
-   clientCAFile is the path to a PEM-encoded certificate bundle. If set, any request
+   <p>clientCAFile is the path to a PEM-encoded certificate bundle. If set, any request
 presenting a client certificate signed by one of the authorities in the bundle
 is authenticated with a username corresponding to the CommonName,
-and groups corresponding to the Organization in the client certificate.</td>
+and groups corresponding to the Organization in the client certificate.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `MemoryReservation`     {#kubelet-config-k8s-io-v1beta1-MemoryReservation}
     
-
-
 
 **Appears in:**
 
 - [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
 
 
-MemoryReservation specifies the memory reservation of different types for each NUMA node
+<p>MemoryReservation specifies the memory reservation of different types for each NUMA node</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>numaNode</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>limits</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `MemorySwapConfiguration`     {#kubelet-config-k8s-io-v1beta1-MemorySwapConfiguration}
     
-
-
 
 **Appears in:**
 
@@ -1893,82 +1700,70 @@ MemoryReservation specifies the memory reservation of different types for each N
 
 
 
-
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>swapBehavior</code><br/>
 <code>string</code>
 </td>
 <td>
-   swapBehavior configures swap memory available to container workloads. May be one of
-"", "LimitedSwap": workload combined memory and swap usage cannot exceed pod memory limit
-"UnlimitedSwap": workloads can use unlimited swap, up to the allocatable limit.</td>
+   <p>swapBehavior configures swap memory available to container workloads. May be one of
+&quot;&quot;, &quot;LimitedSwap&quot;: workload combined memory and swap usage cannot exceed pod memory limit
+&quot;UnlimitedSwap&quot;: workloads can use unlimited swap, up to the allocatable limit.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ResourceChangeDetectionStrategy`     {#kubelet-config-k8s-io-v1beta1-ResourceChangeDetectionStrategy}
     
 (Alias of `string`)
 
-
 **Appears in:**
 
 - [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
 
 
-ResourceChangeDetectionStrategy denotes a mode in which internal
-managers (secret, configmap) are discovering object changes.
+<p>ResourceChangeDetectionStrategy denotes a mode in which internal
+managers (secret, configmap) are discovering object changes.</p>
 
 
-    
 
 
 ## `ShutdownGracePeriodByPodPriority`     {#kubelet-config-k8s-io-v1beta1-ShutdownGracePeriodByPodPriority}
     
 
-
-
 **Appears in:**
 
 - [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
 
 
-ShutdownGracePeriodByPodPriority specifies the shutdown grace period for Pods based on their associated priority class value
+<p>ShutdownGracePeriodByPodPriority specifies the shutdown grace period for Pods based on their associated priority class value</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>priority</code> <B>[Required]</B><br/>
 <code>int32</code>
 </td>
 <td>
-   priority is the priority value associated with the shutdown grace period</td>
+   <p>priority is the priority value associated with the shutdown grace period</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>shutdownGracePeriodSeconds</code> <B>[Required]</B><br/>
 <code>int64</code>
 </td>
 <td>
-   shutdownGracePeriodSeconds is the shutdown grace period in seconds</td>
+   <p>shutdownGracePeriodSeconds is the shutdown grace period in seconds</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   
   
     
@@ -1976,148 +1771,133 @@ ShutdownGracePeriodByPodPriority specifies the shutdown grace period for Pods ba
 ## `FormatOptions`     {#FormatOptions}
     
 
-
-
 **Appears in:**
 
 - [LoggingConfiguration](#LoggingConfiguration)
 
 
-FormatOptions contains options for the different logging formats.
+<p>FormatOptions contains options for the different logging formats.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>json</code> <B>[Required]</B><br/>
 <a href="#JSONOptions"><code>JSONOptions</code></a>
 </td>
 <td>
-   [Experimental] JSON contains options for logging format "json".</td>
+   <p>[Experimental] JSON contains options for logging format &quot;json&quot;.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `JSONOptions`     {#JSONOptions}
     
 
-
-
 **Appears in:**
 
 - [FormatOptions](#FormatOptions)
 
 
-JSONOptions contains options for logging format "json".
+<p>JSONOptions contains options for logging format &quot;json&quot;.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>splitStream</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   [Experimental] SplitStream redirects error messages to stderr while
+   <p>[Experimental] SplitStream redirects error messages to stderr while
 info messages go to stdout, with buffering. The default is to write
-both to stdout, without buffering.</td>
+both to stdout, without buffering.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>infoBufferSize</code> <B>[Required]</B><br/>
 <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#QuantityValue"><code>k8s.io/apimachinery/pkg/api/resource.QuantityValue</code></a>
 </td>
 <td>
-   [Experimental] InfoBufferSize sets the size of the info stream when
-using split streams. The default is zero, which disables buffering.</td>
+   <p>[Experimental] InfoBufferSize sets the size of the info stream when
+using split streams. The default is zero, which disables buffering.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
 ## `LoggingConfiguration`     {#LoggingConfiguration}
     
 
-
-
 **Appears in:**
 
 - [KubeletConfiguration](#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
 
 
-LoggingConfiguration contains logging options
-Refer [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
+<p>LoggingConfiguration contains logging options
+Refer <a href="https://github.com/kubernetes/component-base/blob/master/logs/options.go">Logs Options</a> for more information.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>format</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Format Flag specifies the structure of log messages.
-default value of format is `text`</td>
+   <p>Format Flag specifies the structure of log messages.
+default value of format is <code>text</code></p>
+</td>
 </tr>
-    
-  
 <tr><td><code>flushFrequency</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/time#Duration"><code>time.Duration</code></a>
+<a href="https://pkg.go.dev/time#Duration"><code>time.Duration</code></a>
 </td>
 <td>
-   Maximum number of seconds between log flushes. Ignored if the
-selected logging backend writes log messages without buffering.</td>
+   <p>Maximum number of seconds between log flushes. Ignored if the
+selected logging backend writes log messages without buffering.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>verbosity</code> <B>[Required]</B><br/>
 <code>uint32</code>
 </td>
 <td>
-   Verbosity is the threshold that determines which log messages are
+   <p>Verbosity is the threshold that determines which log messages are
 logged. Default is zero which logs only the most important
 messages. Higher values enable additional messages. Error messages
-are always logged.</td>
+are always logged.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>vmodule</code> <B>[Required]</B><br/>
 <a href="#VModuleConfiguration"><code>VModuleConfiguration</code></a>
 </td>
 <td>
-   VModule overrides the verbosity threshold for individual files.
-Only supported for "text" log format.</td>
+   <p>VModule overrides the verbosity threshold for individual files.
+Only supported for &quot;text&quot; log format.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>sanitization</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   [Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
-Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</td>
+   <p>[Experimental] When enabled prevents logging of fields tagged as sensitive (passwords, keys, tokens).
+Runtime log sanitization may introduce significant computation overhead and therefore should not be enabled in production.`)</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>options</code> <B>[Required]</B><br/>
 <a href="#FormatOptions"><code>FormatOptions</code></a>
 </td>
 <td>
-   [Experimental] Options holds additional parameters that are specific
+   <p>[Experimental] Options holds additional parameters that are specific
 to the different logging formats. Only the options for the selected
-format get used, but all of them get validated.</td>
+format get used, but all of them get validated.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
 
@@ -2125,13 +1905,13 @@ format get used, but all of them get validated.</td>
     
 (Alias of `[]k8s.io/component-base/config/v1alpha1.VModuleItem`)
 
-
 **Appears in:**
 
 - [LoggingConfiguration](#LoggingConfiguration)
 
 
-VModuleConfiguration is a collection of individual file names or patterns
-and the corresponding verbosity threshold.
+<p>VModuleConfiguration is a collection of individual file names or patterns
+and the corresponding verbosity threshold.</p>
+
 
 

--- a/genref/output/md/kubelet-credentialprovider.v1alpha1.md
+++ b/genref/output/md/kubelet-credentialprovider.v1alpha1.md
@@ -14,16 +14,14 @@ auto_generated: true
   
     
 
-
 ## `CredentialProviderRequest`     {#credentialprovider-kubelet-k8s-io-v1alpha1-CredentialProviderRequest}
     
 
 
-
-
-CredentialProviderRequest includes the image that the kubelet requires authentication for.
+<p>CredentialProviderRequest includes the image that the kubelet requires authentication for.
 Kubelet will pass this request object to the plugin via stdin. In general, plugins should
-prefer responding with the same apiVersion they were sent.
+prefer responding with the same apiVersion they were sent.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -32,33 +30,27 @@ prefer responding with the same apiVersion they were sent.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>credentialprovider.kubelet.k8s.io/v1alpha1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>CredentialProviderRequest</code></td></tr>
     
-
-  
   
 <tr><td><code>image</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   image is the container image that is being pulled as part of the
+   <p>image is the container image that is being pulled as part of the
 credential provider plugin request. Plugins may optionally parse the image
-to extract any information required to fetch credentials.</td>
+to extract any information required to fetch credentials.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `CredentialProviderResponse`     {#credentialprovider-kubelet-k8s-io-v1alpha1-CredentialProviderResponse}
     
 
 
-
-
-CredentialProviderResponse holds credentials that the kubelet should use for the specified
+<p>CredentialProviderResponse holds credentials that the kubelet should use for the specified
 image provided in the original request. Kubelet will read the response from the plugin via stdout.
-This response should be set to the same apiVersion as CredentialProviderRequest.
+This response should be set to the same apiVersion as CredentialProviderRequest.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -67,118 +59,105 @@ This response should be set to the same apiVersion as CredentialProviderRequest.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>credentialprovider.kubelet.k8s.io/v1alpha1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>CredentialProviderResponse</code></td></tr>
     
-
-  
   
 <tr><td><code>cacheKeyType</code> <B>[Required]</B><br/>
 <a href="#credentialprovider-kubelet-k8s-io-v1alpha1-PluginCacheKeyType"><code>PluginCacheKeyType</code></a>
 </td>
 <td>
-   cacheKeyType indiciates the type of caching key to use based on the image provided
+   <p>cacheKeyType indiciates the type of caching key to use based on the image provided
 in the request. There are three valid values for the cache key type: Image, Registry, and
-Global. If an invalid value is specified, the response will NOT be used by the kubelet.</td>
+Global. If an invalid value is specified, the response will NOT be used by the kubelet.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>cacheDuration</code><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   cacheDuration indicates the duration the provided credentials should be cached for.
+   <p>cacheDuration indicates the duration the provided credentials should be cached for.
 The kubelet will use this field to set the in-memory cache duration for credentials
 in the AuthConfig. If null, the kubelet will use defaultCacheDuration provided in
-CredentialProviderConfig. If set to 0, the kubelet will not cache the provided AuthConfig.</td>
+CredentialProviderConfig. If set to 0, the kubelet will not cache the provided AuthConfig.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>auth</code><br/>
 <a href="#credentialprovider-kubelet-k8s-io-v1alpha1-AuthConfig"><code>map[string]k8s.io/kubelet/pkg/apis/credentialprovider/v1alpha1.AuthConfig</code></a>
 </td>
 <td>
-   auth is a map containing authentication information passed into the kubelet.
+   <p>auth is a map containing authentication information passed into the kubelet.
 Each key is a match image string (more on this below). The corresponding authConfig value
 should be valid for all images that match against this key. A plugin should set
-this field to null if no valid credentials can be returned for the requested image.
-
-Each key in the map is a pattern which can optionally contain a port and a path.
+this field to null if no valid credentials can be returned for the requested image.</p>
+<p>Each key in the map is a pattern which can optionally contain a port and a path.
 Globs can be used in the domain, but not in the port or the path. Globs are supported
-as subdomains like '&lowast;.k8s.io' or 'k8s.&lowast;.io', and top-level-domains such as 'k8s.&lowast;'.
-Matching partial subdomains like 'app&lowast;.k8s.io' is also supported. Each glob can only match
-a single subdomain segment, so &lowast;.io does not match &lowast;.k8s.io.
-
-The kubelet will match images against the key when all of the below are true:
-- Both contain the same number of domain parts and each part matches.
-- The URL path of an imageMatch must be a prefix of the target image URL path.
-- If the imageMatch contains a port, then the port must match in the image as well.
-
-When multiple keys are returned, the kubelet will traverse all keys in reverse order so that:
-- longer keys come before shorter keys with the same prefix
-- non-wildcard keys come before wildcard keys with the same prefix.
-
-For any given match, the kubelet will attempt an image pull with the provided credentials,
-stopping after the first successfully authenticated pull.
-
-Example keys:
-  - 123456789.dkr.ecr.us-east-1.amazonaws.com
-  - &lowast;.azurecr.io
-  - gcr.io
-  - &lowast;.&lowast;.registry.io
-  - registry.io:8080/path</td>
+as subdomains like '<em>.k8s.io' or 'k8s.</em>.io', and top-level-domains such as 'k8s.<em>'.
+Matching partial subdomains like 'app</em>.k8s.io' is also supported. Each glob can only match
+a single subdomain segment, so &lowast;.io does not match &lowast;.k8s.io.</p>
+<p>The kubelet will match images against the key when all of the below are true:</p>
+<ul>
+<li>Both contain the same number of domain parts and each part matches.</li>
+<li>The URL path of an imageMatch must be a prefix of the target image URL path.</li>
+<li>If the imageMatch contains a port, then the port must match in the image as well.</li>
+</ul>
+<p>When multiple keys are returned, the kubelet will traverse all keys in reverse order so that:</p>
+<ul>
+<li>longer keys come before shorter keys with the same prefix</li>
+<li>non-wildcard keys come before wildcard keys with the same prefix.</li>
+</ul>
+<p>For any given match, the kubelet will attempt an image pull with the provided credentials,
+stopping after the first successfully authenticated pull.</p>
+<p>Example keys:</p>
+<ul>
+<li>123456789.dkr.ecr.us-east-1.amazonaws.com</li>
+<li>&lowast;.azurecr.io</li>
+<li>gcr.io</li>
+<li><em>.</em>.registry.io</li>
+<li>registry.io:8080/path</li>
+</ul>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `AuthConfig`     {#credentialprovider-kubelet-k8s-io-v1alpha1-AuthConfig}
     
-
-
 
 **Appears in:**
 
 - [CredentialProviderResponse](#credentialprovider-kubelet-k8s-io-v1alpha1-CredentialProviderResponse)
 
 
-AuthConfig contains authentication information for a container registry.
+<p>AuthConfig contains authentication information for a container registry.
 Only username/password based authentication is supported today, but more authentication
-mechanisms may be added in the future.
+mechanisms may be added in the future.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>username</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   username is the username used for authenticating to the container registry
-An empty username is valid.</td>
+   <p>username is the username used for authenticating to the container registry
+An empty username is valid.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>password</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   password is the password used for authenticating to the container registry
-An empty password is valid.</td>
+   <p>password is the password used for authenticating to the container registry
+An empty password is valid.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PluginCacheKeyType`     {#credentialprovider-kubelet-k8s-io-v1alpha1-PluginCacheKeyType}
     
 (Alias of `string`)
-
 
 **Appears in:**
 
@@ -187,6 +166,4 @@ An empty password is valid.</td>
 
 
 
-
-    
   

--- a/genref/output/md/metrics.v1beta1.md
+++ b/genref/output/md/metrics.v1beta1.md
@@ -4,7 +4,8 @@ content_type: tool-reference
 package: metrics.k8s.io/v1beta1
 auto_generated: true
 ---
-Package v1beta1 is the v1beta1 version of the metrics API.
+<p>Package v1beta1 is the v1beta1 version of the metrics API.</p>
+
 
 ## Resource Types 
 
@@ -16,18 +17,16 @@ Package v1beta1 is the v1beta1 version of the metrics API.
   
     
 
-
 ## `NodeMetrics`     {#metrics-k8s-io-v1beta1-NodeMetrics}
     
-
-
 
 **Appears in:**
 
 - [NodeMetricsList](#metrics-k8s-io-v1beta1-NodeMetricsList)
 
 
-NodeMetrics sets resource usage metrics of a node.
+<p>NodeMetrics sets resource usage metrics of a node.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -36,56 +35,45 @@ NodeMetrics sets resource usage metrics of a node.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeMetrics</code></td></tr>
     
-
-  
   
 <tr><td><code>metadata</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
 </td>
 <td>
-   Standard object's metadata.
-More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadataRefer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
+   <p>Standard object's metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata</p>
+Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-    
-  
 <tr><td><code>timestamp</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
-   The following fields define time interval from which metrics were
-collected from the interval [Timestamp-Window, Timestamp].</td>
+   <p>The following fields define time interval from which metrics were
+collected from the interval [Timestamp-Window, Timestamp].</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>window</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>usage</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
 </td>
 <td>
-   The memory usage is the memory working set.</td>
+   <p>The memory usage is the memory working set.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `NodeMetricsList`     {#metrics-k8s-io-v1beta1-NodeMetricsList}
     
 
 
+<p>NodeMetricsList is a list of NodeMetrics.</p>
 
-
-NodeMetricsList is a list of NodeMetrics.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -94,42 +82,35 @@ NodeMetricsList is a list of NodeMetrics.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>NodeMetricsList</code></td></tr>
     
-
-  
   
 <tr><td><code>metadata</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
-   Standard list metadata.
-More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</td>
+   <p>Standard list metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>items</code> <B>[Required]</B><br/>
 <a href="#metrics-k8s-io-v1beta1-NodeMetrics"><code>[]NodeMetrics</code></a>
 </td>
 <td>
-   List of node metrics.</td>
+   <p>List of node metrics.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PodMetrics`     {#metrics-k8s-io-v1beta1-PodMetrics}
     
-
-
 
 **Appears in:**
 
 - [PodMetricsList](#metrics-k8s-io-v1beta1-PodMetricsList)
 
 
-PodMetrics sets resource usage metrics of a pod.
+<p>PodMetrics sets resource usage metrics of a pod.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -138,56 +119,45 @@ PodMetrics sets resource usage metrics of a pod.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>PodMetrics</code></td></tr>
     
-
-  
   
 <tr><td><code>metadata</code><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
 </td>
 <td>
-   Standard object's metadata.
-More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadataRefer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
+   <p>Standard object's metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata</p>
+Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.</td>
 </tr>
-    
-  
 <tr><td><code>timestamp</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta"><code>meta/v1.Time</code></a>
 </td>
 <td>
-   The following fields define time interval from which metrics were
-collected from the interval [Timestamp-Window, Timestamp].</td>
+   <p>The following fields define time interval from which metrics were
+collected from the interval [Timestamp-Window, Timestamp].</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>window</code> <B>[Required]</B><br/>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"><code>meta/v1.Duration</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span>
-   </td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
-    
-  
 <tr><td><code>containers</code> <B>[Required]</B><br/>
 <a href="#metrics-k8s-io-v1beta1-ContainerMetrics"><code>[]ContainerMetrics</code></a>
 </td>
 <td>
-   Metrics for all containers are collected within the same time window.</td>
+   <p>Metrics for all containers are collected within the same time window.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `PodMetricsList`     {#metrics-k8s-io-v1beta1-PodMetricsList}
     
 
 
+<p>PodMetricsList is a list of PodMetrics.</p>
 
-
-PodMetricsList is a list of PodMetrics.
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -196,66 +166,55 @@ PodMetricsList is a list of PodMetrics.
 <tr><td><code>apiVersion</code><br/>string</td><td><code>metrics.k8s.io/v1beta1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>PodMetricsList</code></td></tr>
     
-
-  
   
 <tr><td><code>metadata</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#listmeta-v1-meta"><code>meta/v1.ListMeta</code></a>
 </td>
 <td>
-   Standard list metadata.
-More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</td>
+   <p>Standard list metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>items</code> <B>[Required]</B><br/>
 <a href="#metrics-k8s-io-v1beta1-PodMetrics"><code>[]PodMetrics</code></a>
 </td>
 <td>
-   List of pod metrics.</td>
+   <p>List of pod metrics.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
-
 
 ## `ContainerMetrics`     {#metrics-k8s-io-v1beta1-ContainerMetrics}
     
-
-
 
 **Appears in:**
 
 - [PodMetrics](#metrics-k8s-io-v1beta1-PodMetrics)
 
 
-ContainerMetrics sets resource usage metrics of a container.
+<p>ContainerMetrics sets resource usage metrics of a container.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>
 <td>
-   Container name corresponding to the one from pod.spec.containers.</td>
+   <p>Container name corresponding to the one from pod.spec.containers.</p>
+</td>
 </tr>
-    
-  
 <tr><td><code>usage</code> <B>[Required]</B><br/>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcelist-v1-core"><code>core/v1.ResourceList</code></a>
 </td>
 <td>
-   The memory usage is the memory working set.</td>
+   <p>The memory usage is the memory working set.</p>
+</td>
 </tr>
-    
-  
 </tbody>
 </table>
-    
   

--- a/genref/types.go
+++ b/genref/types.go
@@ -410,7 +410,7 @@ func renderComments(comments []string) template.HTML {
 			res = buf.String()
 		}
 		// replace '*' by '&lowast;'
-		res = strings.Replace(doc, "*", "&lowast;", -1)
+		res = strings.Replace(res, "*", "&lowast;", -1)
 	} else {
 		res = strings.Replace(doc, "\n\n", string(template.HTML("<br/><br/>")), -1)
 	}


### PR DESCRIPTION
This PR updates the templates so that we are outputing references only for the relevant types. This is to fix a nit where in some outputs (e.g. kube-proxy-config), irrelevant type definitions got sneaked in. A better solution would be to export the resource group name into the configuration file. However, that would be trickier to maintain than this workaround.