### PR TITLE
Add back some config API versions

### DIFF
--- a/genref/config.yaml
+++ b/genref/config.yaml
@@ -99,13 +99,24 @@ apis:
     package: k8s.io/metrics
     path: pkg/apis/metrics/v1beta1
 
-  # v1alpha1 and v1beta1 are skipped
+  # v1alpha1 is skipped
+  # v1beta1 is preserved because it is still referenced.
+  - name: client-authentication
+    title: Client Authentication (v1beta1)
+    package: k8s.io/client-go
+    path: pkg/apis/clientauthentication/v1beta1
+
   - name: client-authentication
     title: Client Authentication (v1)
     package: k8s.io/client-go
     path: pkg/apis/clientauthentication/v1
 
-  # v1alpha1 is skipped
+  # v1alpha1 is preserved because TracingConfiguration is referenced.
+  - name: apiserver-config
+    title: kube-apiserver Configuration (v1alpha1)
+    package: k8s.io/apiserver
+    path: pkg/apis/apiserver/v1alpha1
+
   # v1beta1 is preserved because it has different types exposed.
   - name: apiserver-config
     title: kube-apiserver Configuration (v1beta1)

--- a/genref/output/md/apiserver-config.v1alpha1.md
+++ b/genref/output/md/apiserver-config.v1alpha1.md
@@ -1,0 +1,375 @@
+---
+title: kube-apiserver Configuration (v1alpha1)
+content_type: tool-reference
+package: apiserver.k8s.io/v1alpha1
+auto_generated: true
+---
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+
+
+## Resource Types 
+
+
+- [AdmissionConfiguration](#apiserver-k8s-io-v1alpha1-AdmissionConfiguration)
+- [EgressSelectorConfiguration](#apiserver-k8s-io-v1alpha1-EgressSelectorConfiguration)
+- [TracingConfiguration](#apiserver-k8s-io-v1alpha1-TracingConfiguration)
+  
+    
+
+## `AdmissionConfiguration`     {#apiserver-k8s-io-v1alpha1-AdmissionConfiguration}
+    
+
+
+<p>AdmissionConfiguration provides versioned configuration for admission controllers.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>AdmissionConfiguration</code></td></tr>
+    
+  
+<tr><td><code>plugins</code><br/>
+<a href="#apiserver-k8s-io-v1alpha1-AdmissionPluginConfiguration"><code>[]AdmissionPluginConfiguration</code></a>
+</td>
+<td>
+   <p>Plugins allows specifying a configuration per admission control plugin.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `EgressSelectorConfiguration`     {#apiserver-k8s-io-v1alpha1-EgressSelectorConfiguration}
+    
+
+
+<p>EgressSelectorConfiguration provides versioned configuration for egress selector clients.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>EgressSelectorConfiguration</code></td></tr>
+    
+  
+<tr><td><code>egressSelections</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1alpha1-EgressSelection"><code>[]EgressSelection</code></a>
+</td>
+<td>
+   <p>connectionServices contains a list of egress selection client configurations</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TracingConfiguration`     {#apiserver-k8s-io-v1alpha1-TracingConfiguration}
+    
+
+
+<p>TracingConfiguration provides versioned configuration for tracing clients.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>apiserver.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>TracingConfiguration</code></td></tr>
+    
+  
+<tr><td><code>endpoint</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Endpoint of the collector that's running on the control-plane node.
+The APIServer uses the egressType ControlPlane when sending data to the collector.
+The syntax is defined in https://github.com/grpc/grpc/blob/master/doc/naming.md.
+Defaults to the otlpgrpc default, localhost:4317
+The connection is insecure, and does not support TLS.</p>
+</td>
+</tr>
+<tr><td><code>samplingRatePerMillion</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>SamplingRatePerMillion is the number of samples to collect per million spans.
+Defaults to 0.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `AdmissionPluginConfiguration`     {#apiserver-k8s-io-v1alpha1-AdmissionPluginConfiguration}
+    
+
+**Appears in:**
+
+- [AdmissionConfiguration](#apiserver-k8s-io-v1alpha1-AdmissionConfiguration)
+
+
+<p>AdmissionPluginConfiguration provides the configuration for a single plug-in.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Name is the name of the admission controller.
+It must match the registered admission plugin name.</p>
+</td>
+</tr>
+<tr><td><code>path</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Path is the path to a configuration file that contains the plugin's
+configuration</p>
+</td>
+</tr>
+<tr><td><code>configuration</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Unknown"><code>k8s.io/apimachinery/pkg/runtime.Unknown</code></a>
+</td>
+<td>
+   <p>Configuration is an embedded configuration object to be used as the plugin's
+configuration. If present, it will be used instead of the path to the configuration file.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Connection`     {#apiserver-k8s-io-v1alpha1-Connection}
+    
+
+**Appears in:**
+
+- [EgressSelection](#apiserver-k8s-io-v1alpha1-EgressSelection)
+
+
+<p>Connection provides the configuration for a single egress selection client.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>proxyProtocol</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1alpha1-ProtocolType"><code>ProtocolType</code></a>
+</td>
+<td>
+   <p>Protocol is the protocol used to connect from client to the konnectivity server.</p>
+</td>
+</tr>
+<tr><td><code>transport</code><br/>
+<a href="#apiserver-k8s-io-v1alpha1-Transport"><code>Transport</code></a>
+</td>
+<td>
+   <p>Transport defines the transport configurations we use to dial to the konnectivity server.
+This is required if ProxyProtocol is HTTPConnect or GRPC.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `EgressSelection`     {#apiserver-k8s-io-v1alpha1-EgressSelection}
+    
+
+**Appears in:**
+
+- [EgressSelectorConfiguration](#apiserver-k8s-io-v1alpha1-EgressSelectorConfiguration)
+
+
+<p>EgressSelection provides the configuration for a single egress selection client.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>name</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>name is the name of the egress selection.
+Currently supported values are &quot;controlplane&quot;, &quot;master&quot;, &quot;etcd&quot; and &quot;cluster&quot;
+The &quot;master&quot; egress selector is deprecated in favor of &quot;controlplane&quot;</p>
+</td>
+</tr>
+<tr><td><code>connection</code> <B>[Required]</B><br/>
+<a href="#apiserver-k8s-io-v1alpha1-Connection"><code>Connection</code></a>
+</td>
+<td>
+   <p>connection is the exact information used to configure the egress selection</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ProtocolType`     {#apiserver-k8s-io-v1alpha1-ProtocolType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [Connection](#apiserver-k8s-io-v1alpha1-Connection)
+
+
+<p>ProtocolType is a set of valid values for Connection.ProtocolType</p>
+
+
+
+
+## `TCPTransport`     {#apiserver-k8s-io-v1alpha1-TCPTransport}
+    
+
+**Appears in:**
+
+- [Transport](#apiserver-k8s-io-v1alpha1-Transport)
+
+
+<p>TCPTransport provides the information to connect to konnectivity server via TCP</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>url</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>URL is the location of the konnectivity server to connect to.
+As an example it might be &quot;https://127.0.0.1:8131&quot;</p>
+</td>
+</tr>
+<tr><td><code>tlsConfig</code><br/>
+<a href="#apiserver-k8s-io-v1alpha1-TLSConfig"><code>TLSConfig</code></a>
+</td>
+<td>
+   <p>TLSConfig is the config needed to use TLS when connecting to konnectivity server</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `TLSConfig`     {#apiserver-k8s-io-v1alpha1-TLSConfig}
+    
+
+**Appears in:**
+
+- [TCPTransport](#apiserver-k8s-io-v1alpha1-TCPTransport)
+
+
+<p>TLSConfig provides the authentication information to connect to konnectivity server
+Only used with TCPTransport</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>caBundle</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>caBundle is the file location of the CA to be used to determine trust with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+If absent while TCPTransport.URL is prefixed with https://, default to system trust roots.</p>
+</td>
+</tr>
+<tr><td><code>clientKey</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clientKey is the file location of the client key to be used in mtls handshakes with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+Must be configured if TCPTransport.URL is prefixed with https://</p>
+</td>
+</tr>
+<tr><td><code>clientCert</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>clientCert is the file location of the client certificate to be used in mtls handshakes with the konnectivity server.
+Must be absent/empty if TCPTransport.URL is prefixed with http://
+Must be configured if TCPTransport.URL is prefixed with https://</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Transport`     {#apiserver-k8s-io-v1alpha1-Transport}
+    
+
+**Appears in:**
+
+- [Connection](#apiserver-k8s-io-v1alpha1-Connection)
+
+
+<p>Transport defines the transport configurations we use to dial to the konnectivity server</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>tcp</code><br/>
+<a href="#apiserver-k8s-io-v1alpha1-TCPTransport"><code>TCPTransport</code></a>
+</td>
+<td>
+   <p>TCP is the TCP configuration for communicating with the konnectivity server via TCP
+ProxyProtocol of GRPC is not supported with TCP transport at the moment
+Requires at least one of TCP or UDS to be set</p>
+</td>
+</tr>
+<tr><td><code>uds</code><br/>
+<a href="#apiserver-k8s-io-v1alpha1-UDSTransport"><code>UDSTransport</code></a>
+</td>
+<td>
+   <p>UDS is the UDS configuration for communicating with the konnectivity server via UDS
+Requires at least one of TCP or UDS to be set</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `UDSTransport`     {#apiserver-k8s-io-v1alpha1-UDSTransport}
+    
+
+**Appears in:**
+
+- [Transport](#apiserver-k8s-io-v1alpha1-Transport)
+
+
+<p>UDSTransport provides the information to connect to konnectivity server via UDS</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>udsName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>UDSName is the name of the unix domain socket to connect to konnectivity server
+This does not use a unix:// prefix. (Eg: /etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket)</p>
+</td>
+</tr>
+</tbody>
+</table>
+  

--- a/genref/output/md/client-authentication.v1beta1.md
+++ b/genref/output/md/client-authentication.v1beta1.md
@@ -1,0 +1,229 @@
+---
+title: Client Authentication (v1beta1)
+content_type: tool-reference
+package: client.authentication.k8s.io/v1beta1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+  
+    
+
+## `ExecCredential`     {#client-authentication-k8s-io-v1beta1-ExecCredential}
+    
+
+
+<p>ExecCredential is used by exec-based plugins to communicate credentials to
+HTTP transports.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>client.authentication.k8s.io/v1beta1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>ExecCredential</code></td></tr>
+    
+  
+<tr><td><code>spec</code> <B>[Required]</B><br/>
+<a href="#client-authentication-k8s-io-v1beta1-ExecCredentialSpec"><code>ExecCredentialSpec</code></a>
+</td>
+<td>
+   <p>Spec holds information passed to the plugin by the transport.</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="#client-authentication-k8s-io-v1beta1-ExecCredentialStatus"><code>ExecCredentialStatus</code></a>
+</td>
+<td>
+   <p>Status is filled in by the plugin and holds the credentials that the transport
+should use to contact the API.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Cluster`     {#client-authentication-k8s-io-v1beta1-Cluster}
+    
+
+**Appears in:**
+
+- [ExecCredentialSpec](#client-authentication-k8s-io-v1beta1-ExecCredentialSpec)
+
+
+<p>Cluster contains information to allow an exec plugin to communicate
+with the kubernetes cluster being authenticated to.</p>
+<p>To ensure that this struct contains everything someone would need to communicate
+with a kubernetes cluster (just like they would via a kubeconfig), the fields
+should shadow &quot;k8s.io/client-go/tools/clientcmd/api/v1&quot;.Cluster, with the exception
+of CertificateAuthority, since CA data will always be passed to the plugin as bytes.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>server</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Server is the address of the kubernetes cluster (https://hostname:port).</p>
+</td>
+</tr>
+<tr><td><code>tls-server-name</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>TLSServerName is passed to the server for SNI and is used in the client to
+check server certificates against. If ServerName is empty, the hostname
+used to contact the server is used.</p>
+</td>
+</tr>
+<tr><td><code>insecure-skip-tls-verify</code><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>InsecureSkipTLSVerify skips the validity check for the server's certificate.
+This will make your HTTPS connections insecure.</p>
+</td>
+</tr>
+<tr><td><code>certificate-authority-data</code><br/>
+<code>[]byte</code>
+</td>
+<td>
+   <p>CAData contains PEM-encoded certificate authority certificates.
+If empty, system roots should be used.</p>
+</td>
+</tr>
+<tr><td><code>proxy-url</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>ProxyURL is the URL to the proxy to be used for all requests to this
+cluster.</p>
+</td>
+</tr>
+<tr><td><code>config</code><br/>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime/#RawExtension"><code>k8s.io/apimachinery/pkg/runtime.RawExtension</code></a>
+</td>
+<td>
+   <p>Config holds additional config data that is specific to the exec
+plugin with regards to the cluster being authenticated to.</p>
+<p>This data is sourced from the clientcmd Cluster object's
+extensions[client.authentication.k8s.io/exec] field:</p>
+<p>clusters:</p>
+<ul>
+<li>name: my-cluster
+cluster:
+...
+extensions:
+<ul>
+<li>name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config
+extension:
+audience: 06e3fbd18de8  # arbitrary config</li>
+</ul>
+</li>
+</ul>
+<p>In some environments, the user config may be exactly the same across many clusters
+(i.e. call this exec plugin) minus some details that are specific to each cluster
+such as the audience.  This field allows the per cluster config to be directly
+specified with the cluster info.  Using this field to store secret data is not
+recommended as one of the prime benefits of exec plugins is that no secrets need
+to be stored directly in the kubeconfig.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ExecCredentialSpec`     {#client-authentication-k8s-io-v1beta1-ExecCredentialSpec}
+    
+
+**Appears in:**
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+
+
+<p>ExecCredentialSpec holds request and runtime specific information provided by
+the transport.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>cluster</code><br/>
+<a href="#client-authentication-k8s-io-v1beta1-Cluster"><code>Cluster</code></a>
+</td>
+<td>
+   <p>Cluster contains information to allow an exec plugin to communicate with the
+kubernetes cluster being authenticated to. Note that Cluster is non-nil only
+when provideClusterInfo is set to true in the exec provider config (i.e.,
+ExecConfig.ProvideClusterInfo).</p>
+</td>
+</tr>
+<tr><td><code>interactive</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>Interactive declares whether stdin has been passed to this exec plugin.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `ExecCredentialStatus`     {#client-authentication-k8s-io-v1beta1-ExecCredentialStatus}
+    
+
+**Appears in:**
+
+- [ExecCredential](#client-authentication-k8s-io-v1beta1-ExecCredential)
+
+
+<p>ExecCredentialStatus holds credentials for the transport to use.</p>
+<p>Token and ClientKeyData are sensitive fields. This data should only be
+transmitted in-memory between client and exec plugin process. Exec plugin
+itself should at least be protected via file permissions.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>expirationTimestamp</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta"><code>meta/v1.Time</code></a>
+</td>
+<td>
+   <p>ExpirationTimestamp indicates a time when the provided credentials expire.</p>
+</td>
+</tr>
+<tr><td><code>token</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Token is a bearer token used by the client for request authentication.</p>
+</td>
+</tr>
+<tr><td><code>clientCertificateData</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>PEM-encoded client TLS certificates (including intermediates, if any).</p>
+</td>
+</tr>
+<tr><td><code>clientKeyData</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>PEM-encoded private key for the above certificate.</p>
+</td>
+</tr>
+</tbody>
+</table>
+  


### PR DESCRIPTION
The client-authentication v1beta1 is still referenced in the docs; the API server configuration v1alpha1 is needed because the
`TracingConfiguration` is only available in v1alpha1.