### PR TITLE
Add eventratelimit config API v1alpha1

### DIFF
--- a/genref/config.yaml
+++ b/genref/config.yaml
@@ -159,10 +159,9 @@ apis:
 
   - name: apiserver-eventratelimit
     title: Event Rate Limit Configuration (v1alpha1)
-    package: k8s.io/kubernetes
-    path: plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1
-    # Skipped because k8s.io/kubernetes cannot be imported
-    skip: true
+    package: github.com/tengqm/kubeconfig
+    path: config/admission/eventratelimit/apis/v1alpha1
+    skip: false
 
   - name: apiserver-podtolerationrestriction
     title: Pod Toleration Restriction (v1alpha1)

--- a/genref/go.mod
+++ b/genref/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/tengqm/kubeconfig v0.0.0-20220320070855-e710629e75b8 // indirect
+	github.com/tengqm/kubeconfig v0.0.0-20220517070212-dc0ec0cd4ccc // indirect
 	github.com/yuin/goldmark v1.4.1
 	github.com/yuin/goldmark-highlighting v0.0.0-20210516132338-9216f9c5aa01
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/genref/go.sum
+++ b/genref/go.sum
@@ -445,6 +445,10 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tengqm/kubeconfig v0.0.0-20220320070855-e710629e75b8 h1:qDQR/z0QfhjOTpsbkr99TrzS2u49567BE22sPUGu/hk=
 github.com/tengqm/kubeconfig v0.0.0-20220320070855-e710629e75b8/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
+github.com/tengqm/kubeconfig v0.0.0-20220517065444-8d5ca2c5f74f h1:Yt4qxk5leMxtsk5lSrROaoxj3J3uLnlDZpIuBNTvE2k=
+github.com/tengqm/kubeconfig v0.0.0-20220517065444-8d5ca2c5f74f/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
+github.com/tengqm/kubeconfig v0.0.0-20220517070212-dc0ec0cd4ccc h1:cxA8m21KLKJ0M0JYO7Gw3yF4PLSRlJdFCM7ZbJPuB8c=
+github.com/tengqm/kubeconfig v0.0.0-20220517070212-dc0ec0cd4ccc/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/genref/output/md/apiserver-eventratelimit.v1alpha1.md
+++ b/genref/output/md/apiserver-eventratelimit.v1alpha1.md
@@ -1,0 +1,121 @@
+---
+title: Event Rate Limit Configuration (v1alpha1)
+content_type: tool-reference
+package: evenratelimit.admission.k8s.io/v1alpha1
+auto_generated: true
+---
+
+
+## Resource Types 
+
+
+- [Configuration](#evenratelimit-admission-k8s-io-v1alpha1-Configuration)
+  
+    
+
+## `Configuration`     {#evenratelimit-admission-k8s-io-v1alpha1-Configuration}
+    
+
+
+<p>Configuration provides configuration for the EventRateLimit admission
+controller.</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>evenratelimit.admission.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Configuration</code></td></tr>
+    
+  
+<tr><td><code>limits</code> <B>[Required]</B><br/>
+<a href="#evenratelimit-admission-k8s-io-v1alpha1-Limit"><code>[]Limit</code></a>
+</td>
+<td>
+   <p>limits are the limits to place on event queries received.
+Limits can be placed on events received server-wide, per namespace,
+per user, and per source+object.
+At least one limit is required.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `Limit`     {#evenratelimit-admission-k8s-io-v1alpha1-Limit}
+    
+
+**Appears in:**
+
+- [Configuration](#evenratelimit-admission-k8s-io-v1alpha1-Configuration)
+
+
+<p>Limit is the configuration for a particular limit type</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr><td><code>type</code> <B>[Required]</B><br/>
+<a href="#evenratelimit-admission-k8s-io-v1alpha1-LimitType"><code>LimitType</code></a>
+</td>
+<td>
+   <p>type is the type of limit to which this configuration applies</p>
+</td>
+</tr>
+<tr><td><code>qps</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>qps is the number of event queries per second that are allowed for this
+type of limit. The qps and burst fields are used together to determine if
+a particular event query is accepted. The qps determines how many queries
+are accepted once the burst amount of queries has been exhausted.</p>
+</td>
+</tr>
+<tr><td><code>burst</code> <B>[Required]</B><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>burst is the burst number of event queries that are allowed for this type
+of limit. The qps and burst fields are used together to determine if a
+particular event query is accepted. The burst determines the maximum size
+of the allowance granted for a particular bucket. For example, if the burst
+is 10 and the qps is 3, then the admission control will accept 10 queries
+before blocking any queries. Every second, 3 more queries will be allowed.
+If some of that allowance is not used, then it will roll over to the next
+second, until the maximum allowance of 10 is reached.</p>
+</td>
+</tr>
+<tr><td><code>cacheSize</code><br/>
+<code>int32</code>
+</td>
+<td>
+   <p>cacheSize is the size of the LRU cache for this type of limit. If a bucket
+is evicted from the cache, then the allowance for that bucket is reset. If
+more queries are later received for an evicted bucket, then that bucket
+will re-enter the cache with a clean slate, giving that bucket a full
+allowance of burst queries.</p>
+<p>The default cache size is 4096.</p>
+<p>If limitType is 'server', then cacheSize is ignored.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `LimitType`     {#evenratelimit-admission-k8s-io-v1alpha1-LimitType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [Limit](#evenratelimit-admission-k8s-io-v1alpha1-Limit)
+
+
+<p>LimitType is the type of the limit (e.g., per-namespace)</p>
+
+
+
+  


### PR DESCRIPTION
The package was in k8s.io/kubernetes which cannot be directly imported.
I've copied that file into github.com/tengqm/kubeconfig/admission for
parsing.