### PR TITLE
Bump tengqm kubeconfig

### DIFF
--- a/genref/go.mod
+++ b/genref/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/tengqm/kubeconfig v0.0.0-20220519223338-dea4d154bef9 // indirect
+	github.com/tengqm/kubeconfig v0.0.0-20220603092633-c5d4a54dfe74 // indirect
 	github.com/yuin/goldmark v1.4.1
 	github.com/yuin/goldmark-highlighting v0.0.0-20210516132338-9216f9c5aa01
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/genref/go.sum
+++ b/genref/go.sum
@@ -453,6 +453,8 @@ github.com/tengqm/kubeconfig v0.0.0-20220519222026-9ae6568cd25e h1:YAlFnbdxabSLJ
 github.com/tengqm/kubeconfig v0.0.0-20220519222026-9ae6568cd25e/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
 github.com/tengqm/kubeconfig v0.0.0-20220519223338-dea4d154bef9 h1:SPV//WvuuKTTKfX6EmQNwb5R8clvR3O/fOsCCKjr7WY=
 github.com/tengqm/kubeconfig v0.0.0-20220519223338-dea4d154bef9/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
+github.com/tengqm/kubeconfig v0.0.0-20220603092633-c5d4a54dfe74 h1:+K0BmQgPsmY1lp/a05+bzZBni9lwWqWWqfhvlbfhzkA=
+github.com/tengqm/kubeconfig v0.0.0-20220603092633-c5d4a54dfe74/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/genref/output/md/apiserver-eventratelimit.v1alpha1.md
+++ b/genref/output/md/apiserver-eventratelimit.v1alpha1.md
@@ -1,7 +1,7 @@
 ---
 title: Event Rate Limit Configuration (v1alpha1)
 content_type: tool-reference
-package: evenratelimit.admission.k8s.io/v1alpha1
+package: eventratelimit.admission.k8s.io/v1alpha1
 auto_generated: true
 ---
 
@@ -9,11 +9,11 @@ auto_generated: true
 ## Resource Types 
 
 
-- [Configuration](#evenratelimit-admission-k8s-io-v1alpha1-Configuration)
+- [Configuration](#eventratelimit-admission-k8s-io-v1alpha1-Configuration)
   
     
 
-## `Configuration`     {#evenratelimit-admission-k8s-io-v1alpha1-Configuration}
+## `Configuration`     {#eventratelimit-admission-k8s-io-v1alpha1-Configuration}
     
 
 
@@ -25,12 +25,12 @@ controller.</p>
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
 <tbody>
     
-<tr><td><code>apiVersion</code><br/>string</td><td><code>evenratelimit.admission.k8s.io/v1alpha1</code></td></tr>
+<tr><td><code>apiVersion</code><br/>string</td><td><code>eventratelimit.admission.k8s.io/v1alpha1</code></td></tr>
 <tr><td><code>kind</code><br/>string</td><td><code>Configuration</code></td></tr>
     
   
 <tr><td><code>limits</code> <B>[Required]</B><br/>
-<a href="#evenratelimit-admission-k8s-io-v1alpha1-Limit"><code>[]Limit</code></a>
+<a href="#eventratelimit-admission-k8s-io-v1alpha1-Limit"><code>[]Limit</code></a>
 </td>
 <td>
    <p>limits are the limits to place on event queries received.
@@ -42,12 +42,12 @@ At least one limit is required.</p>
 </tbody>
 </table>
 
-## `Limit`     {#evenratelimit-admission-k8s-io-v1alpha1-Limit}
+## `Limit`     {#eventratelimit-admission-k8s-io-v1alpha1-Limit}
     
 
 **Appears in:**
 
-- [Configuration](#evenratelimit-admission-k8s-io-v1alpha1-Configuration)
+- [Configuration](#eventratelimit-admission-k8s-io-v1alpha1-Configuration)
 
 
 <p>Limit is the configuration for a particular limit type</p>
@@ -59,7 +59,7 @@ At least one limit is required.</p>
     
   
 <tr><td><code>type</code> <B>[Required]</B><br/>
-<a href="#evenratelimit-admission-k8s-io-v1alpha1-LimitType"><code>LimitType</code></a>
+<a href="#eventratelimit-admission-k8s-io-v1alpha1-LimitType"><code>LimitType</code></a>
 </td>
 <td>
    <p>type is the type of limit to which this configuration applies</p>
@@ -105,13 +105,13 @@ allowance of burst queries.</p>
 </tbody>
 </table>
 
-## `LimitType`     {#evenratelimit-admission-k8s-io-v1alpha1-LimitType}
+## `LimitType`     {#eventratelimit-admission-k8s-io-v1alpha1-LimitType}
     
 (Alias of `string`)
 
 **Appears in:**
 
-- [Limit](#evenratelimit-admission-k8s-io-v1alpha1-Limit)
+- [Limit](#eventratelimit-admission-k8s-io-v1alpha1-Limit)
 
 
 <p>LimitType is the type of the limit (e.g., per-namespace)</p>


### PR DESCRIPTION
This PR bumps the version of tengqm/kubeconfig where a typo for package name 'eventratelimit' was fixed.