### PR TITLE
Fix a typo on generated warning

### DIFF
--- a/gen-compdocs/generators/doc.go
+++ b/gen-compdocs/generators/doc.go
@@ -44,7 +44,7 @@ The file is auto-generated from the Go source code of the component using a gene
 [generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
 to generate the reference documentation, please read
 [Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
-To update the reference conent, please follow the 
+To update the reference content, please follow the 
 [Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
 guide. You can file document formatting bugs against the
 [reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.


### PR DESCRIPTION
Found a typo while trying to fix https://github.com/kubernetes/website/pull/34130.