### PR TITLE
    Bump kubeconfig version for kubeadm reference update

### DIFF
--- a/genref/go.mod
+++ b/genref/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/tengqm/kubeconfig v0.0.0-20220603092633-c5d4a54dfe74 // indirect
+	github.com/tengqm/kubeconfig v0.0.0-20220707123054-dd00a506fbd1 // indirect
 	github.com/yuin/goldmark v1.4.1
 	github.com/yuin/goldmark-highlighting v0.0.0-20210516132338-9216f9c5aa01
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/genref/go.sum
+++ b/genref/go.sum
@@ -455,6 +455,8 @@ github.com/tengqm/kubeconfig v0.0.0-20220519223338-dea4d154bef9 h1:SPV//WvuuKTTK
 github.com/tengqm/kubeconfig v0.0.0-20220519223338-dea4d154bef9/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
 github.com/tengqm/kubeconfig v0.0.0-20220603092633-c5d4a54dfe74 h1:+K0BmQgPsmY1lp/a05+bzZBni9lwWqWWqfhvlbfhzkA=
 github.com/tengqm/kubeconfig v0.0.0-20220603092633-c5d4a54dfe74/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
+github.com/tengqm/kubeconfig v0.0.0-20220707123054-dd00a506fbd1 h1:mf0YXytQuvJhM1TsFt+lyFCTdCMkoS+PqR1nS909Eh8=
+github.com/tengqm/kubeconfig v0.0.0-20220707123054-dd00a506fbd1/go.mod h1:H3x+n9qoLCGiQVYvcB37lX4si43EGMfAnAyYVus2mBk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/genref/output/md/kubeadm-config.v1beta2.md
+++ b/genref/output/md/kubeadm-config.v1beta2.md
@@ -113,7 +113,7 @@ components by adding customized setting or overriding kubeadm default settings.<
 </span></pre><p>The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances deployed
 in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.</p>
 <p>See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or
-https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
+https://pkg.go.dev/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
 for kube proxy official documentation.</p>
 <pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeletConfiguration<span style="color:#bbb">
@@ -121,7 +121,7 @@ for kube proxy official documentation.</p>
 </span></pre><p>The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
 deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.</p>
 <p>See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or
-https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
+https://pkg.go.dev/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
 for kubelet official documentation.</p>
 <p>Here is a fully populated example of a single YAML file containing multiple
 configuration types to be used during a <code>kubeadm init</code> run.</p>

--- a/genref/output/md/kubeadm-config.v1beta3.md
+++ b/genref/output/md/kubeadm-config.v1beta3.md
@@ -122,7 +122,7 @@ components by adding customized setting or overriding kubeadm default settings.<
 </span></pre><p>The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances
 deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.</p>
 <p>See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or
-https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
+https://pkg.go.dev/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
 for kube-proxy official documentation.</p>
 <pre style="background-color:#fff"><span style="color:#000;font-weight:bold">apiVersion</span>:<span style="color:#bbb"> </span>kubelet.config.k8s.io/v1beta1<span style="color:#bbb">
 </span><span style="color:#bbb"></span><span style="color:#000;font-weight:bold">kind</span>:<span style="color:#bbb"> </span>KubeletConfiguration<span style="color:#bbb">
@@ -130,7 +130,7 @@ for kube-proxy official documentation.</p>
 </span></pre><p>The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
 deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.</p>
 <p>See https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/ or
-https://godoc.org/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
+https://pkg.go.dev/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
 for kubelet official documentation.</p>
 <p>Here is a fully populated example of a single YAML file containing multiple
 configuration types to be used during a <code>kubeadm init</code> run.</p>


### PR DESCRIPTION
The kubeadm reference doc has some trivial fix to be synced.
This PR first bumps the kubeadm module version then regenerate kubeadm config reference.

