### PR TITLE
Fix kube version comparison

### DIFF
--- a/gen-apidocs/generators/api/types.go
+++ b/gen-apidocs/generators/api/types.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/go-openapi/spec"
@@ -80,46 +81,76 @@ func (k ApiKind) String() string {
 }
 
 type ApiVersion string
+type versionType int
+
+const (
+	// Bigger the version type number, higher priority it is
+	versionTypeAlpha versionType = iota
+	versionTypeBeta
+	versionTypeGA
+)
+
+var kubeVersionRegex = regexp.MustCompile("^v([\\d]+)(?:(alpha|beta)([\\d]+))?$")
 
 func (a ApiVersion) String() string {
 	return string(a)
 }
 
+// logic copied from k8s.apimachinery
+func parseKubeVersion(v string) (majorVersion int, vType versionType, minorVersion int, ok bool) {
+	var err error
+	submatches := kubeVersionRegex.FindStringSubmatch(v)
+	if len(submatches) != 4 {
+		return 0, 0, 0, false
+	}
+	switch submatches[2] {
+	case "alpha":
+		vType = versionTypeAlpha
+	case "beta":
+		vType = versionTypeBeta
+	case "":
+		vType = versionTypeGA
+	default:
+		return 0, 0, 0, false
+	}
+	if majorVersion, err = strconv.Atoi(submatches[1]); err != nil {
+		return 0, 0, 0, false
+	}
+	if vType != versionTypeGA {
+		if minorVersion, err = strconv.Atoi(submatches[3]); err != nil {
+			return 0, 0, 0, false
+		}
+	}
+	return majorVersion, vType, minorVersion, true
+}
+
+// logic copied from k8s.apimachinery
+func compareVersionStrings(v1, v2 string) int {
+	if v1 == v2 {
+		return 0
+	}
+	v1major, v1type, v1minor, ok1 := parseKubeVersion(v1)
+	v2major, v2type, v2minor, ok2 := parseKubeVersion(v2)
+	switch {
+	case !ok1 && !ok2:
+		return strings.Compare(v2, v1)
+	case !ok1 && ok2:
+		return -1
+	case ok1 && !ok2:
+		return 1
+	}
+	if v1type != v2type {
+		return int(v1type) - int(v2type)
+	}
+	if v1major != v2major {
+		return v1major - v2major
+	}
+	return v1minor - v2minor
+}
+
 func (this ApiVersion) LessThan(that ApiVersion) bool {
-	re := regexp.MustCompile("(v\\d+)(alpha|beta|)(\\d*)")
-	thisMatches := re.FindStringSubmatch(string(this))
-	thatMatches := re.FindStringSubmatch(string(that))
-
-	a := []string{thisMatches[1]}
-	if len(thisMatches) > 2 {
-		a = []string{thisMatches[2], thisMatches[1], thisMatches[0]}
-	}
-
-	b := []string{thatMatches[1]}
-	if len(thatMatches) > 2 {
-		b = []string{thatMatches[2], thatMatches[1], thatMatches[0]}
-	}
-
-	for i := 0; i < len(a) && i < len(b); i++ {
-		v1 := ""
-		v2 := ""
-		if i < len(a) {
-			v1 = a[i]
-		}
-		if i < len(b) {
-			v2 = b[i]
-		}
-		// If the "beta" or "alpha" is missing, then it is ga (empty string comes before non-empty string)
-		if len(v1) == 0 || len(v2) == 0 {
-			return v1 < v2
-		}
-		// The string with the higher number comes first (or in the case of alpha/beta, beta comes first)
-		if v1 != v2 {
-			return v1 > v2
-		}
-	}
-
-	return false
+	res := compareVersionStrings(string(this), string(that))
+	return res > 0
 }
 
 type ApiVersions []ApiVersion

--- a/gen-apidocs/generators/util.go
+++ b/gen-apidocs/generators/util.go
@@ -69,16 +69,4 @@ func PrintInfo(config *api.Config) {
 			}
 		}
 	}
-
-	//fmt.Printf("Old definitions:\n")
-	//for name, d := range definitions.All {
-	//	if !d.InToc && len(d.OperationCategories) > 0 && d.IsOldVersion && !d.IsInlined {
-	//		fmt.Printf("[%s]\n", name)
-	//		for _, oc := range d.OperationCategories {
-	//			for _, o := range oc.Operations {
-	//				fmt.Printf("\t [%s]\n", o.ID)
-	//			}
-	//		}
-	//	}
-	//}
 }


### PR DESCRIPTION
The current logic for comparing kube-alike version strings is problematic. It cannot handle two GA versions. This PR revises the logic by borrowing the functions used in k8s.io/apimachinery.