### PR TITLE
Improve the ConfigAPI reference generator

### DIFF
--- a/genref/markdown/pkg.tpl
+++ b/genref/markdown/pkg.tpl
@@ -2,7 +2,16 @@
 
 {{ $grpname := "" -}}
 {{- range $idx, $val := .packages -}}
-{{- if and (ne .GroupName "") (eq $grpname "") -}}
+{{/* Special handling for kubeconfig */}}
+{{- if eq .Title "kubeconfig (v1)" -}}
+---
+title: {{ .Title }}
+content_type: tool-reference
+package: v1
+auto_generated: true
+---
+{{- else -}}
+  {{- if and (ne .GroupName "") (eq $grpname "") -}}
 ---
 title: {{ .Title }}
 content_type: tool-reference
@@ -11,19 +20,20 @@ auto_generated: true
 ---
 {{ .GetComment -}}
 {{ $grpname = .GroupName }}
+  {{- end -}}
 {{- end -}}
 {{- end }}
 
 ## Resource Types 
 
 {{ range .packages -}}
-  {{- if ne .GroupName "" -}}
+  {{/*- if ne .GroupName "" -*/}}
     {{- range .VisibleTypes -}}
       {{- if .IsExported }}
 - [{{ .DisplayName }}]({{ .Link }})
       {{- end -}}
     {{- end -}}
-  {{ end -}}
+  {{/* end -*/}}
 {{- end -}}
 
 {{ range .packages }}

--- a/genref/types.go
+++ b/genref/types.go
@@ -180,6 +180,18 @@ func (t *apiType) IsExported() bool {
 	if strings.Contains(comments, "+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object") {
 		return true
 	}
+
+	// There are cases where this comment is not the "second closest".
+	// Check this again.
+	comments = strings.Join(t.CommentLines, "\n")
+	if strings.Contains(comments, "+genclient") {
+		return true
+	}
+
+	if strings.Contains(comments, "+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object") {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
This PR improves the detection of exposed types by including the "closest" comment as well because some types are not strictly following the implicit protocols.
We also relax the constraint for filtering "exported" types. For example, the (Kube)Config type in the "v1" group should be exposed when parsing the client-go package.