### PR TITLE
Update ref from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/genref/output/html/kubeadm-config.v1beta1.html
+++ b/genref/output/html/kubeadm-config.v1beta1.html
@@ -208,7 +208,7 @@ kind: ClusterConfiguration
 etcd:
   # one of local or external
   local:
-    imageRepository: "k8s.gcr.io"
+    imageRepository: "registry.k8s.io"
     imageTag: "3.2.24"
     dataDir: "/var/lib/etcd"
     extraArgs:
@@ -262,7 +262,7 @@ scheduler:
     readOnly: false
     pathType: File
 certificatesDir: "/etc/kubernetes/pki"
-imageRepository: "k8s.gcr.io"
+imageRepository: "registry.k8s.io"
 useHyperKubeImage: false
 clusterName: "example-cluster"
 ---
@@ -647,9 +647,9 @@ Possible usages are:
           
 
           `imageRepository` specifies the container registry from which images are pulled.
-If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
+If empty, `registry.k8s.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
 `gcr.io/k8s-staging-ci-images` will be used for control plane components and
-kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+kube-proxy, while `registry.k8s.io` will be used for all the other images.
 
           
 

--- a/genref/output/html/kubeadm-config.v1beta2.html
+++ b/genref/output/html/kubeadm-config.v1beta2.html
@@ -204,7 +204,7 @@ kind: ClusterConfiguration
 etcd:
   # one of local or external
   local:
-    imageRepository: "k8s.gcr.io"
+    imageRepository: "registry.k8s.io"
     imageTag: "3.2.24"
     dataDir: "/var/lib/etcd"
     extraArgs:
@@ -258,7 +258,7 @@ scheduler:
     readOnly: false
     pathType: File
 certificatesDir: "/etc/kubernetes/pki"
-imageRepository: "k8s.gcr.io"
+imageRepository: "registry.k8s.io"
 useHyperKubeImage: false
 clusterName: "example-cluster"
 ---
@@ -638,9 +638,9 @@ The value must be an absolute path.
           
 
           `imageRepository` specifies the container registry from which images are pulled.
-If empty, `k8s.gcr.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
+If empty, `registry.k8s.io` will be used. If kubernetes version is a CI build (starts with `ci/` or `ci-cross/`)
 `gcr.io/k8s-staging-ci-images` will be used for control plane components and
-kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+kube-proxy, while `registry.k8s.io` will be used for all the other images.
 
           
 


### PR DESCRIPTION
With the [change to defaulting](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) to registry.k8s.io as our image registry and the [planned freeze in April](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/), projects within the Kubernetes orgs need to update their image references to point to the new address.

ref: https://github.com/kubernetes/k8s.io/issues/4738