### PR TITLE
Support referenced parameters

### DIFF
--- a/gen-resourcesdocs/pkg/config/output_test.go
+++ b/gen-resourcesdocs/pkg/config/output_test.go
@@ -36,7 +36,7 @@ func (o FakeSection) AddContent(s string) error                              { r
 func (o FakeSection) AddTypeDefinition(typ string, description string) error { return nil }
 func (o FakeSection) AddFieldCategory(name string) error                     { return nil }
 
-func (o FakeSection) AddProperty(name string, property *kubernetes.Property, linkend []string, indent bool, defname string, shortName string) error {
+func (o FakeSection) AddProperty(name string, property *kubernetes.Property, linkend []string, indent int, defname string, shortName string) error {
 	return nil
 }
 func (o FakeSection) EndProperty() error       { return nil }

--- a/gen-resourcesdocs/pkg/kubernetes/actions.go
+++ b/gen-resourcesdocs/pkg/kubernetes/actions.go
@@ -144,7 +144,7 @@ func (a ActionInfoList) Less(i, j int) bool {
 type Actions map[string]ActionInfoList
 
 // Add an action to the collection of actions
-func (o Actions) Add(key string, operation *spec.Operation, httpMethod string, pathParameters []spec.Parameter) {
+func (o Actions) Add(specParameters map[string]spec.Parameter, key string, operation *spec.Operation, httpMethod string, pathParameters []spec.Parameter) {
 
 	desc := operation.Description
 	if strings.Contains(strings.ToLower(desc), "deprecated") {
@@ -168,10 +168,10 @@ func (o Actions) Add(key string, operation *spec.Operation, httpMethod string, p
 
 			list := new(ParametersList)
 			for _, pathParam := range pathParameters {
-				list.Add(pathParam)
+				list.Add(specParameters, pathParam)
 			}
 			for _, opParam := range operation.Parameters {
-				list.Add(opParam)
+				list.Add(specParameters, opParam)
 			}
 			sort.Sort(list)
 

--- a/gen-resourcesdocs/pkg/kubernetes/parmeters.go
+++ b/gen-resourcesdocs/pkg/kubernetes/parmeters.go
@@ -37,7 +37,11 @@ func (a ParametersList) Less(i, j int) bool {
 }
 
 // Add a parameter to the list
-func (a *ParametersList) Add(parameter spec.Parameter) {
+func (a *ParametersList) Add(specParameters map[string]spec.Parameter, parameter spec.Parameter) {
+	if !parameter.Ref.GetPointer().IsEmpty() {
+		key := Key(strings.TrimPrefix(parameter.Ref.GetPointer().String(), "/parameters/"))
+		parameter = specParameters[key.String()]
+	}
 	desc := parameter.Description
 	if strings.Contains(strings.ToLower(desc), "deprecated") {
 		return

--- a/gen-resourcesdocs/pkg/kubernetes/spec.go
+++ b/gen-resourcesdocs/pkg/kubernetes/spec.go
@@ -133,25 +133,25 @@ func (o *Spec) getActions() error {
 	paths := o.Swagger.Paths.Paths
 	for key, path := range paths {
 		if path.Get != nil {
-			o.Actions.Add(key, path.Get, "GET", path.Parameters)
+			o.Actions.Add(o.Swagger.Parameters, key, path.Get, "GET", path.Parameters)
 		}
 		if path.Put != nil {
-			o.Actions.Add(key, path.Put, "PUT", path.Parameters)
+			o.Actions.Add(o.Swagger.Parameters, key, path.Put, "PUT", path.Parameters)
 		}
 		if path.Post != nil {
-			o.Actions.Add(key, path.Post, "POST", path.Parameters)
+			o.Actions.Add(o.Swagger.Parameters, key, path.Post, "POST", path.Parameters)
 		}
 		if path.Delete != nil {
-			o.Actions.Add(key, path.Delete, "DELETE", path.Parameters)
+			o.Actions.Add(o.Swagger.Parameters, key, path.Delete, "DELETE", path.Parameters)
 		}
 		if path.Options != nil {
-			o.Actions.Add(key, path.Options, "OPTIONS", path.Parameters)
+			o.Actions.Add(o.Swagger.Parameters, key, path.Options, "OPTIONS", path.Parameters)
 		}
 		if path.Head != nil {
-			o.Actions.Add(key, path.Head, "HEAD", path.Parameters)
+			o.Actions.Add(o.Swagger.Parameters, key, path.Head, "HEAD", path.Parameters)
 		}
 		if path.Patch != nil {
-			o.Actions.Add(key, path.Patch, "PATCH", path.Parameters)
+			o.Actions.Add(o.Swagger.Parameters, key, path.Patch, "PATCH", path.Parameters)
 		}
 	}
 


### PR DESCRIPTION
Kubernetes v1.28 spec introduces the use of referenced Parameters:

```
        "parameters": [
          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+            "$ref": "#/parameters/body-2Y1dVQaQ"
            }
          },
```

The changes in this PR makes the converter able to get the parameter information from the referenced parameter.

This change is necessary to build the multi-pages API reference for Kubernetes v1.28
