### PR TITLE
[gen-kubectldocs] fix Go lint issues, improve error handling

### DIFF
--- a/gen-kubectldocs/go.mod
+++ b/gen-kubectldocs/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/apimachinery v0.26.0
 	k8s.io/kubectl v0.26.0
 )
 
@@ -68,7 +69,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.26.0 // indirect
-	k8s.io/apimachinery v0.26.0 // indirect
 	k8s.io/cli-runtime v0.26.0 // indirect
 	k8s.io/client-go v0.26.0 // indirect
 	k8s.io/component-base v0.26.0 // indirect

--- a/gen-kubectldocs/main.go
+++ b/gen-kubectldocs/main.go
@@ -18,10 +18,15 @@ package main
 
 import (
 	"flag"
+	"log"
+
 	"github.com/kubernetes-sigs/reference-docs/gen-kubectldocs/generators"
 )
 
 func main() {
 	flag.Parse()
-	generators.GenerateFiles()
+
+	if err := generators.GenerateFiles(); err != nil {
+		log.Fatalf("Failed to generate files: %v", err)
+	}
 }


### PR DESCRIPTION
This PR fixes a bunch of general linting issues and adds extra error handling. My favorite improvement is the error message for when no `--kubernetes-version` flag was given: Previously it read "must specifiy --toc-file", which isn't even a real flag. :)