### PR TITLE
[gen-apidocs] fix Go lint issues, improve error handling, replace navdata generator with regular JSON encoder

### DIFF
--- a/gen-apidocs/generators/api/examples.go
+++ b/gen-apidocs/generators/api/examples.go
@@ -109,36 +109,36 @@ func (ce CurlExample) GetSampleType() string {
 func (ce CurlExample) GetRequest(o *Operation) string {
 	c := o.ExampleConfig
 	y := c.Request
-	if len(y) <= 0 && len(c.Name) <= 0 {
+	if len(y) == 0 && len(c.Name) == 0 {
 		return ""
 	}
 
 	switch o.Type.Name {
 	case "Create":
-		return fmt.Sprintf("$ kubectl proxy\n$ curl -X POST -H 'Content-Type: application/yaml' --data '\n%s' http://127.0.0.1:8001%s", y, strings.Replace(o.Path, "{namespace}", "default", -1))
+		return fmt.Sprintf("$ kubectl proxy\n$ curl -X POST -H 'Content-Type: application/yaml' --data '\n%s' http://127.0.0.1:8001%s", y, strings.ReplaceAll(o.Path, "{namespace}", "default"))
 	case "Delete":
-		path := strings.Replace(o.Path, "{namespace}", o.ExampleConfig.Namespace, -1)
-		path = strings.Replace(path, "{name}", o.ExampleConfig.Name, -1)
+		path := strings.ReplaceAll(o.Path, "{namespace}", o.ExampleConfig.Namespace)
+		path = strings.ReplaceAll(path, "{name}", o.ExampleConfig.Name)
 		return fmt.Sprintf("$ kubectl proxy\n$ curl -X DELETE -H 'Content-Type: application/yaml' --data '\n%s' 'http://127.0.0.1:8001%s'", y, path)
 	case "List":
-		path := strings.Replace(o.Path, "{namespace}", o.ExampleConfig.Namespace, -1)
-		path = strings.Replace(path, "{name}", o.ExampleConfig.Name, -1)
+		path := strings.ReplaceAll(o.Path, "{namespace}", o.ExampleConfig.Namespace)
+		path = strings.ReplaceAll(path, "{name}", o.ExampleConfig.Name)
 		return fmt.Sprintf("$ kubectl proxy\n$ curl -X GET 'http://127.0.0.1:8001%s'", path)
 	case "Patch":
-		path := strings.Replace(o.Path, "{namespace}", o.ExampleConfig.Namespace, -1)
-		path = strings.Replace(path, "{name}", o.ExampleConfig.Name, -1)
+		path := strings.ReplaceAll(o.Path, "{namespace}", o.ExampleConfig.Namespace)
+		path = strings.ReplaceAll(path, "{name}", o.ExampleConfig.Name)
 		return fmt.Sprintf("$ kubectl proxy\n$ curl -X PATCH -H 'Content-Type: application/strategic-merge-patch+json' --data '\n%s' \\\n\t'http://127.0.0.1:8001%s'", y, path)
 	case "Read":
-		path := strings.Replace(o.Path, "{namespace}", o.ExampleConfig.Namespace, -1)
-		path = strings.Replace(path, "{name}", o.ExampleConfig.Name, -1)
+		path := strings.ReplaceAll(o.Path, "{namespace}", o.ExampleConfig.Namespace)
+		path = strings.ReplaceAll(path, "{name}", o.ExampleConfig.Name)
 		return fmt.Sprintf("$ kubectl proxy\n$ curl -X GET http://127.0.0.1:8001%s", path)
 	case "Replace":
-		path := strings.Replace(o.Path, "{namespace}", o.ExampleConfig.Namespace, -1)
-		path = strings.Replace(path, "{name}", o.ExampleConfig.Name, -1)
+		path := strings.ReplaceAll(o.Path, "{namespace}", o.ExampleConfig.Namespace)
+		path = strings.ReplaceAll(path, "{name}", o.ExampleConfig.Name)
 		return fmt.Sprintf("$ kubectl proxy\n$ curl -X PUT -H 'Content-Type: application/yaml' --data '\n%s' http://127.0.0.1:8001%s", y, path)
 	case "Watch":
-		path := strings.Replace(o.Path, "{namespace}", o.ExampleConfig.Namespace, -1)
-		path = strings.Replace(path, "{name}", o.ExampleConfig.Name, -1)
+		path := strings.ReplaceAll(o.Path, "{namespace}", o.ExampleConfig.Namespace)
+		path = strings.ReplaceAll(path, "{name}", o.ExampleConfig.Name)
 		return fmt.Sprintf("$ kubectl proxy\n$ curl -X GET 'http://127.0.0.1:8001%s'", path)
 	}
 	return ""
@@ -147,24 +147,24 @@ func (ce CurlExample) GetRequest(o *Operation) string {
 func (ce CurlExample) GetResponse(o *Operation) string {
 	c := o.ExampleConfig
 	j := o.ExampleConfig.Response
-	if len(j) <= 0 && len(c.Name) <= 0 {
+	if len(j) == 0 && len(c.Name) == 0 {
 		return ""
 	}
 	switch o.Type.Name {
 	case "Create":
-		return fmt.Sprintf("%s", j)
+		return j
 	case "Delete":
-		return fmt.Sprintf("%s", j)
+		return j
 	case "List":
-		return fmt.Sprintf("%s", j)
+		return j
 	case "Patch":
-		return fmt.Sprintf("%s", j)
+		return j
 	case "Read":
-		return fmt.Sprintf("%s", j)
+		return j
 	case "Replace":
-		return fmt.Sprintf("%s", j)
+		return j
 	case "Watch":
-		return fmt.Sprintf("%s", j)
+		return j
 	}
 	return ""
 }
@@ -201,7 +201,7 @@ func (ke KubectlExample) GetRequest(o *Operation) string {
 	c := o.ExampleConfig
 	t := strings.ToLower(o.Definition.Name)
 	y := c.Request
-	if len(y) <= 0 && len(c.Name) <= 0 {
+	if len(y) == 0 && len(c.Name) == 0 {
 		return ""
 	}
 	switch o.Type.Name {
@@ -228,24 +228,24 @@ func (ke KubectlExample) GetResponse(o *Operation) string {
 	name := o.ExampleConfig.Name
 	t := strings.ToLower(o.Definition.Name)
 	j := o.ExampleConfig.Response
-	if len(j) <= 0 && len(c.Name) <= 0 {
+	if len(j) == 0 && len(c.Name) == 0 {
 		return ""
 	}
 	switch o.Type.Name {
 	case "Create":
-		return fmt.Sprintf("%s \"%s\" created", t, name)
+		return fmt.Sprintf("%s %q created", t, name)
 	case "Delete":
-		return fmt.Sprintf("%s \"%s\" deleted", t, name)
+		return fmt.Sprintf("%s %q deleted", t, name)
 	case "List":
-		return fmt.Sprintf("%s", j)
+		return j
 	case "Patch":
-		return fmt.Sprintf("\"%s\" patched", name)
+		return fmt.Sprintf("%q patched", name)
 	case "Read":
-		return string(j)
+		return j
 	case "Replace":
-		return fmt.Sprintf("%s \"%s\" replaced", t, name)
+		return fmt.Sprintf("%s %q replaced", t, name)
 	case "Watch":
-		return string(j)
+		return j
 	}
 	return ""
 }

--- a/gen-apidocs/generators/api/types.go
+++ b/gen-apidocs/generators/api/types.go
@@ -90,7 +90,7 @@ const (
 	versionTypeGA
 )
 
-var kubeVersionRegex = regexp.MustCompile("^v([\\d]+)(?:(alpha|beta)([\\d]+))?$")
+var kubeVersionRegex = regexp.MustCompile(`^v([\d]+)(?:(alpha|beta)([\d]+))?$`)
 
 func (a ApiVersion) String() string {
 	return string(a)
@@ -280,7 +280,7 @@ func (a Fields) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
 func (f Field) Link() string {
 	if f.Definition != nil {
-		return strings.Replace(f.Type, f.Definition.Name, f.Definition.MdLink(), -1)
+		return strings.ReplaceAll(f.Type, f.Definition.Name, f.Definition.MdLink())
 	} else {
 		return f.Type
 	}
@@ -288,7 +288,7 @@ func (f Field) Link() string {
 
 func (f Field) FullLink() string {
 	if f.Definition != nil {
-		return strings.Replace(f.Type, f.Definition.Name, f.Definition.HrefLink(), -1)
+		return strings.ReplaceAll(f.Type, f.Definition.Name, f.Definition.HrefLink())
 	} else {
 		return f.Type
 	}

--- a/gen-apidocs/generators/api/util.go
+++ b/gen-apidocs/generators/api/util.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"errors"
 	"github.com/go-openapi/spec"
 )
 
@@ -28,8 +27,8 @@ import (
 func GetDefinitionVersionKind(s spec.Schema) (string, string, string) {
 	// Get the reference for complex types
 	if IsDefinition(s) {
-		s := fmt.Sprintf("%s", s.SchemaProps.Ref.GetPointer())
-		s = strings.Replace(s, "/definitions/", "", -1)
+		s := s.SchemaProps.Ref.GetPointer().String()
+		s = strings.ReplaceAll(s, "/definitions/", "")
 		name := strings.Split(s, ".")
 
 		var group, version, kind string
@@ -55,7 +54,7 @@ func GetDefinitionVersionKind(s spec.Schema) (string, string, string) {
 			// - io.k8s.apimachinery.pkg.runtime.RawExtension
 			return "", "", ""
 		} else {
-			panic(errors.New(fmt.Sprintf("Could not locate group for %s", name)))
+			panic(fmt.Sprintf("Could not locate group for %s", name))
 		}
 		return group, version, kind
 	}
@@ -80,7 +79,7 @@ func GetTypeName(s spec.Schema) string {
 	}
 	// Get the value for primitive types
 	if len(s.Type) > 0 {
-		return fmt.Sprintf("%s", s.Type[0])
+		return s.Type[0]
 	}
 	panic(fmt.Errorf("No type found for object %v", s))
 }
@@ -97,10 +96,10 @@ func IsDefinition(s spec.Schema) bool {
 
 // handle '*', 'a/*', '*/b', '*/*' cases
 func EscapeAsterisks(des string) string {
-	s := strings.Replace(des, "'*'", `'\*'`, -1)
-	s = strings.Replace(s, "/*'", `/\*'`, -1)
-	s = strings.Replace(s, "'*/", `'\*/`, -1)
-	s = strings.Replace(s, "'*/*'", `'\*/\*'`, -1)
+	s := strings.ReplaceAll(des, "'*'", `'\*'`)
+	s = strings.ReplaceAll(s, "/*'", `/\*'`)
+	s = strings.ReplaceAll(s, "'*/", `'\*/`)
+	s = strings.ReplaceAll(s, "'*/*'", `'\*/\*'`)
 	return s
 }
 

--- a/gen-apidocs/main.go
+++ b/gen-apidocs/main.go
@@ -18,11 +18,14 @@ package main
 
 import (
 	"flag"
+	"log"
 
 	"github.com/kubernetes-sigs/reference-docs/gen-apidocs/generators"
 )
 
 func main() {
 	flag.Parse()
-	generators.GenerateFiles()
+	if err := generators.GenerateFiles(); err != nil {
+		log.Fatalf("failure: %v", err)
+	}
 }


### PR DESCRIPTION
This PR fixes a whole lot of general linting issues, adds extra error handling, fixes some typos and replaces the navdata generator with a more generic, recursive implementation.