### PR TITLE
[gen-apidocs] remove standalone navdata, use DOM instead

### DIFF
--- a/gen-apidocs/config/sections/_cluster.html
+++ b/gen-apidocs/config/sections/_cluster.html
@@ -1,5 +1,5 @@
-<H1 id="-strong-cluster-apis-strong-"><strong>CLUSTER</strong></H1>
+<DIV id="cluster-apis">
+<H1 class="toc-item section resource-category">Cluster</H1>
 
 <P>Cluster resources are responsible for defining configuration of the cluster itself, and are generally only used by cluster operators.</P>
-
-<HR />
+</DIV>

--- a/gen-apidocs/config/sections/_config.html
+++ b/gen-apidocs/config/sections/_config.html
@@ -1,4 +1,5 @@
-<H1 id="-strong-config-and-storage-apis-strong-"><STRONG>CONFIG & STORAGE</STRONG></H1>
+<DIV id="config-and-storage-apis">
+<H1 class="toc-item section resource-category">Config &amp; Storage</H1>
 
 <P>Config and Storage resources are responsible for injecting data into your applications and persisting data externally to your container.</P>
 
@@ -8,4 +9,4 @@
 <LI><A href="#secret-v1-core">Secrets</A> for providing binary data injected into the application through files</LI>
 <LI><A href="#volume-v1-core">Volumes</A> for providing a filesystem external to the Container.  Maybe shared across Containers within the same Pod and have a lifetime persisting beyond a Container or Pod.</LI>
 </UL>
-<HR />
+</DIV>

--- a/gen-apidocs/config/sections/_definitions.html
+++ b/gen-apidocs/config/sections/_definitions.html
@@ -1,3 +1,5 @@
-<H1 id="-strong-definitions-strong-"><STRONG>DEFINITIONS</STRONG></H1>
+<DIV id="definitions">
+<H1 class="toc-item section">Definitions</H1>
 
 <P>This section contains definitions for objects used in the Kubernetes APIs.</P>
+</DIV>

--- a/gen-apidocs/config/sections/_meta.html
+++ b/gen-apidocs/config/sections/_meta.html
@@ -1,4 +1,5 @@
-<H1 id="-strong-metadata-apis-strong-"><STRONG>METADATA</STRONG></H1>
+<DIV id="metadata-apis">
+<H1 class="toc-item section resource-category">Metadata</H1>
 
 <P>Metadata resources are responsible for configuring behavior of your other Resources within the Cluster.</P>
 
@@ -8,4 +9,4 @@
 <LI><A href="#poddisruptionbudget-v1alpha1">PodDisruptionBudget</A> for configuring how many replicas in a given workload maybe made concurrently unavailable when performing maintenance.</LI>
 <LI><A href="#event-v1-core">Event</A> for notification of resource lifecycle events in the cluster.</LI>
 </UL>
-<HR />
+</DIV>

--- a/gen-apidocs/config/sections/_oldversions.html
+++ b/gen-apidocs/config/sections/_oldversions.html
@@ -1,3 +1,5 @@
-<H1 id="-strong-old-api-versions-strong-"><STRONG>OLD API VERSIONS</STRONG></H1>
+<DIV id="old-api-versions">
+<H1 class="toc-item section" id="">Old API Versions</H1>
 
 <P>This section contains older versions of resources shown above.</P>
+</DIV>

--- a/gen-apidocs/config/sections/_overview.html
+++ b/gen-apidocs/config/sections/_overview.html
@@ -1,30 +1,27 @@
-<H1 id="-strong-api-overview-strong-"><STRONG>API OVERVIEW</STRONG></H1>
+<DIV id="api-overview">
+<H1 class="toc-item section">API Overview</H1>
 
-<P>Welcome to the Kubernetes API.  You can use the Kubernetes API to read
+<P>Welcome to the Kubernetes API. You can use the Kubernetes API to read
 and write Kubernetes resource objects via a Kubernetes API endpoint.</P>
 
 <H2 id="resource-categories">Resource Categories</H2>
 
 <P>This is a high-level overview of the basic types of resources provide by the Kubernetes API and their primary functions.</P>
-<P><B>Workloads</B> are objects you use to manage and run your containers on the cluster.</P>
-<P><B>Discovery &amp; LB</B> resources are objects you use to "stitch" your workloads together into an externally accessible, load-balanced Service.</P>
-<P><B>Config &amp; Storage</B> resources are objects you use to inject initialization data into your applications, and to persist data that is external to your container.</P>
-<P><B>Cluster</B> resources objects define how the cluster itself is configured; these are typically used only by cluster operators.</P>
-<P><B>Metadata</B> resources are objects you use to configure the behavior of other resources within the cluster, such as <code>HorizontalPodAutoscaler</code> for scaling workloads.</P>
-
-<HR />
+<P><STRONG>Workloads</STRONG> are objects you use to manage and run your containers on the cluster.</P>
+<P><STRONG>Discovery &amp; LB</STRONG> resources are objects you use to "stitch" your workloads together into an externally accessible, load-balanced Service.</P>
+<P><STRONG>Config &amp; Storage</STRONG> resources are objects you use to inject initialization data into your applications, and to persist data that is external to your container.</P>
+<P><STRONG>Cluster</STRONG> resources objects define how the cluster itself is configured; these are typically used only by cluster operators.</P>
+<P><STRONG>Metadata</STRONG> resources are objects you use to configure the behavior of other resources within the cluster, such as <code>HorizontalPodAutoscaler</code> for scaling workloads.</P>
 
 <H2 id="resource-objects">Resource Objects</H2>
 
 <P>Resource objects typically have 3 components:</P>
 <UL>
-<LI><B>Resource ObjectMeta</B>: This is metadata about the resource, such as its name, type, api version, annotations, and labels.  This contains
+<LI><STRONG>Resource ObjectMeta</STRONG>: This is metadata about the resource, such as its name, type, api version, annotations, and labels. This contains
 fields that maybe updated both by the end user and the system (e.g. annotations).</LI>
-<LI><B>ResourceSpec</B>: This is defined by the user and describes the desired state of system.  Fill this in when creating or updating an object.</LI>
-<LI><B>ResourceStatus</B>: This is filled in by the server and reports the current state of the system.  In most cases, users don't need to change this.</LI>
+<LI><STRONG>ResourceSpec</STRONG>: This is defined by the user and describes the desired state of system. Fill this in when creating or updating an object.</LI>
+<LI><STRONG>ResourceStatus</STRONG>: This is filled in by the server and reports the current state of the system. In most cases, users don't need to change this.</LI>
 </UL>
-
-<HR />
 
 <H2 id="resource-operations">Resource Operations</H2>
 
@@ -32,48 +29,48 @@ fields that maybe updated both by the end user and the system (e.g. annotations)
 
 <H4 id="resource-operations-create">Create</H4>
 
-<P>Create operations will create the resource in the storage backend.  After a resource is create the system will apply
+<P>Create operations will create the resource in the storage backend. After a resource is create the system will apply
 the desired state.</P>
 
 <H4 id="resource-operations-update">Update</H4>
 
-<P>Updates come in 2 forms: <B>Replace</B> and <B>Patch</B>:
+<P>Updates come in 2 forms: <STRONG>Replace</STRONG> and <STRONG>Patch</STRONG>:
 
 <UL>
-<LI><B>Replace</B>:
-Replacing a resource object will update the resource by replacing the existing spec with the provided one.  For
+<LI><STRONG>Replace</STRONG>:
+Replacing a resource object will update the resource by replacing the existing spec with the provided one. For
 read-then-write operations this is safe because an optimistic lock failure will occur if the resource was modified
-between the read and write. <I>Note</I>: The <I>ResourceStatus</I> will be ignored by the system and will not be updated.
+between the read and write. <EM>Note</EM>: The <EM>ResourceStatus</EM> will be ignored by the system and will not be updated.
 To update the status, one must invoke the specific status update operation.<BR />
 
-Note: Replacing a resource object may not result immediately in changes being propagated to downstream objects.  For instance
-replacing a <CODE>ConfigMap</CODE> or <CODE>Secret</CODE> resource will not result in all <I>Pod</I>s seeing the changes unless the <I>Pod</I>s are
+Note: Replacing a resource object may not result immediately in changes being propagated to downstream objects. For instance
+replacing a <CODE>ConfigMap</CODE> or <CODE>Secret</CODE> resource will not result in all <EM>Pod</EM>s seeing the changes unless the <EM>Pod</EM>s are
 restarted out of band.</P></LI>
 
-<LI><B>Patch</B>:
-Patch will apply a change to a specific field.  How the change is merged is defined per field.  Lists may either be
-replaced or merged.  Merging lists will not preserve ordering.<BR />
+<LI><STRONG>Patch</STRONG>:
+Patch will apply a change to a specific field. How the change is merged is defined per field. Lists may either be
+replaced or merged. Merging lists will not preserve ordering.<BR />
 
-<B>Patches will never cause optimistic locking failures, and the last write will win.</B>  Patches are recommended
-when the full state is not read before an update, or when failing on optimistic locking is undesirable. <I>When patching
+<STRONG>Patches will never cause optimistic locking failures, and the last write will win.</STRONG> Patches are recommended
+when the full state is not read before an update, or when failing on optimistic locking is undesirable. <EM>When patching
 complex types, arrays and maps, how the patch is applied is defined on a per-field basis and may either replace
-the field's current value, or merge the contents into the current value.</I></LI>
+the field's current value, or merge the contents into the current value.</EM></LI>
 </UL>
 
 <H4 id="resource-operations-read">Read</H4>
 
-<P>Reads come in 3 forms: <B>Get</B>, <B>List</B> and <B>Watch</B>:<P>
+<P>Reads come in 3 forms: <STRONG>Get</STRONG>, <STRONG>List</STRONG> and <STRONG>Watch</STRONG>:</P>
 
 <UL>
-<LI><B>Get</B>: Get will retrieve a specific resource object by name.</LI>
-<LI><B>List</B>: List will retrieve all resource objects of a specific type within a namespace, and the results can be restricted to resources matching a selector query.<BR />
-<B>List All Namespaces</B>: Like <B>List</B> but retrieves resources across all namespaces.</LI>
-<LI><B>Watch</B>: Watch will stream results for an object(s) as it is updated.  Similar to a callback, watch is used to respond to resource changes.</LI>
+<LI><STRONG>Get</STRONG>: Get will retrieve a specific resource object by name.</LI>
+<LI><STRONG>List</STRONG>: List will retrieve all resource objects of a specific type within a namespace, and the results can be restricted to resources matching a selector query.<BR />
+<STRONG>List All Namespaces</STRONG>: Like <STRONG>List</STRONG> but retrieves resources across all namespaces.</LI>
+<LI><STRONG>Watch</STRONG>: Watch will stream results for an object(s) as it is updated. Similar to a callback, watch is used to respond to resource changes.</LI>
 </UL>
 
 <H4 id="resource-operations-read">Delete</H4>
 
-<P>Delete will delete a resource.  Depending on the specific resource, child objects may or may not be garbage collected by the server.  See
+<P>Delete will delete a resource. Depending on the specific resource, child objects may or may not be garbage collected by the server. See
 notes on specific resource objects for details.</P>
 
 <H4 id="resource-operations-additional">Additional Operations</H4>
@@ -81,8 +78,8 @@ notes on specific resource objects for details.</P>
 <P>Resources may define additional operations specific to that resource type.</P>
 
 <UL>
-	<LI><B>Rollback</B>: Rollback a PodTemplate to a previous version.  Only available for some resource types.</LI>
-	<LI><B>Read / Write Scale</B>: Read or Update the number of replicas for the given resource.  Only available for some resource types.</LI>
-	<LI><B>Read / Write Status</B>: Read or Update the Status for a resource object.  The Status can only changed through these update operations.</LI>
+	<LI><STRONG>Rollback</STRONG>: Rollback a PodTemplate to a previous version. Only available for some resource types.</LI>
+	<LI><STRONG>Read / Write Scale</STRONG>: Read or Update the number of replicas for the given resource. Only available for some resource types.</LI>
+	<LI><STRONG>Read / Write Status</STRONG>: Read or Update the Status for a resource object. The Status can only changed through these update operations.</LI>
 </UL>
-<HR />
+</DIV>

--- a/gen-apidocs/config/sections/_servicediscovery.html
+++ b/gen-apidocs/config/sections/_servicediscovery.html
@@ -1,7 +1,8 @@
-<H1 id="-strong-service-apis-strong-"><STRONG>SERVICE APIs</STRONG></H1>
+<DIV id="service-apis">
+<H1 class="toc-item section resource-category">Service</H1>
 
 <P>Service API resources are responsible for stitching your workloads together into an accessible Loadbalanced Service.  By default,
-<A href="#-strong-workloads-strong">Workloads</A> are only accessible within the cluster, and they must be exposed externally using a either
+<A href="#workloads-apis">Workloads</A> are only accessible within the cluster, and they must be exposed externally using a either
 a *LoadBalancer* or *NodePort* <A href="#service-v1-core">Service</A>.  For development, internally accessible
 Workloads can be accessed via proxy through the api master using the <code>kubectl proxy</code> command.</P>
 
@@ -11,4 +12,4 @@ Workloads can be accessed via proxy through the api master using the <code>kubec
 	<LI><A href="#service-v1-core">Services</A> for providing a single ip endpoint loadbalanced across multiple Workload replicas.</LI>
 	<LI><A href="#ingress-v1beta1-extensions">Ingress</A> for providing a https(s) endpoint http(s) routed to one or more *Services*.</LI>
 </UL>
-<HR />
+</DIV>

--- a/gen-apidocs/config/sections/_workloads.html
+++ b/gen-apidocs/config/sections/_workloads.html
@@ -1,4 +1,5 @@
-<H1 id="-strong-workloads-apis-strong-"><STRONG>WORKLOADS</STRONG></H1>
+<DIV id="workloads-apis">
+<H1 class="toc-item section resource-category">Workloads</H1>
 
 <P>Workloads resources are responsible for managing and running your containers on the cluster. <A href="#container-v1-core">Containers</A> are created
 by Controllers through <A href="#pod-v1-core">Pods</A>. Pods run Containers and provide environmental dependencies such as shared or
@@ -11,5 +12,4 @@ data injected into the container.</P>
 <LI><A href="#statefulset-v1-apps">StatefulSets</A> for stateful persistent apps (e.g. databases).</LI>
 <LI><A href="#job-v1-batch">Jobs</A> for run-to-completion apps (e.g. batch Jobs).</LI>
 </UL>
-
-<HR />
+</DIV>

--- a/gen-apidocs/generators/api/config.go
+++ b/gen-apidocs/generators/api/config.go
@@ -60,9 +60,7 @@ func NewConfig() (*Config, error) {
 	IncludesDir = filepath.Join(BuildDir, "includes")
 	SectionsDir = filepath.Join(ConfigDir, "sections")
 
-	var versionChar = "v"
-
-	var k8sRelease = fmt.Sprintf("%s%s", versionChar, strings.ReplaceAll(*KubernetesRelease, ".", "_"))
+	var k8sRelease = fmt.Sprintf("v%s", strings.ReplaceAll(*KubernetesRelease, ".", "_"))
 	VersionedConfigDir = filepath.Join(ConfigDir, k8sRelease)
 
 	config, err := LoadConfigFromYAML()
@@ -78,7 +76,7 @@ func NewConfig() (*Config, error) {
 	ParseSpecInfo(specs, config)
 
 	// Set the spec version
-	config.SpecVersion = fmt.Sprintf("%s%s.%s", versionChar, *KubernetesRelease, "0")
+	config.SpecVersion = fmt.Sprintf("v%s.%s", *KubernetesRelease, "0")
 
 	// Initialize all of the operations
 	defs, err := NewDefinitions(config, specs)

--- a/gen-apidocs/generators/writer.go
+++ b/gen-apidocs/generators/writer.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package generators
 
 import (
@@ -81,6 +82,7 @@ func GenerateFiles() error {
 		if err := writer.WriteResourceCategory(c.Name, c.Include); err != nil {
 			return err
 		}
+
 		for _, r := range c.Resources {
 			if r.Definition == nil {
 				fmt.Printf("Warning: Missing definition for item in TOC %s\n", r.Name)
@@ -168,20 +170,20 @@ func getLink(s string) string {
 	return strings.ToLower(strings.ReplaceAll(tmp, " ", "-"))
 }
 
-func writeStaticFile(title, location, defaultContent string) error {
-	fn := filepath.Join(api.SectionsDir, location)
-	to := filepath.Join(api.IncludesDir, location)
-	_, err := os.Stat(fn)
-	if err == nil {
-		// copy the file if it exists
-		return os.Link(fn, to)
+func writeStaticFile(filename, defaultContent string) error {
+	src := filepath.Join(api.SectionsDir, filename)
+	dst := filepath.Join(api.IncludesDir, filename)
+
+	// copy the file if it exists
+	if _, err := os.Stat(src); err == nil {
+		content, err := os.ReadFile(src)
+		if err != nil {
+			return err
+		}
+		defaultContent = string(content)
 	}
 
-	if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to stat file %s: %w", fn, err)
-	}
+	fmt.Printf("Creating file %s\n", dst)
 
-	fmt.Printf("Creating file %s\n", to)
-
-	return os.WriteFile(to, []byte(defaultContent), 0644)
+	return os.WriteFile(dst, []byte(defaultContent), 0644)
 }


### PR DESCRIPTION
This is a follow-up to #333. In that PR, the navData.js generation was refactored, but I was unsure if it still functioned properly. While investigating I found that there is really no need to keep generating a standalone file, if we simply put the necessary data into the DOM from the beginning.

So that's what this PR does. It extends the generated markup a bit, by introducing `<div class="toc-item" id="...">...</div>` wrappers around each concept/section and by re-organizing the DOM for the navigation tree entirely. That way the scroll-apiref.js can deduce everything it needs from the site already.

Sadly the script lives in another castle, so to show the result of this PR, I uploaded it to https://kube-api.ninja/refdocs-pr/ (using copies of the assets hosted on kubernetes.io).

https://github.com/kubernetes/website/pull/43076 is the sister PR to this one, containing the rewritten `scroll-apiref.js`.