### PR TITLE
[gen-apidocs] Fix HTML lint errors

### DIFF
--- a/gen-apidocs/config/sections/_oldversions.html
+++ b/gen-apidocs/config/sections/_oldversions.html
@@ -1,5 +1,5 @@
 <DIV id="old-api-versions">
-<H1 class="toc-item section" id="">Old API Versions</H1>
+<H1 class="toc-item section">Old API Versions</H1>
 
 <P>This section contains older versions of resources shown above.</P>
 </DIV>

--- a/gen-apidocs/config/sections/_overview.html
+++ b/gen-apidocs/config/sections/_overview.html
@@ -45,7 +45,7 @@ To update the status, one must invoke the specific status update operation.<BR /
 
 Note: Replacing a resource object may not result immediately in changes being propagated to downstream objects. For instance
 replacing a <CODE>ConfigMap</CODE> or <CODE>Secret</CODE> resource will not result in all <EM>Pod</EM>s seeing the changes unless the <EM>Pod</EM>s are
-restarted out of band.</P></LI>
+restarted out of band.</LI>
 
 <LI><STRONG>Patch</STRONG>:
 Patch will apply a change to a specific field. How the change is merged is defined per field. Lists may either be
@@ -68,7 +68,7 @@ the field's current value, or merge the contents into the current value.</EM></L
 <LI><STRONG>Watch</STRONG>: Watch will stream results for an object(s) as it is updated. Similar to a callback, watch is used to respond to resource changes.</LI>
 </UL>
 
-<H4 id="resource-operations-read">Delete</H4>
+<H4 id="resource-operations-delete">Delete</H4>
 
 <P>Delete will delete a resource. Depending on the specific resource, child objects may or may not be garbage collected by the server. See
 notes on specific resource objects for details.</P>

--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -549,8 +549,7 @@ func (h *HTMLWriter) WriteOldVersionsOverview() error {
 }
 
 func (h *HTMLWriter) generateNavContent() string {
-	nav := ""
-	nav += "\n\n<UL id=\"navigation\">\n"
+	nav := "<UL id=\"navigation\">\n"
 
 	for _, sec := range h.TOC.Sections {
 		nav += sec.ToHTML()

--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -574,7 +574,7 @@ func (h *HTMLWriter) generateIndex(navContent string) error {
 	   kubernetes/website/static/css/fontawesome-4.7.0.min.css
 	   kubernetes/website/static/css/style_apiref.css
 	*/
-	fmt.Fprintf(html, "<!DOCTYPE html>\n<HTML>\n<HEAD>\n<META charset=\"UTF-8\">\n")
+	fmt.Fprintf(html, "<!DOCTYPE html>\n<HTML lang=\"en\">\n<HEAD>\n<META charset=\"UTF-8\">\n")
 	fmt.Fprintf(html, "<TITLE>%s</TITLE>\n", h.TOC.Title)
 	fmt.Fprintf(html, "<LINK rel=\"shortcut icon\" href=\"favicon.ico\" type=\"image/vnd.microsoft.icon\">\n")
 	fmt.Fprintf(html, "<LINK rel=\"stylesheet\" href=\"/css/bootstrap-4.3.1.min.css\" type=\"text/css\">\n")


### PR DESCRIPTION
I ran the generated API docs through https://validator.w3.org/nu/ and besides it complaining about `<BR />` (something I would personally change into `<BR>` in this repo, but it's just an info note and so I do not want to cause too much of a diff here), it also mentioned a few other, real issues that this PR fixes.