### PR TITLE
Fix package level template for config API reference

### DIFF
--- a/genref/config.yaml
+++ b/genref/config.yaml
@@ -114,6 +114,7 @@ apis:
   - name: kube-controller-manager-config
     title: kube-controller-manager Configuration (v1alpha1)
     package: k8s.io/kube-controller-manager
+    mainPackage: kubecontrollermanager.config.k8s.io
     path: config/v1alpha1
     includes:
       - k8s.io/cloud-provider/controllers/service/config/v1alpha1
@@ -226,6 +227,7 @@ apis:
   - name: cloud-provider-config
     title: Cloud Provider Configuration (v1alpha1)
     package: k8s.io/cloud-provider
+    mainPackage: cloudcontrollermanager.config.k8s.io
     path: config/v1alpha1
     includes:
       - k8s.io/controller-manager/config/v1alpha1

--- a/genref/markdown/pkg.tpl
+++ b/genref/markdown/pkg.tpl
@@ -1,6 +1,5 @@
 {{ define "packages" -}}
 
-{{ $grpname := "" -}}
 {{- range $idx, $val := .packages -}}
 {{/* Special handling for kubeconfig */}}
 {{- if eq .Title "kubeconfig (v1)" -}}
@@ -11,7 +10,7 @@ package: v1
 auto_generated: true
 ---
 {{- else -}}
-  {{- if and (ne .GroupName "") (eq $grpname "") -}}
+  {{- if and .IsMain (ne .GroupName "") -}}
 ---
 title: {{ .Title }}
 content_type: tool-reference
@@ -19,7 +18,6 @@ package: {{ .DisplayName }}
 auto_generated: true
 ---
 {{ .GetComment -}}
-{{ $grpname = .GroupName }}
   {{- end -}}
 {{- end -}}
 {{- end }}
@@ -27,28 +25,26 @@ auto_generated: true
 ## Resource Types 
 
 {{ range .packages -}}
-  {{/*- if ne .GroupName "" -*/}}
-    {{- range .VisibleTypes -}}
-      {{- if .IsExported }}
+  {{- range .VisibleTypes -}}
+    {{- if .IsExported }}
 - [{{ .DisplayName }}]({{ .Link }})
-      {{- end -}}
     {{- end -}}
-  {{/* end -*/}}
+  {{- end -}}
 {{- end -}}
 
 {{ range .packages }}
   {{ if ne .GroupName "" -}}
-     
     {{/* For package with a group name, list all type definitions in it. */}}
-    {{ range .VisibleTypes }}
+    {{- range .VisibleTypes }}
       {{- if or .Referenced .IsExported -}}
 {{ template "type" . }}
       {{- end -}}
     {{ end }}
   {{ else }}
     {{/* For package w/o group name, list only types referenced. */}}
+    {{ $pkgTitle := .Title }}
     {{- range .VisibleTypes -}}
-      {{- if .Referenced -}}
+      {{- if or .Referenced (eq $pkgTitle "kubeconfig (v1)") -}}
 {{ template "type" . }}
       {{- end -}}
     {{- end }}

--- a/genref/output/md/kubeconfig.v1.md
+++ b/genref/output/md/kubeconfig.v1.md
@@ -11,6 +11,83 @@ auto_generated: true
 - [Config](#Config)
   
     
+    
+
+## `Config`     {#Config}
+    
+
+
+<p>Config holds the information needed to build connect to remote kubernetes clusters as a given user</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>Config</code></td></tr>
+    
+  
+<tr><td><code>kind</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Legacy field from pkg/api/types.go TypeMeta.
+TODO(jlowdermilk): remove this after eliminating downstream dependencies.</p>
+</td>
+</tr>
+<tr><td><code>apiVersion</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>Legacy field from pkg/api/types.go TypeMeta.
+TODO(jlowdermilk): remove this after eliminating downstream dependencies.</p>
+</td>
+</tr>
+<tr><td><code>preferences</code> <B>[Required]</B><br/>
+<a href="#Preferences"><code>Preferences</code></a>
+</td>
+<td>
+   <p>Preferences holds general information to be use for cli interactions</p>
+</td>
+</tr>
+<tr><td><code>clusters</code> <B>[Required]</B><br/>
+<a href="#NamedCluster"><code>[]NamedCluster</code></a>
+</td>
+<td>
+   <p>Clusters is a map of referencable names to cluster configs</p>
+</td>
+</tr>
+<tr><td><code>users</code> <B>[Required]</B><br/>
+<a href="#NamedAuthInfo"><code>[]NamedAuthInfo</code></a>
+</td>
+<td>
+   <p>AuthInfos is a map of referencable names to user configs</p>
+</td>
+</tr>
+<tr><td><code>contexts</code> <B>[Required]</B><br/>
+<a href="#NamedContext"><code>[]NamedContext</code></a>
+</td>
+<td>
+   <p>Contexts is a map of referencable names to context configs</p>
+</td>
+</tr>
+<tr><td><code>current-context</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>CurrentContext is the name of the context that you would like to use by default</p>
+</td>
+</tr>
+<tr><td><code>extensions</code><br/>
+<a href="#NamedExtension"><code>[]NamedExtension</code></a>
+</td>
+<td>
+   <p>Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields</p>
+</td>
+</tr>
+</tbody>
+</table>
 
 ## `AuthInfo`     {#AuthInfo}
     

--- a/genref/types.go
+++ b/genref/types.go
@@ -33,6 +33,9 @@ type apiPackage struct {
 
 	// Title is set from config
 	Title string
+
+	// IsMain is set if the package is the main one
+	IsMain bool
 }
 
 // DisplayName returns the full name of the API package


### PR DESCRIPTION
This PR fixes a few things:

- The names of the (possibly more than one) package is sorted, so that the generated output is deterministic.
- An improvement to manually specify the main package when more than one API group/versions are found.
- Fixed an error related to the processing of kubeconfig reference.
