### PR TITLE
fix: sort types

### DIFF
--- a/genref/types.go
+++ b/genref/types.go
@@ -403,7 +403,10 @@ func sortTypes(typs []*apiType) []*apiType {
 		} else if !t1.IsExported() && t2.IsExported() {
 			return false
 		}
-		return t1.Name.Name < t2.Name.Name
+		if t1.Name.Name != t2.Name.Name {
+			return t1.Name.Name < t2.Name.Name
+		}
+		return t1.Name.String() < t2.Name.String()
 	})
 	return typs
 }


### PR DESCRIPTION
This PR fixes `sortTypes` func by considering the package when sorting, in case both types have the same name.

Let's say a type `Foo` exists in `v1` and `v2`.
If we consider only the name (`Foo`) we can't decide on the order, it will be random from one run to the other.
In this case, we can additionally consider the package, it becomes obvious that `v1` should come before `v2` and the order is now predictible.

Fixes #350