### PR TITLE
Add pod/exec and pod/attach to api reference

### DIFF
--- a/gen-apidocs/config/v1_29/config.yaml
+++ b/gen-apidocs/config/v1_29/config.yaml
@@ -310,6 +310,14 @@ operation_categories:
       match: create${group}${version}(Namespaced)?${resource}Rollback
     - name: Read Log
       match: read${group}${version}(Namespaced)?${resource}Log
+    - name: Get Connect Exec
+      match: connect${group}${version}Get(Namespaced)?${resource}Exec
+    - name: Create Connect Exec
+      match: connect${group}${version}Post(Namespaced)?${resource}Exec
+    - name: Get Connect Attach
+      match: connect${group}${version}Get(Namespaced)?${resource}Attach
+    - name: Create Connect Attach
+      match: connect${group}${version}Post(Namespaced)?${resource}Attach
 
 # List of *partial* operation IDs for matching. All matched operations are
 # excluded from the reference doc.
@@ -319,8 +327,6 @@ excluded_operations:
   - getCodeVersion
   - logFileHandler
   - logFileListHandler
-  - NamespacedPodAttach
-  - NamespacedPodExec
   - replaceCoreV1NamespaceFinalize
   - V1beta1CertificateSigningRequestApproval
   - V1CertificateSigningRequestApproval


### PR DESCRIPTION
Add exec and attach operations to the generated API reference documentation.