### PR TITLE
Add SIG Docs co-chairs to reference-docs owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,9 +6,12 @@ reviewers:
 # auto-merge happen if a /lgtm exists, or vice versa, or they can do both
 # No need for approvers to also be listed as reviewers
 approvers:
+- divya-mohan0209
 - feloy
 - jimangel
 - kbhawkey
+- natalisucks
 - onlydole
+- reylejano
 - sftim
 - tengqm


### PR DESCRIPTION
This PR adds SIG Docs co-chairs to reference-docs owners file