### PR TITLE
Exclude excludedOperations in misc operations

### DIFF
--- a/gen-apidocs/generators/api/config.go
+++ b/gen-apidocs/generators/api/config.go
@@ -260,7 +260,7 @@ func (c *Config) initOperations(specs []*loads.Document) error {
 
 	VisitOperations(specs, func(target Operation) {
 		if op, ok := c.Operations[target.ID]; !ok || op.Definition == nil {
-			if !c.opExcluded(op.ID) {
+			if !c.OpExcluded(op.ID) {
 				fmt.Printf("\033[31mNo Definition found for %s [%s].\033[0m\n", op.ID, op.Path)
 			} else {
                 fmt.Printf("Op excluded: %s\n", op.ID)
@@ -285,7 +285,7 @@ func (c *Config) initOperations(specs []*loads.Document) error {
 	return nil
 }
 
-func (c *Config) opExcluded(op string) bool {
+func (c *Config) OpExcluded(op string) bool {
 	for _, pattern := range c.ExcludedOperations {
 		if strings.Contains(op, pattern) {
 			return true

--- a/gen-apidocs/generators/writer.go
+++ b/gen-apidocs/generators/writer.go
@@ -99,7 +99,7 @@ func GenerateFiles() error {
     // Write orphaned operation endpoints
     orphanedIDs :=  make([]string, 0)
     for id, o := range config.Operations {
-        if o.Definition == nil {
+        if o.Definition == nil && !config.OpExcluded(o.ID) {
             orphanedIDs = append(orphanedIDs, id)
         }
     }


### PR DESCRIPTION
See [comment](https://github.com/kubernetes-sigs/reference-docs/pull/364#issuecomment-2266301250).

Excluded operations were incorrectly being added to the misc operations section. This fixes that bug.