### PR TITLE
Look through AdditionalProperties for references

### DIFF
--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -146,6 +146,16 @@ func (s *Definitions) getReferences(d *Definition) []*Definition {
 	refs := []*Definition{}
 	// Find all of the resources referenced by this definition
 	for _, p := range d.schema.Properties {
+		if p.AdditionalProperties != nil && p.AdditionalProperties.Schema != nil {
+			additionalProperty := p.AdditionalProperties.Schema.Ref
+			if len(additionalProperty.String()) > 0 {
+				group, version, kind := GetDefinitionVersionKindFromString(additionalProperty.String())
+				definition, ok := s.GetByVersionKind(group, version, kind)
+				if ok {
+					refs = append(refs, definition)
+				}
+			}
+		}
 		if !IsComplex(p) {
 			// Skip primitive types and collections of primitive types
 			continue

--- a/gen-apidocs/generators/api/util.go
+++ b/gen-apidocs/generators/api/util.go
@@ -28,41 +28,45 @@ func GetDefinitionVersionKind(s spec.Schema) (string, string, string) {
 	// Get the reference for complex types
 	if IsDefinition(s) {
 		s := s.SchemaProps.Ref.GetPointer().String()
-		s = strings.ReplaceAll(s, "/definitions/", "")
-		name := strings.Split(s, ".")
-
-		var group, version, kind string
-		if name[len(name)-3] == "api" {
-			// e.g. "io.k8s.apimachinery.pkg.api.resource.Quantity"
-			group = "core"
-			version = name[len(name)-2]
-			kind = name[len(name)-1]
-		} else if name[len(name)-4] == "api" {
-			// e.g. "io.k8s.api.core.v1.Pod"
-			group = name[len(name)-3]
-			version = name[len(name)-2]
-			kind = name[len(name)-1]
-		} else if name[len(name)-4] == "apis" {
-			// e.g. "io.k8s.apimachinery.pkg.apis.meta.v1.Status"
-			group = name[len(name)-3]
-			version = name[len(name)-2]
-			kind = name[len(name)-1]
-		} else if name[len(name)-3] == "util" || name[len(name)-3] == "pkg" {
-			// This is for:
-			// - io.k8s.apimachinery.pkg.util.intstr.IntOrString
-			// - io.k8s.apimachinery.pkg.version.Info
-			// - io.k8s.apimachinery.pkg.runtime.RawExtension
-			return "", "", ""
-		} else {
-			panic(fmt.Sprintf("Could not locate group for %s", name))
-		}
-		return group, version, kind
+		return GetDefinitionVersionKindFromString(s)
 	}
 	// Recurse if type is array
 	if IsArray(s) {
 		return GetDefinitionVersionKind(*s.Items.Schema)
 	}
 	return "", "", ""
+}
+
+func GetDefinitionVersionKindFromString(s string) (string, string, string) {
+	s = strings.ReplaceAll(s, "/definitions/", "")
+	name := strings.Split(s, ".")
+
+	var group, version, kind string
+	if name[len(name)-3] == "api" {
+		// e.g. "io.k8s.apimachinery.pkg.api.resource.Quantity"
+		group = "core"
+		version = name[len(name)-2]
+		kind = name[len(name)-1]
+	} else if name[len(name)-4] == "api" {
+		// e.g. "io.k8s.api.core.v1.Pod"
+		group = name[len(name)-3]
+		version = name[len(name)-2]
+		kind = name[len(name)-1]
+	} else if name[len(name)-4] == "apis" {
+		// e.g. "io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+		group = name[len(name)-3]
+		version = name[len(name)-2]
+		kind = name[len(name)-1]
+	} else if name[len(name)-3] == "util" || name[len(name)-3] == "pkg" {
+		// This is for:
+		// - io.k8s.apimachinery.pkg.util.intstr.IntOrString
+		// - io.k8s.apimachinery.pkg.version.Info
+		// - io.k8s.apimachinery.pkg.runtime.RawExtension
+		return "", "", ""
+	} else {
+		panic(fmt.Sprintf("Could not locate group for %s", name))
+	}
+	return group, version, kind
 }
 
 // GetTypeName returns the display name of a Schema.  This is the api kind for definitions and the type for


### PR DESCRIPTION
Running `make api` ends up with the following error:

```
----------------------------------
Orphaned Definitions:
[resource.v1alpha3.DeviceAttribute]
panic: Orphaned definitions found.

goroutine 1 [running]:
github.com/kubernetes-sigs/reference-docs/gen-apidocs/generators.PrintInfo(0x1400029fc38?)
        /Users/davanum/go/src/sigs.k8s.io/reference-docs/gen-apidocs/generators/util.go:47 +0x4d8
github.com/kubernetes-sigs/reference-docs/gen-apidocs/generators.GenerateFiles()
        /Users/davanum/go/src/sigs.k8s.io/reference-docs/gen-apidocs/generators/writer.go:56 +0x70
main.main()
        /Users/davanum/go/src/sigs.k8s.io/reference-docs/gen-apidocs/main.go:28 +0x64
exit status 2
make: *** [api] Error 1
```

If you look at the definition:
https://github.com/kubernetes/kubernetes/blob/8db6fc7e3fabc00f12be17d5a1623cba278d4b6b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json#L115-L140

The `resource.v1alpha3.DeviceAttribute` is actually referenced by `resource.v1alpha3.BasicDevice`, so we need to traverse the `additionalProperties` array and ensure that we mark the g/v/k as being used.