### PR TITLE
Add script to update api docs to latest released tags

### DIFF
--- a/hack/update-api-docs.sh
+++ b/hack/update-api-docs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "$K8S_WEBROOT" ]; then
+  echo "Error: missing $K8S_WEBROOT directory. Exiting..."
+  exit 1
+fi
+
+if [ ! -d "gen-apidocs" ]; then
+  echo "Error: gen-apidocs directory not found. Exiting..."
+  exit 1
+else
+  cd "gen-apidocs"
+fi
+
+CONFIG_DIR="config"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/kubernetes/kubernetes"
+
+if ! mapfile -t latest_versions < <(curl -s "https://api.github.com/repos/kubernetes/kubernetes/tags?per_page=100" |
+  jq -r '.[].name' | grep -v -e alpha -e beta -e rc |
+  sort -V |
+  awk -F. '!seen[$1"."$2]++ {print $0}'); then
+  echo "Error: Failed to fetch or process tags. Exiting..."
+  exit 1
+fi
+
+for version in "${latest_versions[@]}"; do
+  directory_version=${version}
+  directory_version=${directory_version%.*}
+  directory_version=${directory_version//./_}
+  if [ -d "$CONFIG_DIR/$directory_version" ]; then
+    echo "Processing tag $version in directory $directory_version"
+    if ! curl -s --output "$CONFIG_DIR/$directory_version/swagger.json" "$GITHUB_RAW_URL/$version/api/openapi-spec/swagger.json"; then
+      echo "Error: Failed to download swagger.json for $version"
+      continue
+    fi
+    if ! go run main.go --kubernetes-release="$(echo $version | sed 's/^v//' | cut -d'.' -f1-2)" --work-dir=.; then
+      echo "Error: Failed to run main.go for $version"
+      continue
+    fi
+    cp ./build/index.html "$K8S_WEBROOT/static/docs/reference/generated/kubernetes-api/${version%.*}"
+  else
+    echo "$directory_version NOT FOUND"
+  fi
+done


### PR DESCRIPTION
Here's a script that fetches the latest released tags across the stable releases, updates the swagger json and generates new index.html files for all the new versions.

The idea is to to run this script from prow or github automation and then generate PR(s) to both this repository and the kubernetes/website repository automatically as a follow up.

kubernetes/website should be checked out and the environment variable K8S_WEBROOT must be set correctly before running the script. We use github API to fetch latest tags and directly pull swagger.json from github as well for specific tags.