### PR TITLE
mark ResourceClaim as v1beta1 in K8s 1.32 ref docs

### DIFF
--- a/gen-apidocs/config/v1_32/config.yaml
+++ b/gen-apidocs/config/v1_32/config.yaml
@@ -153,7 +153,7 @@ resource_categories:
       version: v1
       group: scheduling
     - name: ResourceClaim
-      version: v1alpha3
+      version: v1beta1
       group: resource
     - name: ResourceClaimTemplate
       version: v1beta1


### PR DESCRIPTION
Kubernetes 1.32 has promoted ResourceClaims to v1beta1. ResourceClaimTemplates, listed right below it, are already correctly marked for v1beta1.