### PR TITLE
Improve Config API reference generator for resource types

### DIFF
--- a/genref/config.yaml
+++ b/genref/config.yaml
@@ -74,6 +74,8 @@ apis:
     title: Kubelet Stats (v1alpha1)
     package: k8s.io/kubelet
     path: pkg/apis/stats/v1alpha1
+    resources:
+      - Summary
     # skip: true
 
   - name: kubelet-credentialprovider

--- a/genref/output/md/kubelet-stats.v1alpha1.md
+++ b/genref/output/md/kubelet-stats.v1alpha1.md
@@ -3,6 +3,7 @@
 ## Resource Types 
 
 
+- [Summary](#Summary)
   
     
     
@@ -457,6 +458,7 @@ hugepages).</p>
 
 **Appears in:**
 
+- [Summary](#Summary)
 
 
 <p>NodeStats holds node-level unprocessed sample stats.</p>
@@ -615,6 +617,7 @@ NodeFs.Used is the total bytes used on the filesystem.</p>
 
 **Appears in:**
 
+- [Summary](#Summary)
 
 
 <p>PodStats holds pod-level unprocessed sample stats.</p>

--- a/genref/types.go
+++ b/genref/types.go
@@ -36,6 +36,9 @@ type apiPackage struct {
 
 	// IsMain is set if the package is the main one
 	IsMain bool
+
+	// Resources is the customized resource type names
+	Resources []string
 }
 
 // DisplayName returns the full name of the API package
@@ -190,11 +193,18 @@ func (t *apiType) IsExported() bool {
 	if strings.Contains(comments, "+genclient") {
 		return true
 	}
-
 	if strings.Contains(comments, "+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object") {
 		return true
 	}
 
+	t1 := t.deref()
+
+	p := typePkgMap[t1.String()]
+	for _, res := range p.Resources {
+		if res == t.Name.Name {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
The `types.go` file for some APIs may not have the anticipated `// +k8s:deepcopy-gen:...` line for any types. We have to allow the generator to identify the "exposed" resource types. For example, the `Summary` type from the kubernetes stats API does not have this comment line.