### PR TITLE
Fix: Remove duplicated short command descriptions in generated kubeadm CLI docs.

### DIFF
--- a/gen-compdocs/generators/doc.go
+++ b/gen-compdocs/generators/doc.go
@@ -155,9 +155,13 @@ func GenReference(cmd *cobra.Command, w io.Writer, linkHandler func(string) stri
 		// Print the "generated" warning
 		fmt.Fprintf(w, "%s\n\n", generated_warning)
 
-		if _, err := fmt.Fprintf(w, "%s\n\n", short); err != nil {
-			return err
-		}
+		trimmedShort := strings.TrimSpace(strings.TrimSuffix(short, "."))
+        trimmedLong := strings.TrimSpace(strings.TrimSuffix(long, "."))
+		if !strings.HasPrefix(trimmedLong, trimmedShort) {
+	        if _, err := fmt.Fprintf(w, "%s\n\n", short); err != nil {
+		        return err
+	        }
+        }
 
 		if _, err := fmt.Fprintf(w, "### Synopsis\n\n"); err != nil {
 			return err


### PR DESCRIPTION
This PR is for to remove duplicated command descriptions above the Synopsis section for both phase - `kubeadm upgrade apply phase` and `kubeadm upgrade node phase` in the kubeadm upgrade documentation. It solves the same issue for few others kubeadm docs also.

Main Page: https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-upgrade-phase/

Closes: kubernetes/website#51172