### PR TITLE
Fix `navData.js` not generated in `make copyapi` command

### DIFF
--- a/gen-apidocs/generators/html.go
+++ b/gen-apidocs/generators/html.go
@@ -17,6 +17,7 @@ limitations under the License.
 package generators
 
 import (
+	"encoding/json"
 	"fmt"
 	"html"
 	"io"
@@ -633,6 +634,21 @@ func (h *HTMLWriter) generateNavContent() string {
 	return nav
 }
 
+func (h *HTMLWriter) generateNavDataJS() error {
+	navDataPath := filepath.Join(api.BuildDir, "navData.js")
+	f, err := os.Create(navDataPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	navData, err := json.MarshalIndent(h.TOC.Sections, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(f, "window.navData = %s;\n", string(navData))
+	return err
+}
+
 func (h *HTMLWriter) generateIndex(navContent string) error {
 	html, err := os.Create(filepath.Join(api.BuildDir, "index.html"))
 	if err != nil {
@@ -734,6 +750,10 @@ func (h *HTMLWriter) Finalize() error {
 	navContent := h.generateNavContent()
 
 	if err := h.generateIndex(navContent); err != nil {
+		return err
+	}
+
+	if err := h.generateNavDataJS(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR fixes the issue : `navData.js` was not being generated when running `make copyapi` command.
Fixes #403 
<img width="1897" height="863" alt="navdatafix" src="https://github.com/user-attachments/assets/f9550e1c-a890-44a0-8a5f-9e498297c406" />

`navData.js` file is created along side `index.html`
<img width="1901" height="251" alt="navdatafix2" src="https://github.com/user-attachments/assets/1583f19d-b3f7-4217-add5-5b6c8b419f2a" />
