### PR TITLE
Make `k8s.io/kubernetes` repo source path detection flexible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ install:
 - mkdir -p ${BUILD_PATH}/src/k8s.io
 - wget https://github.com/kubernetes/kubernetes/archive/v${K8S_RELEASE}.tar.gz -O ${BUILD_PATH}/src/k8s.io/kubernetes-src.tar.gz
 - pushd ${BUILD_PATH}/src/k8s.io && tar xzf kubernetes-src.tar.gz && mv kubernetes-${K8S_RELEASE} kubernetes && popd
+- # Export K8S_ROOT for API docs generation (updateapispec target)
+- export K8S_ROOT=${BUILD_PATH}/src/k8s.io/kubernetes
 - pushd ${BUILD_PATH}/src/k8s.io/kubernetes && make generated_files && popd
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ install:
 - mkdir -p ${BUILD_PATH}/src/k8s.io
 - wget https://github.com/kubernetes/kubernetes/archive/v${K8S_RELEASE}.tar.gz -O ${BUILD_PATH}/src/k8s.io/kubernetes-src.tar.gz
 - pushd ${BUILD_PATH}/src/k8s.io && tar xzf kubernetes-src.tar.gz && mv kubernetes-${K8S_RELEASE} kubernetes && popd
-- # Export K8S_ROOT for API docs generation (updateapispec target)
-- export K8S_ROOT=${BUILD_PATH}/src/k8s.io/kubernetes
 - pushd ${BUILD_PATH}/src/k8s.io/kubernetes && make generated_files && popd
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -4,35 +4,32 @@
 # to match your environment and release version
 #
 # K8S_WEBROOT=~/src/github.com/kubernetes/website
-# K8S_ROOT=~/k8s/src/k8s.io/kubernetes (or let Makefile auto-detect)
+# K8S_ROOT=~/path/to/your/kubernetes/clone (REQUIRED)
 # K8S_RELEASE=1.17.0, 1.17.5, 1.17.0-rc.2
-# Auto-detection: If K8S_ROOT is not set, the Makefile will search for Kubernetes source
-# in common locations: ../kubernetes, ../../kubernetes, ../../../k8s.io/kubernetes, etc.
+#
+# PREFERRED directory structure (follows Go workspace conventions):
+#   <work dir>/k8s.io/kubernetes     <- Set K8S_ROOT to this path
+#   <work dir>/k8s.io/website
+#   <work dir>/k8s.io/reference-docs
+#
+# Examples:
+#   export K8S_ROOT=~/go/src/k8s.io/kubernetes
+#   export K8S_ROOT=~/workspace/k8s.io/kubernetes
+#   export K8S_ROOT=~/dev/kubernetes  # any valid path works
 
 
 WEBROOT=${K8S_WEBROOT}
-# Auto-detect Kubernetes source path if K8S_ROOT is not set
-ifndef K8S_ROOT
-  K8SROOT := $(shell \
-    if [ -d "../kubernetes" ] && [ -f "../kubernetes/go.mod" ]; then \
-      echo "$$(cd ../kubernetes && pwd)"; \
-    elif [ -d "../../kubernetes" ] && [ -f "../../kubernetes/go.mod" ]; then \
-      echo "$$(cd ../../kubernetes && pwd)"; \
-    elif [ -d "../../../k8s.io/kubernetes" ] && [ -f "../../../k8s.io/kubernetes/go.mod" ]; then \
-      echo "$$(cd ../../../k8s.io/kubernetes && pwd)"; \
-    elif [ -d "../../../../k8s.io/kubernetes" ] && [ -f "../../../../k8s.io/kubernetes/go.mod" ]; then \
-      echo "$$(cd ../../../../k8s.io/kubernetes && pwd)"; \
-    else \
-      echo ""; \
-    fi)
-  
-  ifeq ($(K8SROOT),)
-    $(error Could not auto-detect Kubernetes source. Please set K8S_ROOT environment variable or ensure kubernetes source is in a common location (../kubernetes, ../../kubernetes, ../../../k8s.io/kubernetes, or ../../../../k8s.io/kubernetes))
-  endif
-  
-  $(info Auto-detected Kubernetes source at: $(K8SROOT))
-else
-  K8SROOT=${K8S_ROOT}
+
+# Validate K8S_ROOT is set and points to valid Kubernetes source
+ifeq ($(K8S_ROOT),)
+  $(error K8S_ROOT environment variable is not set. Please set it to your Kubernetes clone path. Example: export K8S_ROOT=~/k8s.io/kubernetes)
+endif
+
+K8SROOT=${K8S_ROOT}
+
+# Verify K8S_ROOT points to a valid Kubernetes repository
+ifeq ($(wildcard $(K8SROOT)/go.mod),)
+  $(error K8S_ROOT ($(K8SROOT)) does not appear to contain a valid Kubernetes repository. Please ensure it points to a Kubernetes source directory with go.mod file)
 endif
 K8SRELEASE=${K8S_RELEASE}
 

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,36 @@
 # to match your environment and release version
 #
 # K8S_WEBROOT=~/src/github.com/kubernetes/website
-# K8S_ROOT=~/k8s/src/k8s.io/kubernetes
+# K8S_ROOT=~/k8s/src/k8s.io/kubernetes (or let Makefile auto-detect)
 # K8S_RELEASE=1.17.0, 1.17.5, 1.17.0-rc.2
-#
+# Auto-detection: If K8S_ROOT is not set, the Makefile will search for Kubernetes source
+# in common locations: ../kubernetes, ../../kubernetes, ../../../k8s.io/kubernetes, etc.
+
 
 WEBROOT=${K8S_WEBROOT}
-K8SROOT=${K8S_ROOT}
+# Auto-detect Kubernetes source path if K8S_ROOT is not set
+ifndef K8S_ROOT
+  K8SROOT := $(shell \
+    if [ -d "../kubernetes" ] && [ -f "../kubernetes/go.mod" ]; then \
+      echo "$$(cd ../kubernetes && pwd)"; \
+    elif [ -d "../../kubernetes" ] && [ -f "../../kubernetes/go.mod" ]; then \
+      echo "$$(cd ../../kubernetes && pwd)"; \
+    elif [ -d "../../../k8s.io/kubernetes" ] && [ -f "../../../k8s.io/kubernetes/go.mod" ]; then \
+      echo "$$(cd ../../../k8s.io/kubernetes && pwd)"; \
+    elif [ -d "../../../../k8s.io/kubernetes" ] && [ -f "../../../../k8s.io/kubernetes/go.mod" ]; then \
+      echo "$$(cd ../../../../k8s.io/kubernetes && pwd)"; \
+    else \
+      echo ""; \
+    fi)
+  
+  ifeq ($(K8SROOT),)
+    $(error Could not auto-detect Kubernetes source. Please set K8S_ROOT environment variable or ensure kubernetes source is in a common location (../kubernetes, ../../kubernetes, ../../../k8s.io/kubernetes, or ../../../../k8s.io/kubernetes))
+  endif
+  
+  $(info Auto-detected Kubernetes source at: $(K8SROOT))
+else
+  K8SROOT=${K8S_ROOT}
+endif
 K8SRELEASE=${K8S_RELEASE}
 
 ifeq ($(K8SRELEASE),)


### PR DESCRIPTION
This PR removes the need of renaming the kubernetes/kubernetes repo to by:

Updating the Makefile to auto-detect the Kubernetes source in common locations:

```
../kubernetes

../../kubernetes

../../../k8s.io/kubernetes

../../../../k8s.io/kubernetes

```

Update `.travis.yml `to use a configurable `K8S_SRC_PATH` that gets passed to the Makefile as `K8S_ROOT.`
Keeping backward compatibility for setups where the repo is already cloned as `k8s.io/kubernetes.`

Now Contributors don’t need to rename their Kubernetes repo to` k8s.io/kubernetes.` The build and CI now work with common repo clone paths and also the existing workflows remain supported.