### PR TITLE
Add missing changes for component reference generator

### DIFF
--- a/gen-compdocs/generators/doc.go
+++ b/gen-compdocs/generators/doc.go
@@ -393,7 +393,7 @@ func flagUsages(f *pflag.FlagSet) string {
 
 		// process markdown in usage, force wrap for "\n"
 		if len(flag.Deprecated) > 0 {
-			usage = usage + "\n[**DEPRECATED**] " + flag.Deprecated
+			usage = usage + " (DEPRECATED: " + flag.Deprecated + ")"
 		}
 		line += processUsage(usage) + "</td>\n</tr>\n"
 


### PR DESCRIPTION
This PR updates the component reference generator to make sure the description about deprecated flags matches the old text closely.
