### PR TITLE
Add recursive traversal for nested additionalProperties in schema

### DIFF
--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -262,7 +262,7 @@ func (s *Definitions) findReferencedDefinitions(schema *spec.Schema, visited map
 		}
 		key := d.Key()
 		if _, exists := seen[key]; !exists {
-			seen[key] = struct{}{}
+			seen[key] = true
 			out = append(out, d)
 		}
 	}


### PR DESCRIPTION
This PR 
Added `s.findReferencedDefinitions(schema *spec.Schema, visited map[string]bool)` which recursively walks a schema node:

- checks schema.Ref and returns the Definition if resolvable via s.GetForSchema,
- descends into AdditionalProperties, Items (array), Properties, AllOf/OneOf/AnyOf,
- deduplicates result Definitions and guards against infinite recursion with a visited set.

Ref [comment ](https://github.com/kubernetes-sigs/reference-docs/pull/414#discussion_r2469559744)