### PR TITLE
gen-apidocs: default to auto-detect and trim v1.35 group mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ updateapispec: createversiondirs
 	cd $(K8SROOT) && git show "v$(K8SRELEASE):api/openapi-spec/swagger.json" > $(CURDIR)/$(APISRC)/config/v$(K8SRELEASEDIR)/swagger.json
 
 api: cleanapi
-	cd $(APISRC) && go run main.go --kubernetes-release=$(K8SRELEASE_PREFIX) --work-dir=.
+	cd $(APISRC) && go run main.go --kubernetes-release=$(K8SRELEASE_PREFIX) --work-dir=. --auto-detect
 
 cleanapi:
 	rm -rf $(shell pwd)/gen-apidocs/build

--- a/gen-apidocs/config/v1_35/config.yaml
+++ b/gen-apidocs/config/v1_35/config.yaml
@@ -1,31 +1,6 @@
 example_location: "examples"
-api_groups:
-  - "AdmissionRegistration"
-  - "ApiExtensions"
-  - "InternalApiserver"
-  - "ApiRegistration"
-  - "Apps"
-  - "AuditRegistration"
-  - "Authentication"
-  - "Authorization"
-  - "Autoscaling"
-  - "Batch"
-  - "Certificates"
-  - "Coordination"
-  - "Core"
-  - "Discovery"
-  - "Extensions"
-  - "FlowControl"
-  - "Meta"
-  - "Networking"
-  - "Node"
-  - "Policy"
-  - "Rbac"
-  - "Resource"
-  - "Scheduling"
-  - "Settings"
-  - "Storage"
-  - "StorageMigration"
+api_groups: []
+
 resource_categories:
   - name: "Workloads APIs"
     include: "workloads"
@@ -361,34 +336,11 @@ excluded_operations:
   - getServiceAccountIssuerOpenIDConfiguration
   - getServiceAccountIssuerOpenIDKeyset
 
-# Map from group name to its full name
+# Special/unconventional group name mappings only.
 group_full_names:
   admission: admission
-  admissionregistration: admissionregistration.k8s.io
-  apiextensions: apiextensions.k8s.io
-  apiregistration: apiregistration.k8s.io
-  apiserverinternal: internal.apiserver.k8s.io
-  apps: apps
-  authentication: authentication.k8s.io
-  authorization: authorization.k8s.io
-  autoscaling: autoscaling
-  batch: batch
-  certificates: certificates.k8s.io
-  coordination: coordination.k8s.io
-  core: core
-  discovery: discovery.k8s.io
-  events: events.k8s.io
   extensions: extensions
-  flowcontrol: flowcontrol.apiserver.k8s.io
   meta: meta
-  networking: networking.k8s.io
-  node: node.k8s.io
-  policy: policy
-  rbac: rbac.authorization.k8s.io
-  resource: resource.k8s.io
-  scheduling: scheduling.k8s.io
-  storage: storage.k8s.io
-  storagemigration: storagemigration.k8s.io
 
 # The map from the group as the resource sees it to the group as the operation
 # sees it.


### PR DESCRIPTION
Follow up PR reduces manual API config maintenance for v1_35 by relying on the already-merged --auto-detect behavior during API generation.

This is a follow-up PR for https://github.com/kubernetes-sigs/reference-docs/pull/431 to safely removes redundant manual entries for v1_35 and keeps only curated/special mappings.

## Validation
Ran API generation and compared output against auto-detect baseline.
index.html diff showed timestamp-only change (Generated at), no content drift.

This indicates the config cleanup is behaviorally safe for the auto-detect generation path.

<img width="748" height="234" alt="image" src="https://github.com/user-attachments/assets/56e300e0-d8e8-4ff3-9b66-5c8b309ca0ec" />

## Notes
- This PR intentionally does not change operation_group_map.
- Scope is limited to v1_35 config cleanup + Makefile default behavio
