### PR TITLE
feat(gen-apidocs): markdown field rendering — H2 sections, inline recursion, cross-refs, nav cleanups

### DIFF
--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -82,8 +82,15 @@ type resourcePage struct {
 	Weight      int
 	Anchor      string
 	Description string
-	Fields      []templateField
+	Sections    []fieldSection
 	Operations  []templateOperation
+}
+
+type fieldSection struct {
+	Title       string
+	Anchor      string
+	Description string
+	Fields      []templateField
 }
 
 type templateField struct {
@@ -124,8 +131,6 @@ type templateResponse struct {
 
 const hugoIndex = "_index.md"
 
-// Title constants are referenced from both the page emitters and
-// tocSortRank; keeping them named prevents the two from drifting.
 const (
 	titleOverview    = "Overview"
 	titleAPIGroups   = "API Groups"
@@ -136,7 +141,6 @@ const (
 
 var _ DocWriter = (*MarkdownWriter)(nil)
 
-//  external k/website links rely on the exact anchor format.
 var anchorRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 
 //go:embed templates/resource.tmpl
@@ -179,28 +183,21 @@ func (m *MarkdownWriter) DefaultStaticContent(title string) string {
 
 // Pipeline methods below follow the call order in writer.go's GenerateFiles().
 
+// No-op: kubernetes-api/_index.md in k/website is hand-curated.
 func (m *MarkdownWriter) WriteOverview() error {
-	if err := m.writeSection("_overview.md", "API Overview"); err != nil {
-		return fmt.Errorf("markdown: overview: %w", err)
-	}
-	m.toc = append(m.toc, &mdTOCItem{
-		title:  titleOverview,
-		path:   "_overview.md",
-		weight: m.nextCategoryWeight(),
-	})
 	return nil
 }
 
 func (m *MarkdownWriter) WriteAPIGroupVersions(gvs api.GroupVersions) error {
-	path := filepath.Join(m.OutputDir, "_group_versions.md")
+	path := filepath.Join(m.OutputDir, "group-versions.md")
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("markdown: group versions: %w", err)
 	}
 	defer f.Close()
 
-	fmt.Fprintln(f, "# API Groups")
-	fmt.Fprintln(f)
+	weight := m.nextCategoryWeight()
+	writeSectionFrontmatter(f, titleAPIGroups, "Kubernetes API groups and their served versions.", weight)
 	fmt.Fprintln(f, "The API Groups and their versions are summarized in the following table.")
 	fmt.Fprintln(f)
 
@@ -224,8 +221,8 @@ func (m *MarkdownWriter) WriteAPIGroupVersions(gvs api.GroupVersions) error {
 
 	m.toc = append(m.toc, &mdTOCItem{
 		title:  titleAPIGroups,
-		path:   "_group_versions.md",
-		weight: m.nextCategoryWeight(),
+		path:   "group-versions.md",
+		weight: weight,
 	})
 	return nil
 }
@@ -272,7 +269,7 @@ func (m *MarkdownWriter) WriteResource(r *api.Resource) error {
 		}
 	}
 
-	filename := fmt.Sprintf("%s-%s.md", strings.ToLower(r.Name), r.Definition.Version)
+	filename := fmt.Sprintf("%s-%s.md", kebabName(r.Name), r.Definition.Version)
 	path := filepath.Join(m.OutputDir, slug, filename)
 
 	f, err := os.Create(path)
@@ -288,23 +285,32 @@ func (m *MarkdownWriter) WriteResource(r *api.Resource) error {
 	return nil
 }
 
+// definitions/_index.md is required for Hugo to nest definition pages
+// under the section; without it children flatten up to the parent level.
 func (m *MarkdownWriter) WriteDefinitionsOverview() error {
-	if err := m.writeSection("_definitions.md", titleDefinitions); err != nil {
-		return fmt.Errorf("markdown: definitions overview: %w", err)
-	}
-	if err := os.MkdirAll(filepath.Join(m.OutputDir, "definitions"), 0755); err != nil {
+	dir := filepath.Join(m.OutputDir, "definitions")
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("markdown: definitions dir: %w", err)
 	}
+	indexPath := filepath.Join(dir, hugoIndex)
+	f, err := os.Create(indexPath)
+	if err != nil {
+		return fmt.Errorf("markdown: definitions _index.md: %w", err)
+	}
+	defer f.Close()
+	weight := m.nextCategoryWeight()
+	writeSectionFrontmatter(f, titleDefinitions, "", weight)
+
 	m.toc = append(m.toc, &mdTOCItem{
 		title:  titleDefinitions,
-		path:   "_definitions.md",
-		weight: m.nextCategoryWeight(),
+		path:   filepath.Join("definitions", hugoIndex),
+		weight: weight,
 	})
 	return nil
 }
 
 func (m *MarkdownWriter) WriteDefinition(d *api.Definition) error {
-	filename := strings.ToLower(d.Name) + "-" + string(d.Version)
+	filename := kebabName(d.Name) + "-" + string(d.Version)
 	if d.Group != "" && d.Group != "core" {
 		filename += "-" + string(d.Group)
 	}
@@ -324,23 +330,27 @@ func (m *MarkdownWriter) WriteDefinition(d *api.Definition) error {
 }
 
 func (m *MarkdownWriter) WriteOrphanedOperationsOverview() error {
-	if err := m.writeSection("_operations.md", titleOperations); err != nil {
-		return fmt.Errorf("markdown: operations overview: %w", err)
-	}
-	if err := os.MkdirAll(filepath.Join(m.OutputDir, "operations"), 0755); err != nil {
+	dir := filepath.Join(m.OutputDir, "operations")
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("markdown: operations dir: %w", err)
 	}
+	indexPath := filepath.Join(dir, hugoIndex)
+	f, err := os.Create(indexPath)
+	if err != nil {
+		return fmt.Errorf("markdown: operations _index.md: %w", err)
+	}
+	defer f.Close()
+	weight := m.nextCategoryWeight()
+	writeSectionFrontmatter(f, titleOperations, "", weight)
+
 	m.toc = append(m.toc, &mdTOCItem{
 		title:  titleOperations,
-		path:   "_operations.md",
-		weight: m.nextCategoryWeight(),
+		path:   filepath.Join("operations", hugoIndex),
+		weight: weight,
 	})
 	return nil
 }
 
-// WriteOperation reuses the "operation" define from resource.tmpl so
-// standalone operation pages match operations rendered inline on
-// resource pages.
 func (m *MarkdownWriter) WriteOperation(o *api.Operation) error {
 	filename := operationSlug(o.ID) + ".md"
 	path := filepath.Join(m.OutputDir, "operations", filename)
@@ -358,15 +368,8 @@ func (m *MarkdownWriter) WriteOperation(o *api.Operation) error {
 	return nil
 }
 
+// No-op: old versions render as resource pages routed to their group folder.
 func (m *MarkdownWriter) WriteOldVersionsOverview() error {
-	if err := m.writeSection("_oldversions.md", titleOldVersions); err != nil {
-		return fmt.Errorf("markdown: old versions overview: %w", err)
-	}
-	m.toc = append(m.toc, &mdTOCItem{
-		title:  titleOldVersions,
-		path:   "_oldversions.md",
-		weight: m.nextCategoryWeight(),
-	})
 	return nil
 }
 
@@ -407,9 +410,6 @@ func (m *MarkdownWriter) Finalize() error {
 	return nil
 }
 
-// buildResourcePage = buildDefinitionPage + operations. currentCategory
-// is the slug of the category this resource lands in; cross-type links
-// are resolved relative to it.
 func (m *MarkdownWriter) buildResourcePage(r *api.Resource, currentCategory string) resourcePage {
 	page := m.buildDefinitionPage(r.Definition, currentCategory)
 	for _, oc := range r.Definition.OperationCategories {
@@ -420,8 +420,8 @@ func (m *MarkdownWriter) buildResourcePage(r *api.Resource, currentCategory stri
 	return page
 }
 
-// buildDefinitionPage is shared by resource pages (which then add
-// operations) and standalone definition pages (which don't).
+// One H2 section per top-level inlined child (Spec, Status, List); deeper
+// inlines stay flattened with dot-notation in their containing section.
 func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory string) resourcePage {
 	page := resourcePage{
 		APIVersion:  groupVersionString(d.GroupFullName, d.Version),
@@ -433,25 +433,103 @@ func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory 
 		Description: d.DescriptionWithEntities,
 	}
 
+	// Inline closure rooted at d gates which types may flatten inline;
+	// anything outside renders as a cross-page link.
+	allowInline := map[string]bool{}
+	var collect func(x *api.Definition)
+	collect = func(x *api.Definition) {
+		for _, c := range x.Inline {
+			if allowInline[c.Key()] {
+				continue
+			}
+			allowInline[c.Key()] = true
+			collect(c)
+		}
+	}
+	collect(d)
+
+	// Section-worthy = directly referenced field type, or d's List type.
+	sectionTypes := map[string]bool{}
+	sectionOrder := []*api.Definition{}
+	addSection := func(def *api.Definition) {
+		if def == nil || sectionTypes[def.Key()] {
+			return
+		}
+		sectionTypes[def.Key()] = true
+		sectionOrder = append(sectionOrder, def)
+	}
+	for _, fld := range d.Fields {
+		if fld.Definition != nil && allowInline[fld.Definition.Key()] {
+			addSection(fld.Definition)
+		}
+	}
+	for _, c := range d.Inline {
+		if c.Name == d.Name+"List" {
+			addSection(c)
+		}
+	}
+
+	visited := map[string]bool{d.Key(): true}
+	root := fieldSection{
+		Title:       d.Name,
+		Anchor:      anchor(d.Name),
+		Description: d.DescriptionWithEntities,
+	}
+	m.appendFields(&root, d, "", currentCategory, allowInline, sectionTypes, visited)
+	page.Sections = append(page.Sections, root)
+
+	for _, s := range sectionOrder {
+		section := fieldSection{
+			Title:       s.Name,
+			Anchor:      anchor(s.Name),
+			Description: s.DescriptionWithEntities,
+		}
+		svisited := map[string]bool{d.Key(): true, s.Key(): true}
+		m.appendFields(&section, s, "", currentCategory, allowInline, sectionTypes, svisited)
+		page.Sections = append(page.Sections, section)
+	}
+	return page
+}
+
+// visited guards against pathological cycles.
+func (m *MarkdownWriter) appendFields(section *fieldSection, d *api.Definition, prefix, currentCategory string, allowInline, sectionTypes, visited map[string]bool) {
 	required := map[string]bool{}
 	for _, name := range d.RequiredFields() {
 		required[name] = true
 	}
 
 	for _, fld := range d.Fields {
-		page.Fields = append(page.Fields, templateField{
-			Name:          fld.Name,
+		fullName := fld.Name
+		if prefix != "" {
+			fullName = prefix + "." + fld.Name
+		}
+
+		typeHref := m.resolveType(fld.Type, currentCategory)
+		if fld.Definition != nil && sectionTypes[fld.Definition.Key()] {
+			typeHref = "#" + anchor(fld.Definition.Name)
+		}
+
+		section.Fields = append(section.Fields, templateField{
+			Name:          fullName,
 			Type:          fld.Type,
-			TypeHref:      m.resolveType(fld.Type, currentCategory),
+			TypeHref:      typeHref,
 			Description:   fld.Description,
 			Required:      required[fld.Name],
-			ConstValue:    constValueFor(fld.Name, page.APIVersion, page.Kind),
+			ConstValue:    constValueFor(fullName, "", ""),
 			PatchStrategy: fld.PatchStrategy,
 			PatchMergeKey: fld.PatchMergeKey,
 		})
-	}
 
-	return page
+		if fld.Definition == nil {
+			continue
+		}
+		key := fld.Definition.Key()
+		if !allowInline[key] || sectionTypes[key] || visited[key] {
+			continue
+		}
+		visited[key] = true
+		m.appendFields(section, fld.Definition, fullName, currentCategory, allowInline, sectionTypes, visited)
+	}
 }
 
 func (m *MarkdownWriter) buildTemplateOperation(o *api.Operation, currentCategory string) templateOperation {
@@ -507,7 +585,7 @@ func (m *MarkdownWriter) linkResources(categories []api.ResourceCategory) {
 			if r.Definition == nil {
 				continue
 			}
-			filename := strings.ToLower(r.Name) + "-" + string(r.Definition.Version)
+			filename := kebabName(r.Name) + "-" + string(r.Definition.Version)
 			m.recordLink(r.Definition.Name, slug, filename, r.Definition.Version)
 		}
 	}
@@ -518,7 +596,7 @@ func (m *MarkdownWriter) linkDefinitions(all map[string]*api.Definition) {
 		if d.InToc || d.IsInlined || d.IsOldVersion {
 			continue
 		}
-		filename := strings.ToLower(d.Name) + "-" + string(d.Version)
+		filename := kebabName(d.Name) + "-" + string(d.Version)
 		if d.Group != "" && d.Group != "core" {
 			filename += "-" + string(d.Group)
 		}
@@ -646,6 +724,17 @@ func escape(s string) string {
 
 func kebabCase(s string) string {
 	return strings.Trim(anchorRegex.ReplaceAllString(strings.ToLower(s), "-"), "-")
+}
+
+var (
+	kebabBoundary1 = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+	kebabBoundary2 = regexp.MustCompile(`([A-Z])([A-Z][a-z])`)
+)
+
+func kebabName(s string) string {
+	s = kebabBoundary2.ReplaceAllString(s, "$1-$2")
+	s = kebabBoundary1.ReplaceAllString(s, "$1-$2")
+	return strings.ToLower(s)
 }
 
 func groupVersionString(group string, version api.ApiVersion) string {

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -45,7 +45,7 @@ type MarkdownWriter struct {
 	resourceWeight  int
 	categoryWeight  int
 
-	// linkMap is populated during render for the PR 2 cross-reference pass.
+	// linkMap maps kind name → page path for cross-reference resolution.
 	linkMap map[string]linkInfo
 
 	toc []*mdTOCItem
@@ -70,6 +70,7 @@ type linkInfo struct {
 	Category string
 	Filename string
 	Anchor   string
+	Version  api.ApiVersion // used to pick the highest version on name collisions
 }
 
 // resourcePage is the view model resource.tmpl consumes.
@@ -88,6 +89,7 @@ type resourcePage struct {
 type templateField struct {
 	Name          string
 	Type          string
+	TypeHref      string // relative path#anchor, empty for primitives and unknowns
 	Description   string
 	Required      bool
 	ConstValue    string // non-empty for fields with a fixed value (apiVersion, kind)
@@ -109,12 +111,14 @@ type templateOperation struct {
 type templateParam struct {
 	Name        string
 	Type        string
+	TypeHref    string // relative path#anchor when Type is a known definition
 	Description string
 }
 
 type templateResponse struct {
 	Code        string
 	Type        string
+	TypeHref    string // relative path#anchor when Type is a known definition
 	Description string
 }
 
@@ -138,23 +142,31 @@ var anchorRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 //go:embed templates/resource.tmpl
 var resourceTemplateSrc string
 
-// q quotes for YAML frontmatter; md escapes `<` for body text.
-// Descriptions are passed raw so the template picks the right escape per site.
+// q quotes for YAML frontmatter; md escapes `<` for body text; hugoRef
+// wraps a relative path in a {{< ref >}} shortcode.
 var resourceTemplate = template.Must(template.New("resource").Funcs(template.FuncMap{
-	"q":  strconv.Quote,
-	"md": escape,
+	"q":       strconv.Quote,
+	"md":      escape,
+	"hugoRef": hugoRef,
 }).Parse(resourceTemplateSrc))
+
+// hugoRef wraps a path in a {{< ref >}} shortcode resolved by Hugo at build time.
+func hugoRef(path string) string {
+	return `{{< ref "` + path + `" >}}`
+}
 
 func NewMarkdownWriter(config *api.Config, copyright, title string) DocWriter {
 	outputDir := filepath.Join(api.BuildDir, "markdown")
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "MarkdownWriter: failed to create output dir %s: %v\n", outputDir, err)
 	}
-	return &MarkdownWriter{
+	m := &MarkdownWriter{
 		Config:    config,
 		OutputDir: outputDir,
 		linkMap:   make(map[string]linkInfo),
 	}
+	m.buildLinkMap(config)
+	return m
 }
 
 func (m *MarkdownWriter) Extension() string {
@@ -261,7 +273,7 @@ func (m *MarkdownWriter) WriteResource(r *api.Resource) error {
 	}
 	defer f.Close()
 
-	if err := resourceTemplate.Execute(f, m.buildResourcePage(r)); err != nil {
+	if err := resourceTemplate.Execute(f, m.buildResourcePage(r, m.currentCategory.slug)); err != nil {
 		return fmt.Errorf("markdown: resource %s body: %w", r.Name, err)
 	}
 
@@ -297,7 +309,7 @@ func (m *MarkdownWriter) WriteDefinition(d *api.Definition) error {
 	}
 	defer f.Close()
 
-	if err := resourceTemplate.Execute(f, m.buildDefinitionPage(d)); err != nil {
+	if err := resourceTemplate.Execute(f, m.buildDefinitionPage(d, "definitions")); err != nil {
 		return fmt.Errorf("markdown: definition %s body: %w", d.Name, err)
 	}
 	return nil
@@ -332,7 +344,7 @@ func (m *MarkdownWriter) WriteOperation(o *api.Operation) error {
 	defer f.Close()
 
 	writeSectionFrontmatter(f, o.Type.Name, o.Description(), m.nextResourceWeight())
-	if err := resourceTemplate.ExecuteTemplate(f, "operation", buildTemplateOperation(o)); err != nil {
+	if err := resourceTemplate.ExecuteTemplate(f, "operation", m.buildTemplateOperation(o, "operations")); err != nil {
 		return fmt.Errorf("markdown: operation %s body: %w", o.ID, err)
 	}
 	return nil
@@ -387,12 +399,14 @@ func (m *MarkdownWriter) Finalize() error {
 	return nil
 }
 
-// buildResourcePage = buildDefinitionPage + operations.
-func (m *MarkdownWriter) buildResourcePage(r *api.Resource) resourcePage {
-	page := m.buildDefinitionPage(r.Definition)
+// buildResourcePage = buildDefinitionPage + operations. currentCategory
+// is the slug of the category this resource lands in; cross-type links
+// are resolved relative to it.
+func (m *MarkdownWriter) buildResourcePage(r *api.Resource, currentCategory string) resourcePage {
+	page := m.buildDefinitionPage(r.Definition, currentCategory)
 	for _, oc := range r.Definition.OperationCategories {
 		for _, o := range oc.Operations {
-			page.Operations = append(page.Operations, buildTemplateOperation(o))
+			page.Operations = append(page.Operations, m.buildTemplateOperation(o, currentCategory))
 		}
 	}
 	return page
@@ -400,7 +414,7 @@ func (m *MarkdownWriter) buildResourcePage(r *api.Resource) resourcePage {
 
 // buildDefinitionPage is shared by resource pages (which then add
 // operations) and standalone definition pages (which don't).
-func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition) resourcePage {
+func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory string) resourcePage {
 	page := resourcePage{
 		APIVersion:  groupVersionString(d.GroupFullName, d.Version),
 		Kind:        d.Name,
@@ -420,6 +434,7 @@ func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition) resourcePage {
 		page.Fields = append(page.Fields, templateField{
 			Name:          fld.Name,
 			Type:          fld.Type,
+			TypeHref:      m.resolveType(fld.Type, currentCategory),
 			Description:   fld.Description,
 			Required:      required[fld.Name],
 			ConstValue:    constValueFor(fld.Name, page.APIVersion, page.Kind),
@@ -431,7 +446,7 @@ func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition) resourcePage {
 	return page
 }
 
-func buildTemplateOperation(o *api.Operation) templateOperation {
+func (m *MarkdownWriter) buildTemplateOperation(o *api.Operation, currentCategory string) templateOperation {
 	op := templateOperation{
 		Verb:   strings.ToLower(o.HttpMethod),
 		Title:  o.Type.Name,
@@ -445,6 +460,7 @@ func buildTemplateOperation(o *api.Operation) templateOperation {
 			out = append(out, templateParam{
 				Name:        p.Name,
 				Type:        p.Type,
+				TypeHref:    m.resolveType(p.Type, currentCategory),
 				Description: p.Description,
 			})
 		}
@@ -462,11 +478,84 @@ func buildTemplateOperation(o *api.Operation) templateOperation {
 		op.Responses = append(op.Responses, templateResponse{
 			Code:        rsp.Code,
 			Type:        rsp.Field.Type,
+			TypeHref:    m.resolveType(rsp.Field.Type, currentCategory),
 			Description: rsp.Field.Description,
 		})
 	}
 
 	return op
+}
+
+// On collisions: resource entries beat definition entries; higher version wins.
+func (m *MarkdownWriter) buildLinkMap(config *api.Config) {
+	m.linkResources(config.ResourceCategories)
+	m.linkDefinitions(config.Definitions.All)
+}
+
+func (m *MarkdownWriter) linkResources(categories []api.ResourceCategory) {
+	for _, c := range categories {
+		slug := kebabCase(c.Name)
+		for _, r := range c.Resources {
+			if r.Definition == nil {
+				continue
+			}
+			filename := strings.ToLower(r.Name) + "-" + string(r.Definition.Version)
+			m.recordLink(r.Definition.Name, slug, filename, r.Definition.Version)
+		}
+	}
+}
+
+func (m *MarkdownWriter) linkDefinitions(all map[string]*api.Definition) {
+	for _, d := range all {
+		if d.InToc || d.IsInlined || d.IsOldVersion {
+			continue
+		}
+		filename := strings.ToLower(d.Name) + "-" + string(d.Version)
+		if d.Group != "" && d.Group != "core" {
+			filename += "-" + string(d.Group)
+		}
+		m.recordLink(d.Name, "definitions", filename, d.Version)
+	}
+}
+
+func (m *MarkdownWriter) recordLink(name, category, filename string, version api.ApiVersion) {
+	if existing, ok := m.linkMap[name]; ok {
+		if existing.Category != "definitions" && category == "definitions" {
+			return
+		}
+		// LessThan returns true when the receiver is the higher version.
+		if existing.Category == category && existing.Version.LessThan(version) {
+			return
+		}
+	}
+	m.linkMap[name] = linkInfo{
+		Category: category,
+		Filename: filename,
+		Anchor:   anchor(name),
+		Version:  version,
+	}
+}
+
+// resolveType returns a relative path#anchor for typeName, or "" if unknown.
+// currentCategory is the slug containing the calling page; "MutatingWebhook
+// array" is normalised to "MutatingWebhook" before lookup.
+func (m *MarkdownWriter) resolveType(typeName, currentCategory string) string {
+	info, ok := m.linkMap[typeName]
+	if !ok {
+		if bare, stripped := strings.CutSuffix(typeName, " array"); stripped {
+			info, ok = m.linkMap[bare]
+		}
+	}
+	if !ok {
+		return ""
+	}
+	var path string
+	if info.Category == currentCategory {
+		path = info.Filename
+	} else {
+		path = "../" + info.Category + "/" + info.Filename
+	}
+	return path + "#" + info.Anchor
 }
 
 // writeSection falls back to a `# Title` stub when

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -264,8 +264,16 @@ func (m *MarkdownWriter) WriteResourceCategory(name, file string) error {
 }
 
 func (m *MarkdownWriter) WriteResource(r *api.Resource) error {
+	slug := m.currentCategory.slug
+	if r.Definition != nil && r.Definition.IsOldVersion {
+		slug = kebabCase(string(r.Definition.Group))
+		if err := os.MkdirAll(filepath.Join(m.OutputDir, slug), 0755); err != nil {
+			return fmt.Errorf("markdown: group dir %s: %w", slug, err)
+		}
+	}
+
 	filename := fmt.Sprintf("%s-%s.md", strings.ToLower(r.Name), r.Definition.Version)
-	path := filepath.Join(m.OutputDir, m.currentCategory.slug, filename)
+	path := filepath.Join(m.OutputDir, slug, filename)
 
 	f, err := os.Create(path)
 	if err != nil {
@@ -273,7 +281,7 @@ func (m *MarkdownWriter) WriteResource(r *api.Resource) error {
 	}
 	defer f.Close()
 
-	if err := resourceTemplate.Execute(f, m.buildResourcePage(r, m.currentCategory.slug)); err != nil {
+	if err := resourceTemplate.Execute(f, m.buildResourcePage(r, slug)); err != nil {
 		return fmt.Errorf("markdown: resource %s body: %w", r.Name, err)
 	}
 

--- a/gen-apidocs/generators/markdown_test.go
+++ b/gen-apidocs/generators/markdown_test.go
@@ -188,11 +188,11 @@ func TestResolveType(t *testing.T) {
 		typeName, currentCategory, want string
 	}{
 		// From the Deployment resource page, DeploymentSpec lives in definitions/
-		{"DeploymentSpec", testCategorySlug, "../definitions/deploymentspec-v1-apps#DeploymentSpec"},
+		{"DeploymentSpec", testCategorySlug, "../definitions/deployment-spec-v1-apps#DeploymentSpec"},
 		// ObjectMeta same — different dir
-		{"ObjectMeta", testCategorySlug, "../definitions/objectmeta-v1-meta#ObjectMeta"},
+		{"ObjectMeta", testCategorySlug, "../definitions/object-meta-v1-meta#ObjectMeta"},
 		// Self-reference (inside the definitions dir)
-		{"ObjectMeta", "definitions", "objectmeta-v1-meta#ObjectMeta"},
+		{"ObjectMeta", "definitions", "object-meta-v1-meta#ObjectMeta"},
 		// Primitive / unknown → empty string
 		{"string", testCategorySlug, ""},
 		{"UnknownThing", testCategorySlug, ""},

--- a/gen-apidocs/generators/markdown_test.go
+++ b/gen-apidocs/generators/markdown_test.go
@@ -31,7 +31,11 @@ import (
 // rewrite any *.golden files from current output.
 var update = flag.Bool("update", false, "rewrite *.golden files from test output")
 
-const testCategorySlug = "workloads-apis"
+const (
+	// Match a real API group so fixture mirrors what auto-detect produces.
+	testCategoryName = "Apps"
+	testCategorySlug = "apps"
+)
 
 func TestAnchor(t *testing.T) {
 	cases := []struct {
@@ -63,7 +67,7 @@ func TestEscape(t *testing.T) {
 
 func TestKebabCase(t *testing.T) {
 	cases := map[string]string{
-		"Workloads APIs":       testCategorySlug,
+		testCategoryName:       testCategorySlug,
 		"Service Discovery":    "service-discovery",
 		"Cluster - Admin":      "cluster-admin",
 		"  Leading trailing  ": "leading-trailing",
@@ -131,7 +135,7 @@ func TestWriteResourceGolden(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(m.OutputDir, testCategorySlug), 0755); err != nil {
 		t.Fatal(err)
 	}
-	m.currentCategory = mdCategory{name: "Workloads APIs", slug: testCategorySlug}
+	m.currentCategory = mdCategory{name: testCategoryName, slug: testCategorySlug}
 
 	r := fabricateDeploymentResource()
 	if err := m.WriteResource(r); err != nil {
@@ -159,6 +163,82 @@ func TestWriteOperationGolden(t *testing.T) {
 	compareWithGolden(t,
 		filepath.Join(m.OutputDir, "operations", "listcorev1pod.md"),
 		"testdata/operation-list.golden.md")
+}
+
+func TestResolveType(t *testing.T) {
+	m := &MarkdownWriter{linkMap: map[string]linkInfo{}}
+	m.linkResources([]api.ResourceCategory{
+		{
+			Name: testCategoryName,
+			Resources: api.Resources{
+				{Name: "Deployment", Definition: &api.Definition{Name: "Deployment", Version: api.ApiVersion("v1")}},
+			},
+		},
+	})
+	m.linkDefinitions(map[string]*api.Definition{
+		"io.k8s.api.apps.v1.DeploymentSpec": {
+			Name: "DeploymentSpec", Group: api.ApiGroup("apps"), Version: api.ApiVersion("v1"),
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+			Name: "ObjectMeta", Group: api.ApiGroup("meta"), Version: api.ApiVersion("v1"),
+		},
+	})
+
+	cases := []struct {
+		typeName, currentCategory, want string
+	}{
+		// From the Deployment resource page, DeploymentSpec lives in definitions/
+		{"DeploymentSpec", testCategorySlug, "../definitions/deploymentspec-v1-apps#DeploymentSpec"},
+		// ObjectMeta same — different dir
+		{"ObjectMeta", testCategorySlug, "../definitions/objectmeta-v1-meta#ObjectMeta"},
+		// Self-reference (inside the definitions dir)
+		{"ObjectMeta", "definitions", "objectmeta-v1-meta#ObjectMeta"},
+		// Primitive / unknown → empty string
+		{"string", testCategorySlug, ""},
+		{"UnknownThing", testCategorySlug, ""},
+		// Resource path: Deployment lives under apps/
+		{"Deployment", "definitions", "../apps/deployment-v1#Deployment"},
+	}
+	for _, c := range cases {
+		if got := m.resolveType(c.typeName, c.currentCategory); got != c.want {
+			t.Errorf("resolveType(%q, %q) = %q, want %q", c.typeName, c.currentCategory, got, c.want)
+		}
+	}
+}
+
+func TestRecordLinkPrecedence(t *testing.T) {
+	m := &MarkdownWriter{linkMap: map[string]linkInfo{}}
+
+	// Pretend Deployment is first seen as a standalone definition...
+	m.recordLink("Deployment", "definitions", "deployment-v1-apps", api.ApiVersion("v1"))
+	if got := m.linkMap["Deployment"].Category; got != "definitions" {
+		t.Fatalf("initial category = %q, want definitions", got)
+	}
+
+	// ...then as a resource. Resource should win.
+	m.recordLink("Deployment", "apps", "deployment-v1", api.ApiVersion("v1"))
+	if got := m.linkMap["Deployment"].Category; got != "apps" {
+		t.Errorf("after resource record, category = %q, want apps", got)
+	}
+
+	// A later standalone-definition record for the same name must not clobber.
+	m.recordLink("Deployment", "definitions", "deployment-v1-apps", api.ApiVersion("v1"))
+	if got := m.linkMap["Deployment"].Category; got != "apps" {
+		t.Errorf("after late definitions record, category = %q, want apps", got)
+	}
+
+	// Version bump within same bucket wins.
+	m.recordLink("HPA", "autoscaling", "horizontalpodautoscaler-v1", api.ApiVersion("v1"))
+	m.recordLink("HPA", "autoscaling", "horizontalpodautoscaler-v2", api.ApiVersion("v2"))
+	if got := m.linkMap["HPA"].Version; string(got) != "v2" {
+		t.Errorf("HPA version = %q, want v2", got)
+	}
+
+	// Older version must not clobber newer.
+	m.recordLink("HPA", "autoscaling", "horizontalpodautoscaler-v1", api.ApiVersion("v1"))
+	if got := m.linkMap["HPA"].Version; string(got) != "v2" {
+		t.Errorf("after old version, HPA version = %q, want v2", got)
+	}
 }
 
 // --- fixture helpers ---

--- a/gen-apidocs/generators/templates/resource.tmpl
+++ b/gen-apidocs/generators/templates/resource.tmpl
@@ -27,7 +27,8 @@ guide. You can file document formatting bugs against the
 {{if .Import}}
 `import "{{.Import}}"`
 {{end}}
-## {{.Kind}} {#{{.Anchor}}}
+{{range .Sections}}
+## {{.Title}} {#{{.Anchor}}}
 
 {{.Description | md}}
 
@@ -44,6 +45,7 @@ guide. You can file document formatting bugs against the
 {{- end}}
   </tbody>
 </table>
+{{end}}
 {{end}}
 {{if .Operations}}
 ## Operations {#Operations}
@@ -62,22 +64,23 @@ guide. You can file document formatting bugs against the
 
 {{.Method}} {{.Path}}
 
-{{if .PathParams}}#### Path Parameters
+{{if .PathParams}}
+#### Path Parameters
 
 {{template "paramTable" .PathParams}}
 {{end}}
-
-{{- if .QueryParams}}#### Query Parameters
+{{if .QueryParams}}
+#### Query Parameters
 
 {{template "paramTable" .QueryParams}}
 {{end}}
-
-{{- if .BodyParams}}#### Body Parameters
+{{if .BodyParams}}
+#### Body Parameters
 
 {{template "paramTable" .BodyParams}}
 {{end}}
-
-{{- if .Responses}}#### Response
+{{if .Responses}}
+#### Response
 
 <table>
   <thead><tr><th>Status</th><th>Description</th><th>Response</th></tr></thead>
@@ -92,7 +95,7 @@ guide. You can file document formatting bugs against the
   </tbody>
 </table>
 {{end}}
-{{- end}}
+{{end}}
 
 {{define "typeWrap" -}}
 {{if .TypeHref}}<a href="{{hugoRef .TypeHref}}">{{.Type}}</a>{{else}}{{.Type}}{{end}}

--- a/gen-apidocs/generators/templates/resource.tmpl
+++ b/gen-apidocs/generators/templates/resource.tmpl
@@ -38,7 +38,7 @@ guide. You can file document formatting bugs against the
   <tbody>
 {{- range .Fields}}
     <tr>
-      <td><code>{{.Name}}</code>{{if .Required}}&nbsp;<strong>*</strong>{{end}}<br/><em>{{.Type}}</em>{{if .ConstValue}}<br/><em>const: <code>{{.ConstValue}}</code></em>{{end}}{{if .PatchStrategy}}<br/><em>patch strategy: {{.PatchStrategy}}{{if .PatchMergeKey}} on key <code>{{.PatchMergeKey}}</code>{{end}}</em>{{end}}</td>
+      <td><code>{{.Name}}</code>{{if .Required}}&nbsp;<strong>*</strong>{{end}}<br/><em>{{template "typeWrap" .}}</em>{{if .ConstValue}}<br/><em>const: <code>{{.ConstValue}}</code></em>{{end}}{{if .PatchStrategy}}<br/><em>patch strategy: {{.PatchStrategy}}{{if .PatchMergeKey}} on key <code>{{.PatchMergeKey}}</code>{{end}}</em>{{end}}</td>
       <td>{{.Description | md}}</td>
     </tr>
 {{- end}}
@@ -86,12 +86,16 @@ guide. You can file document formatting bugs against the
     <tr>
       <td>{{.Code}}</td>
       <td>{{.Description | md}}</td>
-      <td>{{if .Type}}<em>{{.Type}}</em>{{else}}&mdash;{{end}}</td>
+      <td>{{if .Type}}<em>{{template "typeWrap" .}}</em>{{else}}&mdash;{{end}}</td>
     </tr>
 {{- end}}
   </tbody>
 </table>
 {{end}}
+{{- end}}
+
+{{define "typeWrap" -}}
+{{if .TypeHref}}<a href="{{hugoRef .TypeHref}}">{{.Type}}</a>{{else}}{{.Type}}{{end}}
 {{- end}}
 
 {{define "paramTable" -}}
@@ -101,7 +105,7 @@ guide. You can file document formatting bugs against the
 {{- range .}}
     <tr>
       <td><code>{{.Name}}</code></td>
-      <td><em>{{.Type}}</em></td>
+      <td><em>{{template "typeWrap" .}}</em></td>
       <td>{{.Description | md}}</td>
     </tr>
 {{- end}}

--- a/gen-apidocs/generators/testdata/deployment-v1.golden.md
+++ b/gen-apidocs/generators/testdata/deployment-v1.golden.md
@@ -62,3 +62,5 @@ Deployment enables declarative updates for Pods and ReplicaSets.
 
 
 
+
+

--- a/gen-apidocs/generators/testdata/deployment-v1.golden.md
+++ b/gen-apidocs/generators/testdata/deployment-v1.golden.md
@@ -25,6 +25,7 @@ guide. You can file document formatting bugs against the
 
 `import "k8s.io/api/apps/v1"`
 
+
 ## Deployment {#Deployment}
 
 Deployment enables declarative updates for Pods and ReplicaSets.
@@ -35,11 +36,11 @@ Deployment enables declarative updates for Pods and ReplicaSets.
   <thead><tr><th>Field</th><th>Description</th></tr></thead>
   <tbody>
     <tr>
-      <td><code>apiVersion</code><br/><em>string</em><br/><em>const: <code>apps/v1</code></em></td>
+      <td><code>apiVersion</code><br/><em>string</em></td>
       <td>APIVersion defines the versioned schema of this representation of an object.</td>
     </tr>
     <tr>
-      <td><code>kind</code><br/><em>string</em><br/><em>const: <code>Deployment</code></em></td>
+      <td><code>kind</code><br/><em>string</em></td>
       <td>Kind is a string value representing the REST resource.</td>
     </tr>
     <tr>
@@ -56,6 +57,7 @@ Deployment enables declarative updates for Pods and ReplicaSets.
     </tr>
   </tbody>
 </table>
+
 
 
 

--- a/gen-apidocs/generators/testdata/operation-list.golden.md
+++ b/gen-apidocs/generators/testdata/operation-list.golden.md
@@ -11,6 +11,7 @@ auto_generated: true
 
 GET /api/v1/namespaces/{namespace}/pods
 
+
 #### Path Parameters
 
 <table>
@@ -23,6 +24,8 @@ GET /api/v1/namespaces/{namespace}/pods
     </tr>
   </tbody>
 </table>
+
+
 #### Query Parameters
 
 <table>
@@ -35,3 +38,6 @@ GET /api/v1/namespaces/{namespace}/pods
     </tr>
   </tbody>
 </table>
+
+
+


### PR DESCRIPTION
Stacked on the markdown backend (#435). Brings gen-apidocs --backend=markdown
output to parity with gen-resourcesdocs (with some improvement) so the consolidation in #434 can land.

- Auto detect spec by Group name,  eliminating hard-written grouping

<img width="312" height="639" alt="image" src="https://github.com/user-attachments/assets/8d25da78-e5ae-4746-96dc-89210c0cdaa2" />

- Use table format 
<img width="1185" height="781" alt="image" src="https://github.com/user-attachments/assets/96fec6d8-0270-4ae4-b89c-d4dd684fad1c" />

- convert to hugo shortcode