### PR TITLE
Update/api docs openapi enums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,18 +110,24 @@ api: cleanapi
 
 # Build API docs as markdown (Hugo-compatible output in gen-apidocs/build/markdown/).
 # Output is intended to replace gen-resourcesdocs once parity is reached.
-apimd: cleanapi
+apimd: cleanapimd
 	cd $(APISRC) && go run main.go --kubernetes-release=$(K8SRELEASE_PREFIX) --work-dir=. --auto-detect --backend=markdown
 
 cleanapi:
-	rm -rf $(shell pwd)/gen-apidocs/build
+	rm -rf $(shell pwd)/gen-apidocs/build/html
+	rm -rf $(shell pwd)/gen-apidocs/build/includes
+	rm -f $(shell pwd)/gen-apidocs/build/index.html
+	rm -f $(shell pwd)/gen-apidocs/build/navData.js
+
+cleanapimd:
+	rm -rf $(shell pwd)/gen-apidocs/build/markdown
 
 copyapi: api
 	mkdir -p $(APIDST)
-	cp $(APISRC)/build/index.html $(APIDST)/index.html
+	cp $(APISRC)/build/html/index.html $(APIDST)/index.html
 	# copy the new navData.js
 	mkdir -p $(APIDST)/js
-	cp $(APISRC)/build/navData.js $(APIDST)/js/
+	cp $(APISRC)/build/html/navData.js $(APIDST)/js/
 
 # Build resource reference
 genresources:

--- a/gen-apidocs/generators/api/config.go
+++ b/gen-apidocs/generators/api/config.go
@@ -60,7 +60,7 @@ func normalizeGroupLabel(s string) string {
 	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(s), " ", ""))
 }
 
-// Directory for output files
+// Directory for backend output files
 var BuildDir string
 
 // Directory for configuration and data files
@@ -77,7 +77,13 @@ var VersionedConfigDir string
 
 func NewConfig() (*Config, error) {
 	// Initialize global directories
-	BuildDir = filepath.Join(*WorkDir, "build")
+	buildRoot := filepath.Join(*WorkDir, "build")
+	switch *Backend {
+	case "markdown":
+		BuildDir = filepath.Join(buildRoot, "markdown")
+	default:
+		BuildDir = filepath.Join(buildRoot, "html")
+	}
 	ConfigDir = filepath.Join(*WorkDir, "config")
 	IncludesDir = filepath.Join(BuildDir, "includes")
 	SectionsDir = filepath.Join(ConfigDir, "sections")

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -165,7 +165,7 @@ func hugoRef(path string) string {
 }
 
 func NewMarkdownWriter(config *api.Config, copyright, title string) DocWriter {
-	outputDir := filepath.Join(api.BuildDir, "markdown")
+	outputDir := api.BuildDir
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "MarkdownWriter: failed to create output dir %s: %v\n", outputDir, err)
 	}

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -143,6 +143,11 @@ var _ DocWriter = (*MarkdownWriter)(nil)
 
 var anchorRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 
+var (
+	enumHeaderRegex = regexp.MustCompile(`\s+Possible enum values:`)
+	enumBulletRegex = regexp.MustCompile(`\s+- ` + "`")
+)
+
 //go:embed templates/resource.tmpl
 var resourceTemplateSrc string
 
@@ -644,17 +649,6 @@ func (m *MarkdownWriter) resolveType(typeName, currentCategory string) string {
 	return path + "#" + info.Anchor
 }
 
-// writeSection falls back to a `# Title` stub when
-// config/sections/<filename> is absent.
-func (m *MarkdownWriter) writeSection(filename, title string) error {
-	content := readOptionalSection(filename)
-	if content == "" {
-		content = "# " + title + "\n"
-	}
-	dst := filepath.Join(m.OutputDir, filename)
-	return os.WriteFile(dst, []byte(content), 0644)
-}
-
 // readOptionalSection swallows read errors on purpose; missing or
 // unreadable section files fall back to generated content.
 func readOptionalSection(name string) string {
@@ -719,7 +713,10 @@ func anchor(s string) string {
 // escape covers the only markdown-breaking character in OpenAPI descriptions:
 // raw `<` that would otherwise be read as HTML.
 func escape(s string) string {
-	return strings.ReplaceAll(s, "<", `\<`)
+	s = strings.ReplaceAll(s, "<", `\<`)
+	s = enumHeaderRegex.ReplaceAllString(s, "<br/><br/>Possible enum values:")
+	s = enumBulletRegex.ReplaceAllString(s, "<br/> - `")
+	return s
 }
 
 func kebabCase(s string) string {

--- a/gen-apidocs/generators/markdown_test.go
+++ b/gen-apidocs/generators/markdown_test.go
@@ -63,6 +63,9 @@ func TestEscape(t *testing.T) {
 	if got := escape("no change"); got != "no change" {
 		t.Errorf("escape: got %q", got)
 	}
+	if got := escape("Allowed values.  Possible enum values:  - `\"A\"` first.  - `\"B\"` second."); got != "Allowed values.<br/><br/>Possible enum values:<br/> - `\"A\"` first.<br/> - `\"B\"` second." {
+		t.Errorf("escape enum list: got %q", got)
+	}
 }
 
 func TestKebabCase(t *testing.T) {


### PR DESCRIPTION
Regenerates the v1.36 OpenAPI swagger with enum metadata and updates markdown generation so possible enum descriptions render cleanly in generated API reference tables.

Also separates `make api` and `make apimd` outputs into gen-apidocs/build/html and gen-apidocs/build/markdown, so running one target no longer deletes the other backend’s output.