### PR TITLE
add deprecate note on gen-resourcesdocs README and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ copyapi: api
 
 # Build resource reference
 genresources:
+	@echo "WARNING: gen-resourcesdocs is deprecated; use make apimd instead."
 	make -C gen-resourcesdocs kwebsite
 
 # Build config API reference

--- a/gen-resourcesdocs/README.md
+++ b/gen-resourcesdocs/README.md
@@ -1,3 +1,8 @@
+> **Deprecated:** `gen-resourcesdocs` is deprecated in favor of
+> `gen-apidocs --backend=markdown` / `make apimd`.
+> It is kept temporarily for transition and will be removed after the
+> gen-apidocs markdown output fully replaces it in kubernetes/website.
+
 # Kubernetes API resources documentation generator
 
 This tool extracts information from the OpenAPI specification file of the [Kubernetes API](https://github.com/kubernetes/kubernetes/blob/master/api/openapi-spec/swagger.json) and creates documentation in Markdown format, suitable for the [Kubernetes website](https://kubernetes.io/docs/reference/kubernetes-api/).


### PR DESCRIPTION
Add deprecation note on gen-resourcesdocs.

Follows
deprecate -> announce -> wait -> remove (if needed)

Closes: https://github.com/kubernetes-sigs/reference-docs/issues/434