### PR TITLE
Adds deprecation note on gen-kubectldocs README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,17 +66,20 @@ createversiondirs:
 
 # Build kubectl docs
 cleancli:
+	@echo "WARNING: gen-kubectl is deprecated; use gen-compdocs kubectl instead."
 	sudo rm -f main
 	sudo rm -rf $(shell pwd)/gen-kubectldocs/generators/includes
 	sudo rm -rf $(shell pwd)/gen-kubectldocs/generators/build
 	sudo rm -rf $(shell pwd)/gen-kubectldocs/generators/manifest.json
 
 cli: cleancli
+	@echo "WARNING: gen-kubectl is deprecated; use gen-compdocs kubectl instead."
 	cd gen-kubectldocs && go mod download && go run main.go --kubernetes-version v$(K8SRELEASEDIR)
 	mkdir -p $(CLISRC)
 	docker run -v $(shell pwd)/gen-kubectldocs/generators/includes:/source -v $(shell pwd)/gen-kubectldocs/generators/build:/build -v $(shell pwd)/gen-kubectldocs/generators/:/manifest brianpursley/brodocs:latest
 
 copycli: cli
+	@echo "WARNING: gen-kubectl is deprecated; use gen-compdocs kubectl instead."
 	cp gen-kubectldocs/generators/build/index.html $(WEBROOT)/static/docs/reference/generated/kubectl/kubectl-commands.html
 	cp gen-kubectldocs/generators/build/navData.js $(WEBROOT)/static/docs/reference/generated/kubectl/navData.js
 	cp $(CLISRC)/scroll.js $(CLIDST)/scroll.js

--- a/gen-kubectldocs/README.md
+++ b/gen-kubectldocs/README.md
@@ -1,0 +1,6 @@
+> **Deprecated:** `gen-kubectldocs` is deprecated in favor of
+> `gen-compdocs kubectl`.
+> It is kept temporarily for transition and will be removed after the
+> gen-compdocs markdown output fully replaces it in kubernetes/website.
+
+# Generator for kubectl command documentation.


### PR DESCRIPTION
Add deprecation note on gen-kubectldocs

Follows
Deprecate -> Announce -> Wait -> Remove (if needed)

Partially Addresses (Sub-task: 2) #448 