### PR TITLE
reduce gen-apidocs markdown output from 577 to 157 pages

### DIFF
--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -267,8 +267,6 @@ func (m *MarkdownWriter) WriteResourceCategory(name, file string) error {
 
 	if body := readOptionalSection(file + ".md"); body != "" {
 		fmt.Fprintln(f, body)
-	} else {
-		fmt.Fprintf(f, "# %s\n", name)
 	}
 
 	m.currentCategory = mdCategory{name: name, slug: slug}

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -48,6 +48,9 @@ type MarkdownWriter struct {
 	// linkMap maps kind name → page path for cross-reference resolution.
 	linkMap map[string]linkInfo
 
+	classifications map[string]defClassification
+	inlinedByParent map[string][]*api.Definition
+
 	toc []*mdTOCItem
 
 	// finalized guards against Finalize being called twice by GenerateFiles.
@@ -131,6 +134,8 @@ type templateResponse struct {
 
 const hugoIndex = "_index.md"
 
+const apimachineryPrefix = "io.k8s.apimachinery."
+
 const (
 	titleOverview    = "Overview"
 	titleAPIGroups   = "API Groups"
@@ -138,6 +143,15 @@ const (
 	titleOperations  = "Operations"
 	titleOldVersions = "Old API Versions"
 )
+
+// utilityStandalone pins core/v1 utility kinds the BFS can't distinguish
+// from real sub-types.
+var utilityStandalone = map[string]bool{
+	"LocalObjectReference":      true,
+	"NodeSelector":              true,
+	"NodeSelectorTerm":          true,
+	"TypedLocalObjectReference": true,
+}
 
 var _ DocWriter = (*MarkdownWriter)(nil)
 
@@ -174,6 +188,8 @@ func NewMarkdownWriter(config *api.Config, copyright, title string) DocWriter {
 		OutputDir: outputDir,
 		linkMap:   make(map[string]linkInfo),
 	}
+	// Order matters: linkMap consults classifications to alias inlined types.
+	m.classifications = m.classifyDefinitions()
 	m.buildLinkMap(config)
 	return m
 }
@@ -312,6 +328,9 @@ func (m *MarkdownWriter) WriteDefinitionsOverview() error {
 }
 
 func (m *MarkdownWriter) WriteDefinition(d *api.Definition) error {
+	if m.classifications[d.Key()].Mode == classifyInline {
+		return nil
+	}
 	filename := kebabName(d.Name) + "-" + string(d.Version)
 	if d.Group != "" && d.Group != "core" {
 		filename += "-" + string(d.Group)
@@ -471,6 +490,14 @@ func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory 
 		}
 	}
 
+	if siblings := m.inlinedByParent[d.Key()]; len(siblings) > 0 {
+		sorted := append([]*api.Definition(nil), siblings...)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+		for _, c := range sorted {
+			addSection(c)
+		}
+	}
+
 	visited := map[string]bool{d.Key(): true}
 	root := fieldSection{
 		Title:       d.Name,
@@ -580,6 +607,88 @@ func (m *MarkdownWriter) buildLinkMap(config *api.Config) {
 	m.linkDefinitions(config.Definitions.All)
 }
 
+type classifyMode int
+
+const (
+	classifySkip classifyMode = iota
+	classifyInline
+	classifyStandalone
+)
+
+type defClassification struct {
+	Mode       classifyMode
+	InlineInto *api.Definition // non-nil iff Mode == classifyInline
+}
+
+// classifyDefinitions returns each definition's emit mode.
+func (m *MarkdownWriter) classifyDefinitions() map[string]defClassification {
+	out := make(map[string]defClassification, len(m.Config.Definitions.All))
+	m.inlinedByParent = map[string][]*api.Definition{}
+	for _, d := range m.Config.Definitions.All {
+		if d.IsOldVersion || d.IsInlined || d.InToc {
+			out[d.Key()] = defClassification{Mode: classifySkip}
+			continue
+		}
+		if strings.HasPrefix(d.SwaggerKey, apimachineryPrefix) || utilityStandalone[d.Name] {
+			out[d.Key()] = defClassification{Mode: classifyStandalone}
+			continue
+		}
+		if home := m.closestTopLevelHome(d); home != nil {
+			out[d.Key()] = defClassification{Mode: classifyInline, InlineInto: home}
+			m.inlinedByParent[home.Key()] = append(m.inlinedByParent[home.Key()], d)
+			continue
+		}
+		out[d.Key()] = defClassification{Mode: classifyStandalone}
+	}
+	return out
+}
+
+// closestTopLevelHome returns the unique closest InToc ancestor of d via
+// AppearsIn, or nil on a tie or no reachable top-level.
+func (m *MarkdownWriter) closestTopLevelHome(d *api.Definition) *api.Definition {
+	type qItem struct {
+		def  *api.Definition
+		dist int
+	}
+	seen := map[string]bool{d.Key(): true}
+	queue := []qItem{{def: d, dist: 0}}
+
+	minDist := -1
+	winners := []*api.Definition{}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		if minDist >= 0 && cur.dist > minDist {
+			break
+		}
+
+		for _, parent := range cur.def.AppearsIn {
+			if parent == nil || seen[parent.Key()] {
+				continue
+			}
+			seen[parent.Key()] = true
+			nextDist := cur.dist + 1
+			if parent.InToc {
+				if minDist < 0 {
+					minDist = nextDist
+				}
+				if nextDist == minDist {
+					winners = append(winners, parent)
+				}
+				continue
+			}
+			queue = append(queue, qItem{def: parent, dist: nextDist})
+		}
+	}
+
+	if len(winners) == 1 {
+		return winners[0]
+	}
+	return nil
+}
+
 func (m *MarkdownWriter) linkResources(categories []api.ResourceCategory) {
 	for _, c := range categories {
 		slug := kebabCase(c.Name)
@@ -589,6 +698,14 @@ func (m *MarkdownWriter) linkResources(categories []api.ResourceCategory) {
 			}
 			filename := kebabName(r.Name) + "-" + string(r.Definition.Version)
 			m.recordLink(r.Definition.Name, slug, filename, r.Definition.Version)
+			// Types inlined into this page (pattern-matched and refcount-derived)
+			// share the parent's URL; the anchor on the parent is what selects them.
+			for _, child := range r.Definition.Inline {
+				m.recordLink(child.Name, slug, filename, child.Version)
+			}
+			for _, child := range m.inlinedByParent[r.Definition.Key()] {
+				m.recordLink(child.Name, slug, filename, child.Version)
+			}
 		}
 	}
 }
@@ -596,6 +713,9 @@ func (m *MarkdownWriter) linkResources(categories []api.ResourceCategory) {
 func (m *MarkdownWriter) linkDefinitions(all map[string]*api.Definition) {
 	for _, d := range all {
 		if d.InToc || d.IsInlined || d.IsOldVersion {
+			continue
+		}
+		if m.classifications[d.Key()].Mode == classifyInline {
 			continue
 		}
 		filename := kebabName(d.Name) + "-" + string(d.Version)

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -268,10 +268,7 @@ func (m *MarkdownWriter) WriteResourceCategory(name, file string) error {
 func (m *MarkdownWriter) WriteResource(r *api.Resource) error {
 	slug := m.currentCategory.slug
 	if r.Definition != nil && r.Definition.IsOldVersion {
-		slug = kebabCase(string(r.Definition.Group))
-		if err := os.MkdirAll(filepath.Join(m.OutputDir, slug), 0755); err != nil {
-			return fmt.Errorf("markdown: group dir %s: %w", slug, err)
-		}
+		return nil // markdown backend omits old-version pages; current version is canonical
 	}
 
 	filename := fmt.Sprintf("%s-%s.md", kebabName(r.Name), r.Definition.Version)

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -301,7 +301,7 @@ func (m *MarkdownWriter) WriteDefinitionsOverview() error {
 	}
 	defer f.Close()
 	weight := m.nextCategoryWeight()
-	writeSectionFrontmatter(f, titleDefinitions, "", weight)
+	writeSectionFrontmatter(f, titleDefinitions, "", weight, hideFromNav())
 
 	m.toc = append(m.toc, &mdTOCItem{
 		title:  titleDefinitions,
@@ -657,9 +657,22 @@ func readOptionalSection(name string) string {
 	return string(data)
 }
 
+type sectionFrontmatterOpt func(w io.Writer)
+
+// hideFromNav drops the section and its children from the Docsy sidebar.
+// Cross-ref-only sections (definitions) would otherwise add hundreds of
+// nav entries and slow every page render across k/website.
+func hideFromNav() sectionFrontmatterOpt {
+	return func(w io.Writer) {
+		fmt.Fprintln(w, "_build:")
+		fmt.Fprintln(w, "  list: never")
+		fmt.Fprintln(w, "toc_hide: true")
+	}
+}
+
 // writeSectionFrontmatter emits the minimal frontmatter for non-resource
 // pages. Resource pages go through resource.tmpl instead.
-func writeSectionFrontmatter(w io.Writer, title, description string, weight int) {
+func writeSectionFrontmatter(w io.Writer, title, description string, weight int, opts ...sectionFrontmatterOpt) {
 	fmt.Fprintln(w, "---")
 	fmt.Fprintln(w, `content_type: "api_reference"`)
 	if description != "" {
@@ -668,6 +681,9 @@ func writeSectionFrontmatter(w io.Writer, title, description string, weight int)
 	fmt.Fprintf(w, "title: %q\n", title)
 	fmt.Fprintf(w, "weight: %d\n", weight)
 	fmt.Fprintln(w, "auto_generated: true")
+	for _, o := range opts {
+		o(w)
+	}
 	fmt.Fprintln(w, "---")
 	fmt.Fprintln(w)
 }

--- a/gen-apidocs/generators/markdown_test.go
+++ b/gen-apidocs/generators/markdown_test.go
@@ -55,8 +55,7 @@ func TestAnchor(t *testing.T) {
 }
 
 func TestEscape(t *testing.T) {
-	// We only escape `<` — `>` and other characters pass through to match
-	// gen-resourcesdocs chapter.tmpl behaviour.
+	// We only escape `<`; `>` and other characters pass through unchanged.
 	if got := escape("a <b> c"); got != `a \<b> c` {
 		t.Errorf("escape: got %q", got)
 	}
@@ -241,6 +240,167 @@ func TestRecordLinkPrecedence(t *testing.T) {
 	m.recordLink("HPA", "autoscaling", "horizontalpodautoscaler-v1", api.ApiVersion("v1"))
 	if got := m.linkMap["HPA"].Version; string(got) != "v2" {
 		t.Errorf("after old version, HPA version = %q, want v2", got)
+	}
+}
+
+// TestClassifyDefinitions verifies the BFS home-finder on a synthetic
+// reference graph: types with a unique closest top-level inline there,
+// types with ties at the minimum distance stay standalone.
+func TestClassifyDefinitions(t *testing.T) {
+	mkDef := func(name string, inToc bool) *api.Definition {
+		return &api.Definition{
+			Name:    name,
+			Group:   api.ApiGroup("test"),
+			Version: api.ApiVersion("v1"),
+			Kind:    api.ApiKind(name),
+			InToc:   inToc,
+		}
+	}
+
+	// Reference graph (parent --refs--> child; AppearsIn is reverse).
+	//
+	//   Pod (InToc) --> PodSpec --> Container
+	//                          --> Volume --> AzureDiskVolumeSource
+	//                          <-- PodTemplateSpec (shared)
+	//   Deployment (InToc) --> DeploymentSpec --> PodTemplateSpec
+	//   PodTemplate (InToc) --> PodTemplateSpec
+	//   ObjectMeta -- referenced directly by Pod, Deployment, PodTemplate
+	pod := mkDef("Pod", true)
+	deployment := mkDef("Deployment", true)
+	podTemplate := mkDef("PodTemplate", true)
+	podSpec := mkDef("PodSpec", false)
+	deploymentSpec := mkDef("DeploymentSpec", false)
+	podTemplateSpec := mkDef("PodTemplateSpec", false)
+	container := mkDef("Container", false)
+	volume := mkDef("Volume", false)
+	azureDisk := mkDef("AzureDiskVolumeSource", false)
+	objectMeta := mkDef("ObjectMeta", false)
+
+	// Populate AppearsIn (= "who references me?").
+	podSpec.AppearsIn = api.SortDefinitionsByName{pod, podTemplateSpec}
+	deploymentSpec.AppearsIn = api.SortDefinitionsByName{deployment}
+	podTemplateSpec.AppearsIn = api.SortDefinitionsByName{podTemplate, deploymentSpec}
+	container.AppearsIn = api.SortDefinitionsByName{podSpec}
+	volume.AppearsIn = api.SortDefinitionsByName{podSpec}
+	azureDisk.AppearsIn = api.SortDefinitionsByName{volume}
+	objectMeta.AppearsIn = api.SortDefinitionsByName{pod, deployment, podTemplate}
+
+	all := map[string]*api.Definition{}
+	for _, d := range []*api.Definition{
+		pod, deployment, podTemplate,
+		podSpec, deploymentSpec, podTemplateSpec,
+		container, volume, azureDisk, objectMeta,
+	} {
+		all[d.Key()] = d
+	}
+
+	m := &MarkdownWriter{Config: &api.Config{
+		Definitions: api.Definitions{All: all},
+	}}
+	got := m.classifyDefinitions()
+
+	cases := []struct {
+		name       string
+		def        *api.Definition
+		wantMode   classifyMode
+		wantParent *api.Definition // only checked when wantMode == classifyInline
+	}{
+		// Container's only chain hits Pod at dist 2 (Container -> PodSpec -> Pod)
+		// while Deployment / PodTemplate sit at dist 5+. Pod wins uniquely.
+		{"Container inlines into Pod", container, classifyInline, pod},
+		// AzureDisk is one hop deeper than Container; same winner.
+		{"AzureDiskVolumeSource inlines into Pod", azureDisk, classifyInline, pod},
+		// Volume is shared via PodSpec only; same winner as Container.
+		{"Volume inlines into Pod", volume, classifyInline, pod},
+		// ObjectMeta is at distance 1 from three InToc resources → tie → standalone.
+		{"ObjectMeta is standalone", objectMeta, classifyStandalone, nil},
+		// Pod itself is InToc → not classified (own resource page).
+		{"Pod is skip", pod, classifySkip, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cls := got[c.def.Key()]
+			if cls.Mode != c.wantMode {
+				t.Fatalf("Mode = %v, want %v", cls.Mode, c.wantMode)
+			}
+			if c.wantMode == classifyInline && cls.InlineInto != c.wantParent {
+				t.Fatalf("InlineInto = %v, want %v", cls.InlineInto, c.wantParent)
+			}
+		})
+	}
+}
+
+// TestLinkMapAliasesInlinedChildren verifies that a definition classified
+// as inline gets a linkMap entry that points at its parent resource page,
+// not at a standalone definitions/ file (which won't exist after Stage 2).
+func TestLinkMapAliasesInlinedChildren(t *testing.T) {
+	pod := &api.Definition{
+		Name: "Pod", Group: api.ApiGroup("core"), Version: api.ApiVersion("v1"),
+		Kind: api.ApiKind("Pod"), InToc: true,
+	}
+	container := &api.Definition{
+		Name: "Container", Group: api.ApiGroup("core"), Version: api.ApiVersion("v1"),
+		Kind: api.ApiKind("Container"),
+	}
+
+	m := &MarkdownWriter{
+		linkMap: map[string]linkInfo{},
+		classifications: map[string]defClassification{
+			container.Key(): {Mode: classifyInline, InlineInto: pod},
+		},
+		inlinedByParent: map[string][]*api.Definition{
+			pod.Key(): {container},
+		},
+	}
+
+	m.linkResources([]api.ResourceCategory{
+		{
+			Name:      "Workloads",
+			Resources: api.Resources{{Name: "Pod", Definition: pod}},
+		},
+	})
+
+	// Inlined child must alias to the parent's slug + filename.
+	got, ok := m.linkMap["Container"]
+	if !ok {
+		t.Fatal("linkMap missing entry for inlined Container")
+	}
+	if got.Category != "workloads" || got.Filename != "pod-v1" {
+		t.Errorf("Container linkInfo = {%q,%q}, want {workloads,pod-v1}", got.Category, got.Filename)
+	}
+}
+
+// TestLinkDefinitionsSkipsInlined verifies that an inlined type does not get
+// a stale definitions/ entry — only the parent-aliased entry from linkResources.
+func TestLinkDefinitionsSkipsInlined(t *testing.T) {
+	azureDisk := &api.Definition{
+		Name: "AzureDiskVolumeSource", Group: api.ApiGroup("core"),
+		Version: api.ApiVersion("v1"), Kind: api.ApiKind("AzureDiskVolumeSource"),
+	}
+	objectMeta := &api.Definition{
+		Name: "ObjectMeta", Group: api.ApiGroup("meta"),
+		Version: api.ApiVersion("v1"), Kind: api.ApiKind("ObjectMeta"),
+	}
+
+	m := &MarkdownWriter{
+		linkMap: map[string]linkInfo{},
+		classifications: map[string]defClassification{
+			azureDisk.Key():   {Mode: classifyInline}, // InlineInto irrelevant for this test
+			objectMeta.Key():  {Mode: classifyStandalone},
+		},
+	}
+
+	m.linkDefinitions(map[string]*api.Definition{
+		azureDisk.Key():  azureDisk,
+		objectMeta.Key(): objectMeta,
+	})
+
+	if _, exists := m.linkMap["AzureDiskVolumeSource"]; exists {
+		t.Error("inlined AzureDiskVolumeSource got a definitions/ entry; should have been skipped")
+	}
+	if got, ok := m.linkMap["ObjectMeta"]; !ok || got.Category != "definitions" {
+		t.Errorf("ObjectMeta should keep its standalone definitions/ entry; got = %+v ok=%v", got, ok)
 	}
 }
 


### PR DESCRIPTION
The markdown backend's output made k/website's `hugo server` dev mode
unusable (initial build minutes, home page sometimes wouldn't render).

## Approach
Four commits:
1. Skip old-version pages. (similar to old resource-gen approach)
2. Hide `definitions/` from Docsy sidebar nav.
3. Refcount-based inlining of non-resource types into their closest
   top-level parent with BFS. Two carve-outs: `io.k8s.apimachinery.*` types and a
   4-name core/v1 allowlist stay standalone.
4. Drop duplicate H1 on category index pages.

## Result
| | Before | After | Upstream baseline |
|---|---|---|---|
| Pages | 577 | **157** | 101 |
| Dev build | unusable | 120s | 42s |

## Companion PR
https://github.com/kubernetes/website/pull/55758


related #448 