### PR TITLE
add copycomp Makefile targets for component docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ CLIDSTFONT=$(CLIDST)/node_modules/font-awesome
 all:
 	@echo "Supported targets:"
 	@echo "  Build:    api apimd cli comp configapi"
-	@echo "  Copy:     copyapi copyapimd copycli copyconfigapi"
+	@echo "  Copy:     copyapi copyapimd copycli copycomp copyconfigapi"
 	@echo "  Setup:    createversiondirs updateapispec"
 	@echo "  Clean:    cleanapi cleanapimd cleancli cleancomp"
 	@echo "  Other:    genresources (deprecated)"
@@ -100,6 +100,35 @@ cleancomp:
 
 comp: cleancomp
 	make -C gen-compdocs
+
+# Copy component docs into k/website. The destinations
+# contain curated _index.md (and README.md for kubeadm) plus unrelated
+# subdirs (feature-gates*), so we don't rm -rf — we overlay on top.
+COMPSRC=gen-compdocs/build
+COMPCOREDST=$(WEBROOT)/content/en/docs/reference/command-line-tools-reference
+COMPKUBEADMDST=$(WEBROOT)/content/en/docs/reference/setup-tools/kubeadm/generated
+COMPKUBECTLDST=$(WEBROOT)/content/en/docs/reference/kubectl/generated
+
+# Copy core component docs (kube-apiserver, controller-manager, scheduler, proxy, kubelet)
+copycomp-core: require-webroot comp
+	cp $(COMPSRC)/kube-apiserver.md $(COMPCOREDST)/
+	cp $(COMPSRC)/kube-controller-manager.md $(COMPCOREDST)/
+	cp $(COMPSRC)/kube-scheduler.md $(COMPCOREDST)/
+	cp $(COMPSRC)/kube-proxy.md $(COMPCOREDST)/
+	cp $(COMPSRC)/kubelet.md $(COMPCOREDST)/
+
+# Copy kubeadm command docs (overlay; destination has hand-curated _index.md, README.md)
+copycomp-kubeadm: require-webroot comp
+	cp $(COMPSRC)/kubeadm.md $(COMPKUBEADMDST)/
+	for d in $(COMPSRC)/kubeadm_*; do cp -r "$$d" $(COMPKUBEADMDST)/; done
+
+# Copy kubectl command docs (overlay; destination has hand-curated _index.md)
+copycomp-kubectl: require-webroot comp
+	cp $(COMPSRC)/kubectl.md $(COMPKUBECTLDST)/
+	for d in $(COMPSRC)/kubectl_*; do cp -r "$$d" $(COMPKUBECTLDST)/; done
+
+# Run all three copycomp-* targets
+copycomp: copycomp-core copycomp-kubeadm copycomp-kubectl
 
 # Build API docs
 APISRC=gen-apidocs


### PR DESCRIPTION
## What
Three new `make` targets that copy `gen-compdocs/build/` output into the corresponding hand-curated destinations under k/website:

| Target | Source | Destination |
|---|---|---|
| `copycomp-core` | `kube-apiserver.md`, `kube-controller-manager.md`, `kube-scheduler.md`, `kube-proxy.md` | `content/en/docs/reference/command-line-tools-reference/` |
| `copycomp-kubeadm` | `kubeadm.md` + every `kubeadm_*/` subdir | `content/en/docs/reference/setup-tools/kubeadm/generated/` |
| `copycomp-kubectl` | `kubectl.md` + every `kubectl_*/` subdir | `content/en/docs/reference/kubectl/generated/` |

Plus a `copycomp` umbrella that runs all three.

## Why
Mirrors the per-component handoff pattern @tengqm described — each component's regenerated docs go into its specific hand-curated tree (which contains curated `_index.md`, `README.md`, and unrelated subdirs like `feature-gates/`), so we overlay rather than `rm -rf`.

## Verification
- `make -n copycomp-core` clean syntax
- End-to-end run against a real k/website tree: 4 kube-* files copied to command-line-tools-reference/, kubeadm tree copied with 11 subdirs, kubectl tree copied with 45 subdirs. No errors.