### PR TITLE
change '<','>' only if it is treated as a html tag

### DIFF
--- a/gen-compdocs/generators/doc.go
+++ b/gen-compdocs/generators/doc.go
@@ -528,28 +528,8 @@ func escapeAngleBracket(long string) string {
 			return ast.WalkContinue, nil
 		}
 
-		// when pair of '<', '>' characters found in the text and it is treated as a RawHTML node,
-		// then escape the text in RawHTML nodes.
-		t, ok := n.(*ast.RawHTML)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		segs := t.Segments
-
-		for i := 0; i < segs.Len(); i++ {
-			seg := segs.At(i)
-			changing := seg.Value(source)
-			changing = bytes.ReplaceAll(changing, []byte("<"), []byte("&lt;"))
-			changing = bytes.ReplaceAll(changing, []byte(">"), []byte("&gt;"))
-
-			reps = append(reps, repl{
-				start: seg.Start,
-				stop:  seg.Stop,
-				value: changing,
-			})
-		}
-
+		reps = handleRawHTML(n, source, reps)
+		reps = handleHTMLBlock(n, source, reps)
 		return ast.WalkContinue, nil
 	})
 
@@ -564,4 +544,54 @@ func escapeAngleBracket(long string) string {
 
 	out.Write(source[pos:]) // string after the last Text node
 	return out.String()
+}
+
+// pair of '<', '>' characters found in the text that is treated as a RawHTML node.
+// Example:
+// this is <script>test<script>
+func handleRawHTML(n ast.Node, source []byte, reps []repl) []repl {
+	t, ok := n.(*ast.RawHTML)
+	if !ok {
+		return reps
+	}
+	result := escapedSegments(t.Segments, source)
+	return append(reps, result...)
+}
+
+// pair of '<', '>' characters found in the text that is treated as a HTMLBlock node.
+// Example:
+// <script>
+// alert(1)
+// </script>
+func handleHTMLBlock(n ast.Node, source []byte, reps []repl) []repl {
+	t, ok := n.(*ast.HTMLBlock)
+	if !ok {
+		return reps
+	}
+	result := escapedSegments(t.Lines(), source)
+	if !t.ClosureLine.IsEmpty() {
+		result = append(result, escapedSegment(t.ClosureLine, source))
+	}
+	return append(reps, result...)
+}
+
+func escapedSegments(segs *text.Segments, source []byte) []repl {
+	var result []repl
+	for i := 0; i < segs.Len(); i++ {
+		escaped := escapedSegment(segs.At(i), source)
+		result = append(result, escaped)
+	}
+	return result
+}
+
+func escapedSegment(seg text.Segment, source []byte) repl {
+	changing := seg.Value(source)
+	changing = bytes.ReplaceAll(changing, []byte("<"), []byte("&lt;"))
+	changing = bytes.ReplaceAll(changing, []byte(">"), []byte("&gt;"))
+
+	return repl{
+		start: seg.Start,
+		stop:  seg.Stop,
+		value: changing,
+	}
 }

--- a/gen-compdocs/generators/doc.go
+++ b/gen-compdocs/generators/doc.go
@@ -30,9 +30,16 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 )
 
 type byName []*cobra.Command
+type repl struct {
+	start int
+	stop  int
+	value []byte
+}
 
 func (s byName) Len() int           { return len(s) }
 func (s byName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
@@ -140,8 +147,7 @@ func GenReference(cmd *cobra.Command, w io.Writer, linkHandler func(string) stri
 		}
 
 		// Escape any '<', '>' characters found in the long description
-		long = strings.ReplaceAll(long, "<", "&lt;")
-		long = strings.ReplaceAll(long, ">", "&gt;")
+		long = escapeAngleBracket(long)
 		if _, err := fmt.Fprintf(w, "\n%s\n\n", long); err != nil {
 			return err
 		}
@@ -168,8 +174,7 @@ func GenReference(cmd *cobra.Command, w io.Writer, linkHandler func(string) stri
 		}
 
 		// Escape any '<', '>' characters found in the long description
-		long = strings.ReplaceAll(long, "<", "&lt;")
-		long = strings.ReplaceAll(long, ">", "&gt;")
+		long = escapeAngleBracket(long)
 		if _, err := fmt.Fprintf(w, "\n%s\n\n", long); err != nil {
 			return err
 		}
@@ -505,4 +510,58 @@ func processUsage(usage string) string {
 	result = strings.TrimSuffix(result, "\n")
 	result = strings.ReplaceAll(result, "\n", "<br/>")
 	return result
+}
+
+// This function is to escape any '<', '>' characters found in the description of the command,
+// but leave those character which are not treated as html tags using AST.
+// e.g, single angle bracket, pair of angle bracket brackets in code blocks.
+func escapeAngleBracket(long string) string {
+
+	source := []byte(long)
+	doc := goldmark.DefaultParser().Parse(text.NewReader(source))
+
+	var reps []repl
+
+	// iterating node
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		// when pair of '<', '>' characters found in the text and it is treated as a RawHTML node,
+		// then escape the text in RawHTML nodes.
+		t, ok := n.(*ast.RawHTML)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		segs := t.Segments
+
+		for i := 0; i < segs.Len(); i++ {
+			seg := segs.At(i)
+			changing := seg.Value(source)
+			changing = bytes.ReplaceAll(changing, []byte("<"), []byte("&lt;"))
+			changing = bytes.ReplaceAll(changing, []byte(">"), []byte("&gt;"))
+
+			reps = append(reps, repl{
+				start: seg.Start,
+				stop:  seg.Stop,
+				value: changing,
+			})
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	var out bytes.Buffer
+	pos := 0
+
+	for _, r := range reps {
+		out.Write(source[pos:r.start]) // string before the Text node
+		out.Write(r.value)             // string to replace the Text node
+		pos = r.stop
+	}
+
+	out.Write(source[pos:]) // string after the last Text node
+	return out.String()
 }


### PR DESCRIPTION
# Why

[Generated docs kubectl explain has typo with describing JsonPath Identifier](https://github.com/kubernetes/website/issues/54776)

# How

change
from: replace '<', '>' to '&lt;, &gt;' always 
to: replace  '<', '>' to '&lt;' &gt' only if it is treated as html tag (unexpected in long description)

# affected docs(generated docs) after change

1. kubectl explain

```
after <         <type>.<fieldName>[.<fieldName>]
---
before >         &lt;type&gt;.&lt;fieldName&gt;[.&lt;fieldName&gt;]
```

2. kubectl diff

```
after <  Exit status: 0 No differences were found. 1 Differences were found. >1 Kubectl or diff failed with an error.
---
before >  Exit status: 0 No differences were found. 1 Differences were found. &gt;1 Kubectl or diff failed with an error.
```

3. kubectl completion

```
after <  Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2.
---
before >  Note for zsh users: [1] zsh completions are only supported in versions of zsh &gt;= 5.2.
```


# Test

test with [kubernetes/website](https://github.com/kubernetes/website) and [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)

# Comment

This is my first PR in k8s Project. and If I missed something, just let me know.  
Thank you! 


