### PR TITLE
Add updateapispec-enums-from-source to generate enum swagger from a temporary k/k checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ all:
 	@echo "Supported targets:"
 	@echo "  Build:    api apimd cli comp configapi"
 	@echo "  Copy:     copyapi copyapimd copycli copycomp copyconfigapi"
-	@echo "  Setup:    createversiondirs updateapispec"
+	@echo "  Setup:    createversiondirs updateapispec updateapispec-enums-from-source"
 	@echo "  Clean:    cleanapi cleanapimd cleancli cleancomp"
 	@echo "  Other:    genresources (deprecated)"
 
@@ -137,6 +137,13 @@ APIDST=$(WEBROOT)/static/docs/reference/generated/kubernetes-api/v$(K8SRELEASE_P
 updateapispec: require-k8sroot require-k8srelease createversiondirs
 	@echo "Updating swagger.json for release v$(K8SRELEASE)"
 	cd $(K8SROOT) && git show "v$(K8SRELEASE):api/openapi-spec/swagger.json" > $(CURDIR)/$(APISRC)/config/v$(K8SRELEASEDIR)/swagger.json
+
+# Opt-in: generate enum-enabled swagger.json from a temporary k/k checkout, so
+# contributors do not need a manually patched local k/k. Needs network access
+# and k/k's host OpenAPI prerequisites; KEEP_TMP=1 preserves the checkout.
+updateapispec-enums-from-source: require-k8srelease createversiondirs
+	@echo "Generating enum-enabled swagger.json from source for release v$(K8SRELEASE)"
+	./hack/gen-enum-swagger.sh
 
 api: require-k8srelease cleanapi
 	cd $(APISRC) && go run main.go --kubernetes-release=$(K8SRELEASE_PREFIX) --work-dir=. --auto-detect

--- a/gen-apidocs/README.md
+++ b/gen-apidocs/README.md
@@ -24,6 +24,23 @@ For the canonical end-to-end release walkthrough, see [Generating Reference Docu
 
 The `swagger.json` checked into `kubernetes/kubernetes` at `api/openapi-spec/swagger.json` is missing many enum fields that the API reference needs. Regenerate the file with `OpenAPIEnums=true` before running the generator.
 
+### Option A: from a temporary source checkout (no local k/k needed)
+
+From the reference-docs repository root, with only `K8S_RELEASE` set:
+
+```shell
+make updateapispec-enums-from-source
+```
+
+This shallow-clones the release tag into a temporary directory, enables
+`OpenAPIEnums=true` in that copy only, runs k/k's `hack/update-openapi-spec.sh`,
+copies the result into `gen-apidocs/config/v<X_Y>/swagger.json`, verifies the
+enum metadata, and deletes the temporary checkout. It needs network access and
+k/k's host OpenAPI prerequisites, and leaves k/k's checked-in swagger unchanged.
+Set `KEEP_TMP=1` to preserve the checkout and generation log for debugging.
+
+### Option B: from a prepared `K8S_ROOT` checkout
+
 From your `K8S_ROOT` checkout, at the release tag:
 
 1. Edit `hack/update-openapi-spec.sh` and set `OpenAPIEnums=true`.

--- a/hack/gen-enum-swagger.sh
+++ b/hack/gen-enum-swagger.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Generate enum-enabled OpenAPI swagger.json from a temporary Kubernetes source
+# checkout, so release contributors do not need a maintainer-managed, manually
+# patched k/k clone.
+#
+# Steps: shallow-clone the release tag, patch only that temporary checkout to
+# enable OpenAPIEnums=true, run k/k's existing hack/update-openapi-spec.sh, copy
+# only api/openapi-spec/swagger.json into gen-apidocs, verify enum metadata, and
+# delete the temporary checkout (KEEP_TMP=1 preserves it for debugging).
+#
+# Required env: K8S_RELEASE (e.g. 1.36.0)
+# Pass-through env (read directly by k/k): TMP_DIR, ETCD_PORT, API_PORT, API_LOGFILE
+# Debug: KEEP_TMP=1 keeps the temporary checkout and generation log.
+
+set -euo pipefail
+
+if [ -z "${K8S_RELEASE:-}" ]; then
+	echo "K8S_RELEASE not set. Example: export K8S_RELEASE=1.36.0" >&2
+	exit 1
+fi
+
+# Preflight: obvious local tools only. k/k's build reports deeper problems.
+for tool in git go jq curl openssl; do
+	if ! command -v "${tool}" >/dev/null 2>&1; then
+		echo "${tool} is required but was not found in PATH." >&2
+		exit 1
+	fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+
+TAG="v${K8S_RELEASE}"
+# 1.36.0 -> v1_36, matching set_version_dirs.sh and the Makefile.
+VERSION_DIR="v$(echo "${K8S_RELEASE}" | cut -c 1-4 | sed "s/\./_/g")"
+OUT_DIR="${REPO_ROOT}/gen-apidocs/config/${VERSION_DIR}"
+OUT_SWAGGER="${OUT_DIR}/swagger.json"
+
+TMPROOT="$(mktemp -d)"
+KK="${TMPROOT}/kubernetes"
+GEN_LOG="${TMPROOT}/gen-openapi.log"
+
+cleanup() {
+	if [ "${KEEP_TMP:-}" = "1" ]; then
+		echo "KEEP_TMP=1 set; preserving temporary checkout:"
+		echo "  checkout: ${KK}"
+		echo "  log:      ${GEN_LOG}"
+	else
+		chmod -R u+w "${TMPROOT}" 2>/dev/null || true
+		rm -rf "${TMPROOT}"
+	fi
+}
+trap cleanup EXIT
+
+echo "Cloning kubernetes/kubernetes at ${TAG} (shallow) into ${KK}"
+git clone --depth 1 --branch "${TAG}" \
+	https://github.com/kubernetes/kubernetes.git "${KK}"
+
+# Patch only this temporary checkout. k/k hardcodes OpenAPIEnums=false on the
+# kube-apiserver --feature-gates line; flip it to true for enum-enabled output.
+echo "Enabling OpenAPIEnums=true in the temporary checkout"
+sed -i.bak 's/OpenAPIEnums=false/OpenAPIEnums=true/' "${KK}/hack/update-openapi-spec.sh"
+rm -f "${KK}/hack/update-openapi-spec.sh.bak"
+if ! grep -q 'OpenAPIEnums=true' "${KK}/hack/update-openapi-spec.sh"; then
+	echo "Failed to enable OpenAPIEnums in ${KK}/hack/update-openapi-spec.sh." >&2
+	echo "The k/k script format may have changed for ${TAG}; patch it manually." >&2
+	exit 1
+fi
+
+echo "Running k/k hack/update-openapi-spec.sh (logging to ${GEN_LOG})"
+( cd "${KK}" && hack/update-openapi-spec.sh ) 2>&1 | tee "${GEN_LOG}"
+
+mkdir -p "${OUT_DIR}"
+echo "Copying swagger.json into ${OUT_SWAGGER}"
+cp "${KK}/api/openapi-spec/swagger.json" "${OUT_SWAGGER}"
+
+echo "Verifying enum metadata"
+"${SCRIPT_DIR}/verify-enum-swagger.sh" "${OUT_SWAGGER}"
+
+echo "Enum-enabled swagger.json ready at ${OUT_SWAGGER}"

--- a/hack/verify-enum-swagger.sh
+++ b/hack/verify-enum-swagger.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Verify that a swagger.json was generated with OpenAPIEnums=true by counting
+# how many non-empty "enum" arrays it contains. Fails if the count is below a
+# conservative minimum, so a contributor cannot proceed with enum-free swagger.
+#
+# Usage: verify-enum-swagger.sh <path-to-swagger.json> [min-enum-arrays]
+#
+# Reusable across the temporary-checkout, maintainer-checkout, and future
+# artifact-fetch workflows.
+
+set -euo pipefail
+
+SWAGGER="${1:-}"
+MIN_ENUMS="${2:-50}"
+
+if [ -z "${SWAGGER}" ]; then
+	echo "Usage: $0 <path-to-swagger.json> [min-enum-arrays]" >&2
+	exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "jq is required but was not found in PATH." >&2
+	exit 1
+fi
+
+if [ ! -f "${SWAGGER}" ]; then
+	echo "swagger file not found: ${SWAGGER}" >&2
+	exit 1
+fi
+
+# Recursively count every non-empty "enum" array anywhere in the document.
+ENUM_COUNT="$(jq '[.. | objects | select(has("enum")) | .enum | select(length > 0)] | length' "${SWAGGER}")"
+
+if [ "${ENUM_COUNT}" -lt "${MIN_ENUMS}" ]; then
+	echo "Enum verification FAILED: ${SWAGGER} has ${ENUM_COUNT} non-empty enum arrays (expected at least ${MIN_ENUMS})." >&2
+	echo "The swagger was likely generated without OpenAPIEnums=true." >&2
+	exit 1
+fi
+
+echo "Enum verification passed: ${ENUM_COUNT} non-empty enum arrays in ${SWAGGER}."


### PR DESCRIPTION
Adds an opt-in target that produces enum-enabled `swagger.json` without a
prepared local k/k checkout:

    make updateapispec-enums-from-source   # needs only K8S_RELEASE

It shallow-clones the release tag to a temp dir, flips `OpenAPIEnums=false→true`
in that copy only, runs k/k's `hack/update-openapi-spec.sh`, copies just
`swagger.json` into `gen-apidocs/config/v<X_Y>/`, verifies enum metadata, and
deletes the temp checkout (`KEEP_TMP=1` to keep it).

This removes that barrier while leaving k/k's checked-in swagger and
the existing `updateapispec` flow untouched.

## Notes

- Opt-in only; not wired into any default/release path.
- Verification (`hack/verify-enum-swagger.sh`) is a standalone script so the
  checkout-based and future artifact-fetch paths can reuse it.
- Tested on macOS arm64 against v1.36.0: output is byte-identical to the
  checked-in enum swagger (125 enum arrays); temp checkout cleaned up.

<img width="1050" height="240" alt="image" src="https://github.com/user-attachments/assets/3eee0445-29e7-45fd-9951-137a4fc224cf" />


Closes: https://github.com/kubernetes-sigs/reference-docs/issues/456