### PR TITLE
add hugo-md backend with markdown response code tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ CLIDSTFONT=$(CLIDST)/node_modules/font-awesome
 
 all:
 	@echo "Supported targets:"
-	@echo "  Build:    api apimd cli comp configapi"
+	@echo "  Build:    api apimd apimd-hugo cli comp configapi"
 	@echo "  Copy:     copyapi copyapimd copycli copycomp copyconfigapi"
 	@echo "  Setup:    createversiondirs updateapispec updateapispec-enums-from-source"
-	@echo "  Clean:    cleanapi cleanapimd cleancli cleancomp"
+	@echo "  Clean:    cleanapi cleanapimd cleanapimd-hugo cleancli cleancomp"
 	@echo "  Other:    genresources (deprecated)"
 
 # create directories for new release
@@ -153,6 +153,10 @@ api: require-k8srelease cleanapi
 apimd: require-k8srelease cleanapimd
 	cd $(APISRC) && go run main.go --kubernetes-release=$(K8SRELEASE_PREFIX) --work-dir=. --auto-detect --backend=markdown
 
+# Build API docs as Hugo-flavored markdown (gen-apidocs/build/hugo-md/).
+apimd-hugo: require-k8srelease cleanapimd-hugo
+	cd $(APISRC) && go run main.go --kubernetes-release=$(K8SRELEASE_PREFIX) --work-dir=. --auto-detect --backend=hugo-md
+
 cleanapi:
 	rm -rf $(shell pwd)/gen-apidocs/build/html
 	rm -rf $(shell pwd)/gen-apidocs/build/includes
@@ -161,6 +165,9 @@ cleanapi:
 
 cleanapimd:
 	rm -rf $(shell pwd)/gen-apidocs/build/markdown
+
+cleanapimd-hugo:
+	rm -rf $(shell pwd)/gen-apidocs/build/hugo-md
 
 copyapi: require-webroot api
 	mkdir -p $(APIDST)

--- a/gen-apidocs/generators/api/config.go
+++ b/gen-apidocs/generators/api/config.go
@@ -37,7 +37,7 @@ var AllowErrors = flag.Bool("allow-errors", false, "If true, don't fail on error
 var WorkDir = flag.String("work-dir", "", "Working directory for the generator.")
 var UseTags = flag.Bool("use-tags", false, "If true, use the openapi tags instead of the config yaml.")
 var KubernetesRelease = flag.String("kubernetes-release", "", "Kubernetes release version.")
-var Backend = flag.String("backend", "html", "Output format for the generator. Supported values: 'html' or 'markdown'.")
+var Backend = flag.String("backend", "html", "Output format for the generator. Supported values: 'html', 'markdown', or 'hugo-md'.")
 var AutoDetect = flag.Bool("auto-detect", false, "If true, auto-detect API groups and versions from swagger.json.")
 
 // titleCase converts a string to title case as a replacement for deprecated strings.Title
@@ -81,6 +81,8 @@ func NewConfig() (*Config, error) {
 	switch *Backend {
 	case "markdown":
 		BuildDir = filepath.Join(buildRoot, "markdown")
+	case "hugo-md":
+		BuildDir = filepath.Join(buildRoot, "hugo-md")
 	default:
 		BuildDir = filepath.Join(buildRoot, "html")
 	}

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -45,6 +45,10 @@ type MarkdownWriter struct {
 	resourceWeight  int
 	categoryWeight  int
 
+	// HugoMode emits Hugo-flavored markdown (markdown tables with class
+	// attributes that Hugo render hooks can target). Set by NewHugoMDWriter.
+	HugoMode bool
+
 	// linkMap maps kind name → page path for cross-reference resolution.
 	linkMap map[string]linkInfo
 
@@ -116,6 +120,7 @@ type templateOperation struct {
 	QueryParams []templateParam
 	BodyParams  []templateParam
 	Responses   []templateResponse
+	HugoMode    bool
 }
 
 type templateParam struct {
@@ -192,6 +197,12 @@ func NewMarkdownWriter(config *api.Config, copyright, title string) DocWriter {
 	m.classifications = m.classifyDefinitions()
 	m.buildLinkMap(config)
 	return m
+}
+
+func NewHugoMDWriter(config *api.Config, copyright, title string) DocWriter {
+	w := NewMarkdownWriter(config, copyright, title).(*MarkdownWriter)
+	w.HugoMode = true
+	return w
 }
 
 func (m *MarkdownWriter) Extension() string {
@@ -561,10 +572,11 @@ func (m *MarkdownWriter) appendFields(section *fieldSection, d *api.Definition, 
 
 func (m *MarkdownWriter) buildTemplateOperation(o *api.Operation, currentCategory string) templateOperation {
 	op := templateOperation{
-		Verb:   strings.ToLower(o.HttpMethod),
-		Title:  o.Type.Name,
-		Method: o.HttpMethod,
-		Path:   o.Path,
+		Verb:     strings.ToLower(o.HttpMethod),
+		Title:    o.Type.Name,
+		Method:   o.HttpMethod,
+		Path:     o.Path,
+		HugoMode: m.HugoMode,
 	}
 
 	convert := func(params api.Fields) []templateParam {

--- a/gen-apidocs/generators/markdown_test.go
+++ b/gen-apidocs/generators/markdown_test.go
@@ -167,6 +167,25 @@ func TestWriteOperationGolden(t *testing.T) {
 		"testdata/operation-list.golden.md")
 }
 
+func TestWriteOperationGoldenHugoMode(t *testing.T) {
+	m, cleanup := newTestWriter(t)
+	defer cleanup()
+	m.HugoMode = true
+
+	if err := os.MkdirAll(filepath.Join(m.OutputDir, "operations"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	o := fabricateOperation()
+	if err := m.WriteOperation(o); err != nil {
+		t.Fatalf("WriteOperation: %v", err)
+	}
+
+	compareWithGolden(t,
+		filepath.Join(m.OutputDir, "operations", "listcorev1pod.md"),
+		"testdata/operation-list-hugo.golden.md")
+}
+
 func TestResolveType(t *testing.T) {
 	m := &MarkdownWriter{linkMap: map[string]linkInfo{}}
 	m.linkResources([]api.ResourceCategory{
@@ -455,6 +474,10 @@ func fabricateOperation() *api.Operation {
 		},
 		QueryParams: api.Fields{
 			{Name: "watch", Type: "boolean", Description: "Watch for changes to the described resources."},
+		},
+		HttpResponses: api.HttpResponses{
+			{Code: "200", Field: api.Field{Type: "PodList", Description: "OK"}},
+			{Code: "401", Field: api.Field{Description: "Unauthorized"}},
 		},
 	}
 }

--- a/gen-apidocs/generators/templates/resource.tmpl
+++ b/gen-apidocs/generators/templates/resource.tmpl
@@ -82,6 +82,13 @@ guide. You can file document formatting bugs against the
 {{if .Responses}}
 #### Response
 
+{{if .HugoMode -}}
+| Status | Description | Response |
+|---|---|---|
+{{range .Responses}}| {{.Code}} | {{.Description | md}} | {{if .Type}}{{template "mdTypeWrap" .}}{{else}}—{{end}} |
+{{end -}}
+{class="api-reference-response-codes"}
+{{- else -}}
 <table>
   <thead><tr><th>Status</th><th>Description</th><th>Response</th></tr></thead>
   <tbody>
@@ -94,11 +101,16 @@ guide. You can file document formatting bugs against the
 {{- end}}
   </tbody>
 </table>
+{{- end}}
 {{end}}
 {{end}}
 
 {{define "typeWrap" -}}
 {{if .TypeHref}}<a href="{{hugoRef .TypeHref}}">{{.Type}}</a>{{else}}{{.Type}}{{end}}
+{{- end}}
+
+{{define "mdTypeWrap" -}}
+{{if .TypeHref}}[{{.Type}}]({{hugoRef .TypeHref}}){{else}}{{.Type}}{{end}}
 {{- end}}
 
 {{define "paramTable" -}}

--- a/gen-apidocs/generators/testdata/deployment-v1.golden.md
+++ b/gen-apidocs/generators/testdata/deployment-v1.golden.md
@@ -66,3 +66,5 @@ Deployment enables declarative updates for Pods and ReplicaSets.
 
 
 
+
+

--- a/gen-apidocs/generators/testdata/operation-list-hugo.golden.md
+++ b/gen-apidocs/generators/testdata/operation-list-hugo.golden.md
@@ -43,19 +43,9 @@ GET /api/v1/namespaces/{namespace}/pods
 
 #### Response
 
-<table>
-  <thead><tr><th>Status</th><th>Description</th><th>Response</th></tr></thead>
-  <tbody>
-    <tr>
-      <td>200</td>
-      <td>OK</td>
-      <td><em>PodList</em></td>
-    </tr>
-    <tr>
-      <td>401</td>
-      <td>Unauthorized</td>
-      <td>&mdash;</td>
-    </tr>
-  </tbody>
-</table>
+| Status | Description | Response |
+|---|---|---|
+| 200 | OK | PodList |
+| 401 | Unauthorized | — |
+{class="api-reference-response-codes"}
 

--- a/gen-apidocs/generators/writer.go
+++ b/gen-apidocs/generators/writer.go
@@ -71,8 +71,11 @@ func GenerateFiles() error {
 	case "markdown":
 		fmt.Println("Using Markdown backend for documentation generation.")
 		writer = NewMarkdownWriter(config, copyright, title)
+	case "hugo-md":
+		fmt.Println("Using Hugo-flavored Markdown backend for documentation generation.")
+		writer = NewHugoMDWriter(config, copyright, title)
 	default:
-		return fmt.Errorf("unsupported backend '%s': must be 'html' or 'markdown'", *api.Backend)
+		return fmt.Errorf("unsupported backend '%s': must be 'html', 'markdown', or 'hugo-md'", *api.Backend)
 	}
 
 	// Write the main overview page directly to avoid an unnecessary thin wrapper


### PR DESCRIPTION
Adds a third gen-apidocs backend, `--backend=hugo-md`, alongside the
existing `html` and `markdown` backends. When enabled, the generator
emits markdown tables with class attributes that Hugo render hooks can target.

Phase 1 of #440: HTTP response code tables only. All other tables stay
unchanged from `--backend=markdown`. 

The default backends are byte-identical to before (confirmed via existing goldens).
