### PR TITLE
hugo-md: extend to all operation sub-tables + restructure page (#440 phases 2, 6, 7, 8)

### DIFF
--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -17,16 +17,12 @@ limitations under the License.
 package generators
 
 import (
-	_ "embed"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
-	"strconv"
 	"strings"
-	"text/template"
 
 	"github.com/kubernetes-sigs/reference-docs/gen-apidocs/generators/api"
 )
@@ -159,29 +155,6 @@ var utilityStandalone = map[string]bool{
 }
 
 var _ DocWriter = (*MarkdownWriter)(nil)
-
-var anchorRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)
-
-var (
-	enumHeaderRegex = regexp.MustCompile(`\s+Possible enum values:`)
-	enumBulletRegex = regexp.MustCompile(`\s+- ` + "`")
-)
-
-//go:embed templates/resource.tmpl
-var resourceTemplateSrc string
-
-// q quotes for YAML frontmatter; md escapes `<` for body text; hugoRef
-// wraps a relative path in a {{< ref >}} shortcode.
-var resourceTemplate = template.Must(template.New("resource").Funcs(template.FuncMap{
-	"q":       strconv.Quote,
-	"md":      escape,
-	"hugoRef": hugoRef,
-}).Parse(resourceTemplateSrc))
-
-// hugoRef wraps a path in a {{< ref >}} shortcode resolved by Hugo at build time.
-func hugoRef(path string) string {
-	return `{{< ref "` + path + `" >}}`
-}
 
 func NewMarkdownWriter(config *api.Config, copyright, title string) DocWriter {
 	outputDir := api.BuildDir
@@ -847,58 +820,6 @@ func tocSortRank(title string) int {
 	default:
 		return 2
 	}
-}
-
-func anchor(s string) string {
-	return strings.Trim(anchorRegex.ReplaceAllString(s, "-"), "-")
-}
-
-// escape covers the only markdown-breaking character in OpenAPI descriptions:
-// raw `<` that would otherwise be read as HTML.
-func escape(s string) string {
-	s = strings.ReplaceAll(s, "<", `\<`)
-	s = enumHeaderRegex.ReplaceAllString(s, "<br/><br/>Possible enum values:")
-	s = enumBulletRegex.ReplaceAllString(s, "<br/> - `")
-	return s
-}
-
-func kebabCase(s string) string {
-	return strings.Trim(anchorRegex.ReplaceAllString(strings.ToLower(s), "-"), "-")
-}
-
-var (
-	kebabBoundary1 = regexp.MustCompile(`([a-z0-9])([A-Z])`)
-	kebabBoundary2 = regexp.MustCompile(`([A-Z])([A-Z][a-z])`)
-)
-
-func kebabName(s string) string {
-	s = kebabBoundary2.ReplaceAllString(s, "$1-$2")
-	s = kebabBoundary1.ReplaceAllString(s, "$1-$2")
-	return strings.ToLower(s)
-}
-
-func groupVersionString(group string, version api.ApiVersion) string {
-	if group == "" || group == "core" {
-		return version.String()
-	}
-	return fmt.Sprintf("%s/%s", group, version.String())
-}
-
-func operationSlug(id string) string {
-	return strings.Trim(anchorRegex.ReplaceAllString(strings.ToLower(id), "-"), "-")
-}
-
-// constValueFor hard-codes the two fields Kubernetes manifests always
-// carry with fixed values (apiVersion and kind). Swagger doesn't tag
-// them as const so we derive them from the GVK.
-func constValueFor(fieldName, apiVersion, kind string) string {
-	switch fieldName {
-	case "apiVersion":
-		return apiVersion
-	case "kind":
-		return kind
-	}
-	return ""
 }
 
 func (m *MarkdownWriter) nextCategoryWeight() int {

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -79,14 +79,25 @@ type linkInfo struct {
 // resourcePage is the view model resource.tmpl consumes.
 type resourcePage struct {
 	APIVersion  string
+	APIGroup    string
 	Kind        string
 	Import      string
 	Title       string
 	Weight      int
 	Anchor      string
 	Description string
-	Sections    []fieldSection
-	Operations  []templateOperation
+	HugoMode    bool
+
+	Sections []fieldSection
+
+	// The remaining slices regroup Sections by role for the hugo-md template
+	// path. They reference the same data, partitioned by section kind.
+	ResourceSection   fieldSection
+	FieldSections     []fieldSection // Kind="field": .spec, .status, etc.
+	CollectionSection *fieldSection  // Kind="collection": the List type (zero or one)
+	TypeSections      []fieldSection // Kind="type": other inlined nested types
+
+	Operations []templateOperation
 }
 
 type fieldSection struct {
@@ -94,6 +105,13 @@ type fieldSection struct {
 	Anchor      string
 	Description string
 	Fields      []templateField
+
+	Kind string
+
+	// FieldPath is set for Kind="field": the dot-notation field name on
+	// the parent resource (e.g. "spec", "status"). Used by hugo-md to
+	// emit `## `.spec` {#NodeSpec}` style headings.
+	FieldPath string
 }
 
 type templateField struct {
@@ -428,12 +446,14 @@ func (m *MarkdownWriter) buildResourcePage(r *api.Resource, currentCategory stri
 func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory string) resourcePage {
 	page := resourcePage{
 		APIVersion:  groupVersionString(d.GroupFullName, d.Version),
+		APIGroup:    string(d.Group),
 		Kind:        d.Name,
 		Import:      d.GoImportPath(),
 		Title:       d.Name,
 		Weight:      m.nextResourceWeight(),
 		Anchor:      anchor(d.Name),
 		Description: d.DescriptionWithEntities,
+		HugoMode:    m.HugoMode,
 	}
 
 	// Inline closure rooted at d gates which types may flatten inline;
@@ -451,24 +471,31 @@ func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory 
 	}
 	collect(d)
 
-	// Section-worthy = directly referenced field type, or d's List type.
+	// sectionEntry tracks each section-worthy definition alongside the
+	// classification used by the hugo-md heading restructure.
+	type sectionEntry struct {
+		def       *api.Definition
+		kind      string // "field", "collection", or "type"
+		fieldPath string // populated when kind == "field"
+	}
+
 	sectionTypes := map[string]bool{}
-	sectionOrder := []*api.Definition{}
-	addSection := func(def *api.Definition) {
+	sectionOrder := []sectionEntry{}
+	addSection := func(def *api.Definition, kind, fieldPath string) {
 		if def == nil || sectionTypes[def.Key()] {
 			return
 		}
 		sectionTypes[def.Key()] = true
-		sectionOrder = append(sectionOrder, def)
+		sectionOrder = append(sectionOrder, sectionEntry{def: def, kind: kind, fieldPath: fieldPath})
 	}
 	for _, fld := range d.Fields {
 		if fld.Definition != nil && allowInline[fld.Definition.Key()] {
-			addSection(fld.Definition)
+			addSection(fld.Definition, "field", fld.Name)
 		}
 	}
 	for _, c := range d.Inline {
 		if c.Name == d.Name+"List" {
-			addSection(c)
+			addSection(c, "collection", "")
 		}
 	}
 
@@ -476,7 +503,7 @@ func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory 
 		sorted := append([]*api.Definition(nil), siblings...)
 		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
 		for _, c := range sorted {
-			addSection(c)
+			addSection(c, "type", "")
 		}
 	}
 
@@ -485,19 +512,34 @@ func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory 
 		Title:       d.Name,
 		Anchor:      anchor(d.Name),
 		Description: d.DescriptionWithEntities,
+		Kind:        "resource",
 	}
 	m.appendFields(&root, d, "", currentCategory, allowInline, sectionTypes, visited)
 	page.Sections = append(page.Sections, root)
+	page.ResourceSection = root
 
-	for _, s := range sectionOrder {
+	for _, e := range sectionOrder {
+		s := e.def
 		section := fieldSection{
 			Title:       s.Name,
 			Anchor:      anchor(s.Name),
 			Description: s.DescriptionWithEntities,
+			Kind:        e.kind,
+			FieldPath:   e.fieldPath,
 		}
 		svisited := map[string]bool{d.Key(): true, s.Key(): true}
 		m.appendFields(&section, s, "", currentCategory, allowInline, sectionTypes, svisited)
 		page.Sections = append(page.Sections, section)
+
+		switch e.kind {
+		case "field":
+			page.FieldSections = append(page.FieldSections, section)
+		case "collection":
+			cs := section
+			page.CollectionSection = &cs
+		case "type":
+			page.TypeSections = append(page.TypeSections, section)
+		}
 	}
 	return page
 }

--- a/gen-apidocs/generators/markdown_test.go
+++ b/gen-apidocs/generators/markdown_test.go
@@ -475,6 +475,9 @@ func fabricateOperation() *api.Operation {
 		QueryParams: api.Fields{
 			{Name: "watch", Type: "boolean", Description: "Watch for changes to the described resources."},
 		},
+		BodyParams: api.Fields{
+			{Name: "body", Type: "Pod", Description: "Pod to create."},
+		},
 		HttpResponses: api.HttpResponses{
 			{Code: "200", Field: api.Field{Type: "PodList", Description: "OK"}},
 			{Code: "401", Field: api.Field{Description: "Unauthorized"}},

--- a/gen-apidocs/generators/markdown_test.go
+++ b/gen-apidocs/generators/markdown_test.go
@@ -149,6 +149,26 @@ func TestWriteResourceGolden(t *testing.T) {
 		"testdata/deployment-v1.golden.md")
 }
 
+func TestWriteResourceGoldenHugoMode(t *testing.T) {
+	m, cleanup := newTestWriter(t)
+	defer cleanup()
+	m.HugoMode = true
+
+	if err := os.MkdirAll(filepath.Join(m.OutputDir, testCategorySlug), 0755); err != nil {
+		t.Fatal(err)
+	}
+	m.currentCategory = mdCategory{name: testCategoryName, slug: testCategorySlug}
+
+	r := fabricateDeploymentResource()
+	if err := m.WriteResource(r); err != nil {
+		t.Fatalf("WriteResource: %v", err)
+	}
+
+	compareWithGolden(t,
+		filepath.Join(m.OutputDir, testCategorySlug, "deployment-v1.md"),
+		"testdata/deployment-v1-hugo.golden.md")
+}
+
 func TestWriteOperationGolden(t *testing.T) {
 	m, cleanup := newTestWriter(t)
 	defer cleanup()

--- a/gen-apidocs/generators/template_helpers.go
+++ b/gen-apidocs/generators/template_helpers.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	_ "embed"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+//go:embed templates/resource.tmpl
+var resourceTemplateSrc string
+
+// Template helpers registered on resourceTemplate:
+//
+//	q       quotes for YAML frontmatter
+//	md      escapes `<` for body text
+//	hugoRef wraps a relative path in a {{< ref >}} shortcode
+var resourceTemplate = template.Must(template.New("resource").Funcs(template.FuncMap{
+	"q":       strconv.Quote,
+	"md":      escape,
+	"hugoRef": hugoRef,
+}).Parse(resourceTemplateSrc))
+
+var (
+	enumHeaderRegex = regexp.MustCompile(`\s+Possible enum values:`)
+	enumBulletRegex = regexp.MustCompile(`\s+- ` + "`")
+)
+
+// escape covers the only markdown-breaking character in OpenAPI descriptions:
+// raw `<` that would otherwise be read as HTML.
+func escape(s string) string {
+	s = strings.ReplaceAll(s, "<", `\<`)
+	s = enumHeaderRegex.ReplaceAllString(s, "<br/><br/>Possible enum values:")
+	s = enumBulletRegex.ReplaceAllString(s, "<br/> - `")
+	return s
+}
+
+// hugoRef wraps a path in a {{< ref >}} shortcode resolved by Hugo at build time.
+func hugoRef(path string) string {
+	return `{{< ref "` + path + `" >}}`
+}

--- a/gen-apidocs/generators/template_helpers.go
+++ b/gen-apidocs/generators/template_helpers.go
@@ -31,10 +31,12 @@ var resourceTemplateSrc string
 //
 //	q       quotes for YAML frontmatter
 //	md      escapes `<` for body text
+//	mdCell  escapes pipes and newlines for safe use inside markdown table cells
 //	hugoRef wraps a relative path in a {{< ref >}} shortcode
 var resourceTemplate = template.Must(template.New("resource").Funcs(template.FuncMap{
 	"q":       strconv.Quote,
 	"md":      escape,
+	"mdCell":  mdCell,
 	"hugoRef": hugoRef,
 }).Parse(resourceTemplateSrc))
 
@@ -49,6 +51,15 @@ func escape(s string) string {
 	s = strings.ReplaceAll(s, "<", `\<`)
 	s = enumHeaderRegex.ReplaceAllString(s, "<br/><br/>Possible enum values:")
 	s = enumBulletRegex.ReplaceAllString(s, "<br/> - `")
+	return s
+}
+
+// mdCell escapes a description for safe use inside a markdown table cell:
+// pipes break the row, and raw newlines split the cell across rows.
+func mdCell(s string) string {
+	s = escape(s)
+	s = strings.ReplaceAll(s, "|", `\|`)
+	s = strings.ReplaceAll(s, "\n", " ")
 	return s
 }
 

--- a/gen-apidocs/generators/template_helpers.go
+++ b/gen-apidocs/generators/template_helpers.go
@@ -18,6 +18,7 @@ package generators
 
 import (
 	_ "embed"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -29,15 +30,19 @@ var resourceTemplateSrc string
 
 // Template helpers registered on resourceTemplate:
 //
-//	q       quotes for YAML frontmatter
-//	md      escapes `<` for body text
-//	mdCell  escapes pipes and newlines for safe use inside markdown table cells
-//	hugoRef wraps a relative path in a {{< ref >}} shortcode
+//	q             quotes for YAML frontmatter
+//	md            escapes `<` for body text
+//	mdCell        escapes pipes and newlines for safe use inside markdown table cells
+//	hugoRef       wraps a relative path in a {{< ref >}} shortcode
+//	hugoShortcode emits a Hugo shortcode with positional string args
+//	dict          builds a map for passing named args to named templates
 var resourceTemplate = template.Must(template.New("resource").Funcs(template.FuncMap{
-	"q":       strconv.Quote,
-	"md":      escape,
-	"mdCell":  mdCell,
-	"hugoRef": hugoRef,
+	"q":             strconv.Quote,
+	"md":            escape,
+	"mdCell":        mdCell,
+	"hugoRef":       hugoRef,
+	"hugoShortcode": hugoShortcode,
+	"dict":          dict,
 }).Parse(resourceTemplateSrc))
 
 var (
@@ -66,4 +71,34 @@ func mdCell(s string) string {
 // hugoRef wraps a path in a {{< ref >}} shortcode resolved by Hugo at build time.
 func hugoRef(path string) string {
 	return `{{< ref "` + path + `" >}}`
+}
+
+// hugoShortcode emits a Hugo shortcode invocation: `{{< name "arg1" "arg2" >}}`.
+// String args are quoted to preserve embedded whitespace.
+func hugoShortcode(name string, args ...string) string {
+	if len(args) == 0 {
+		return `{{< ` + name + ` >}}`
+	}
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		quoted[i] = strconv.Quote(a)
+	}
+	return `{{< ` + name + ` ` + strings.Join(quoted, " ") + ` >}}`
+}
+
+// dict builds a map[string]any from alternating key/value pairs, used to pass
+// named arguments to {{template "name" ...}} calls.
+func dict(values ...any) (map[string]any, error) {
+	if len(values)%2 != 0 {
+		return nil, fmt.Errorf("dict: odd argument count %d", len(values))
+	}
+	m := make(map[string]any, len(values)/2)
+	for i := 0; i < len(values); i += 2 {
+		k, ok := values[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("dict: non-string key at index %d (%T)", i, values[i])
+		}
+		m[k] = values[i+1]
+	}
+	return m, nil
 }

--- a/gen-apidocs/generators/templates/resource.tmpl
+++ b/gen-apidocs/generators/templates/resource.tmpl
@@ -67,17 +67,41 @@ guide. You can file document formatting bugs against the
 {{if .PathParams}}
 #### Path Parameters
 
+{{if .HugoMode -}}
+| Name | Type | Description |
+|---|---|---|
+{{range .PathParams}}| `{{.Name}}` | {{template "mdTypeWrap" .}} | {{.Description | mdCell}} |
+{{end -}}
+{class="api-reference-path-parameters"}
+{{- else -}}
 {{template "paramTable" .PathParams}}
+{{- end}}
 {{end}}
 {{if .QueryParams}}
 #### Query Parameters
 
+{{if .HugoMode -}}
+| Name | Type | Description |
+|---|---|---|
+{{range .QueryParams}}| `{{.Name}}` | {{template "mdTypeWrap" .}} | {{.Description | mdCell}} |
+{{end -}}
+{class="api-reference-query-parameters"}
+{{- else -}}
 {{template "paramTable" .QueryParams}}
+{{- end}}
 {{end}}
 {{if .BodyParams}}
 #### Body Parameters
 
+{{if .HugoMode -}}
+| Name | Type | Description |
+|---|---|---|
+{{range .BodyParams}}| `{{.Name}}` | {{template "mdTypeWrap" .}} | {{.Description | mdCell}} |
+{{end -}}
+{class="api-reference-request-body"}
+{{- else -}}
 {{template "paramTable" .BodyParams}}
+{{- end}}
 {{end}}
 {{if .Responses}}
 #### Response
@@ -85,7 +109,7 @@ guide. You can file document formatting bugs against the
 {{if .HugoMode -}}
 | Status | Description | Response |
 |---|---|---|
-{{range .Responses}}| {{.Code}} | {{.Description | md}} | {{if .Type}}{{template "mdTypeWrap" .}}{{else}}—{{end}} |
+{{range .Responses}}| {{.Code}} | {{.Description | mdCell}} | {{if .Type}}{{template "mdTypeWrap" .}}{{else}}—{{end}} |
 {{end -}}
 {class="api-reference-response-codes"}
 {{- else -}}

--- a/gen-apidocs/generators/templates/resource.tmpl
+++ b/gen-apidocs/generators/templates/resource.tmpl
@@ -1,10 +1,19 @@
 ---
 api_metadata:
+{{- if .HugoMode}}
+{{- if .APIGroup}}
+  apiGroup: {{.APIGroup | q}}
+{{- end}}
+{{- end}}
   apiVersion: {{.APIVersion | q}}
-{{- if .Import}}
+{{- if and .Import (not .HugoMode)}}
   import: {{.Import | q}}
 {{- end}}
   kind: {{.Kind | q}}
+{{- if and .HugoMode .Import}}
+code_import:
+  go: {{.Import | q}}
+{{- end}}
 content_type: "api_reference"
 description: {{.Description | q}}
 title: {{.Title | q}}
@@ -23,6 +32,71 @@ guide. You can file document formatting bugs against the
 [reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
 -->
 
+{{if .HugoMode -}}
+{{/* ============================ HUGO-MD PATH ============================ */}}
+
+{{/* --- Resource section --- */}}
+
+## {{.Kind}} object API type {#resource}
+
+{{hugoShortcode "api-object-preamble" .Kind}}
+
+{{.ResourceSection.Description | md}}
+
+{{template "fieldsTable" .ResourceSection.Fields}}
+
+{{/* --- Field sections (.spec, .status, etc.) --- */}}
+
+{{range .FieldSections}}
+## `.{{.FieldPath}}` {#{{.Anchor}}}
+
+{{.Description | md}}
+
+{{template "fieldsTable" .Fields}}
+{{end}}
+
+{{/* --- Collection section (NodeList, etc.) --- */}}
+
+{{if .CollectionSection}}
+## {{.Kind}} collection API type {#collections}
+
+{{hugoShortcode "api-collection-preamble" .Kind}}
+
+### {{.CollectionSection.Title}} {#{{.CollectionSection.Anchor}}}
+
+{{.CollectionSection.Description | md}}
+
+{{template "fieldsTable" .CollectionSection.Fields}}
+{{end}}
+
+{{/* --- Operations --- */}}
+
+{{if .Operations}}
+## API operations on {{.Kind}} {#operations-resource}
+
+{{hugoShortcode "api-operations-preamble" .Kind}}
+{{end}}
+{{- range .Operations}}
+{{template "operation" .}}
+{{- end}}
+
+{{/* --- Nested types used by this API --- */}}
+
+{{if .TypeSections}}
+## Types used in this API
+
+{{hugoShortcode "api-type-preamble" .Kind}}
+{{range .TypeSections}}
+### {{.Title}} {#{{.Anchor}}}
+
+{{.Description | md}}
+
+{{template "fieldsTable" .Fields}}
+{{end}}
+{{end}}
+
+{{- else -}}
+{{/* ============================ DEFAULT PATH ============================= */}}
 `apiVersion: {{.APIVersion}}`
 {{if .Import}}
 `import "{{.Import}}"`
@@ -34,18 +108,7 @@ guide. You can file document formatting bugs against the
 
 <hr>
 
-{{if .Fields}}<table>
-  <thead><tr><th>Field</th><th>Description</th></tr></thead>
-  <tbody>
-{{- range .Fields}}
-    <tr>
-      <td><code>{{.Name}}</code>{{if .Required}}&nbsp;<strong>*</strong>{{end}}<br/><em>{{template "typeWrap" .}}</em>{{if .ConstValue}}<br/><em>const: <code>{{.ConstValue}}</code></em>{{end}}{{if .PatchStrategy}}<br/><em>patch strategy: {{.PatchStrategy}}{{if .PatchMergeKey}} on key <code>{{.PatchMergeKey}}</code>{{end}}</em>{{end}}</td>
-      <td>{{.Description | md}}</td>
-    </tr>
-{{- end}}
-  </tbody>
-</table>
-{{end}}
+{{if .Fields}}{{template "fieldsTable" .Fields}}{{end}}
 {{end}}
 {{if .Operations}}
 ## Operations {#Operations}
@@ -55,6 +118,21 @@ guide. You can file document formatting bugs against the
 {{end}}
 {{- range .Operations}}
 {{template "operation" .}}
+{{- end}}
+{{- end}}
+
+{{define "fieldsTable" -}}
+<table>
+  <thead><tr><th>Field</th><th>Description</th></tr></thead>
+  <tbody>
+{{- range .}}
+    <tr>
+      <td><code>{{.Name}}</code>{{if .Required}}&nbsp;<strong>*</strong>{{end}}<br/><em>{{template "typeWrap" .}}</em>{{if .ConstValue}}<br/><em>const: <code>{{.ConstValue}}</code></em>{{end}}{{if .PatchStrategy}}<br/><em>patch strategy: {{.PatchStrategy}}{{if .PatchMergeKey}} on key <code>{{.PatchMergeKey}}</code>{{end}}</em>{{end}}</td>
+      <td>{{.Description | md}}</td>
+    </tr>
+{{- end}}
+  </tbody>
+</table>
 {{- end}}
 
 {{define "operation" -}}
@@ -68,11 +146,7 @@ guide. You can file document formatting bugs against the
 #### Path Parameters
 
 {{if .HugoMode -}}
-| Name | Type | Description |
-|---|---|---|
-{{range .PathParams}}| `{{.Name}}` | {{template "mdTypeWrap" .}} | {{.Description | mdCell}} |
-{{end -}}
-{class="api-reference-path-parameters"}
+{{template "mdParamTable" dict "Params" .PathParams "Class" "api-reference-path-parameters"}}
 {{- else -}}
 {{template "paramTable" .PathParams}}
 {{- end}}
@@ -81,11 +155,7 @@ guide. You can file document formatting bugs against the
 #### Query Parameters
 
 {{if .HugoMode -}}
-| Name | Type | Description |
-|---|---|---|
-{{range .QueryParams}}| `{{.Name}}` | {{template "mdTypeWrap" .}} | {{.Description | mdCell}} |
-{{end -}}
-{class="api-reference-query-parameters"}
+{{template "mdParamTable" dict "Params" .QueryParams "Class" "api-reference-query-parameters"}}
 {{- else -}}
 {{template "paramTable" .QueryParams}}
 {{- end}}
@@ -94,11 +164,7 @@ guide. You can file document formatting bugs against the
 #### Body Parameters
 
 {{if .HugoMode -}}
-| Name | Type | Description |
-|---|---|---|
-{{range .BodyParams}}| `{{.Name}}` | {{template "mdTypeWrap" .}} | {{.Description | mdCell}} |
-{{end -}}
-{class="api-reference-request-body"}
+{{template "mdParamTable" dict "Params" .BodyParams "Class" "api-reference-request-body"}}
 {{- else -}}
 {{template "paramTable" .BodyParams}}
 {{- end}}
@@ -135,6 +201,16 @@ guide. You can file document formatting bugs against the
 
 {{define "mdTypeWrap" -}}
 {{if .TypeHref}}[{{.Type}}]({{hugoRef .TypeHref}}){{else}}{{.Type}}{{end}}
+{{- end}}
+
+{{/* mdParamTable: hugo-md variant of paramTable. Expects dict "Params" <slice> "Class" <css-class>. */}}
+
+{{define "mdParamTable" -}}
+| Name | Type | Description |
+|---|---|---|
+{{range .Params}}| `{{.Name}}` | {{template "mdTypeWrap" .}} | {{.Description | mdCell}} |
+{{end -}}
+{class="{{.Class}}"}
 {{- end}}
 
 {{define "paramTable" -}}

--- a/gen-apidocs/generators/testdata/deployment-v1-hugo.golden.md
+++ b/gen-apidocs/generators/testdata/deployment-v1-hugo.golden.md
@@ -1,8 +1,10 @@
 ---
 api_metadata:
+  apiGroup: "apps"
   apiVersion: "apps/v1"
-  import: "k8s.io/api/apps/v1"
   kind: "Deployment"
+code_import:
+  go: "k8s.io/api/apps/v1"
 content_type: "api_reference"
 description: "Deployment enables declarative updates for Pods and ReplicaSets."
 title: "Deployment"
@@ -22,16 +24,14 @@ guide. You can file document formatting bugs against the
 -->
 
 
-`apiVersion: apps/v1`
-
-`import "k8s.io/api/apps/v1"`
 
 
-## Deployment {#Deployment}
+
+## Deployment object API type {#resource}
+
+{{< api-object-preamble "Deployment" >}}
 
 Deployment enables declarative updates for Pods and ReplicaSets.
-
-<hr>
 
 <table>
   <thead><tr><th>Field</th><th>Description</th></tr></thead>
@@ -58,6 +58,20 @@ Deployment enables declarative updates for Pods and ReplicaSets.
     </tr>
   </tbody>
 </table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/gen-apidocs/generators/testdata/operation-list-hugo.golden.md
+++ b/gen-apidocs/generators/testdata/operation-list-hugo.golden.md
@@ -14,31 +14,26 @@ GET /api/v1/namespaces/{namespace}/pods
 
 #### Path Parameters
 
-<table>
-  <thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><code>namespace</code></td>
-      <td><em>string</em></td>
-      <td>object name and auth scope, such as for teams and users</td>
-    </tr>
-  </tbody>
-</table>
+| Name | Type | Description |
+|---|---|---|
+| `namespace` | string | object name and auth scope, such as for teams and users |
+{class="api-reference-path-parameters"}
 
 
 #### Query Parameters
 
-<table>
-  <thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><code>watch</code></td>
-      <td><em>boolean</em></td>
-      <td>Watch for changes to the described resources.</td>
-    </tr>
-  </tbody>
-</table>
+| Name | Type | Description |
+|---|---|---|
+| `watch` | boolean | Watch for changes to the described resources. |
+{class="api-reference-query-parameters"}
 
+
+#### Body Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| `body` | Pod | Pod to create. |
+{class="api-reference-request-body"}
 
 
 #### Response

--- a/gen-apidocs/generators/testdata/operation-list.golden.md
+++ b/gen-apidocs/generators/testdata/operation-list.golden.md
@@ -40,6 +40,19 @@ GET /api/v1/namespaces/{namespace}/pods
 </table>
 
 
+#### Body Parameters
+
+<table>
+  <thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>body</code></td>
+      <td><em>Pod</em></td>
+      <td>Pod to create.</td>
+    </tr>
+  </tbody>
+</table>
+
 
 #### Response
 

--- a/gen-apidocs/generators/util.go
+++ b/gen-apidocs/generators/util.go
@@ -18,11 +18,63 @@ package generators
 
 import (
 	"fmt"
-
+	"regexp"
 	"strings"
 
 	"github.com/kubernetes-sigs/reference-docs/gen-apidocs/generators/api"
 )
+
+var (
+	anchorRegex    = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+	kebabBoundary1 = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+	kebabBoundary2 = regexp.MustCompile(`([A-Z])([A-Z][a-z])`)
+)
+
+// anchor produces a stable in-page anchor from a kind or section name.
+func anchor(s string) string {
+	return strings.Trim(anchorRegex.ReplaceAllString(s, "-"), "-")
+}
+
+// kebabCase lowercases and slugifies any string into a kebab-case identifier
+// used for directory and file names.
+func kebabCase(s string) string {
+	return strings.Trim(anchorRegex.ReplaceAllString(strings.ToLower(s), "-"), "-")
+}
+
+// kebabName converts a CamelCase API kind (e.g. "PodTemplate") into its
+// kebab-cased file form (e.g. "pod-template"), preserving acronym boundaries.
+func kebabName(s string) string {
+	s = kebabBoundary2.ReplaceAllString(s, "$1-$2")
+	s = kebabBoundary1.ReplaceAllString(s, "$1-$2")
+	return strings.ToLower(s)
+}
+
+// groupVersionString formats the canonical "group/version" string used in
+// API references, collapsing the core group to a bare version.
+func groupVersionString(group string, version api.ApiVersion) string {
+	if group == "" || group == "core" {
+		return version.String()
+	}
+	return fmt.Sprintf("%s/%s", group, version.String())
+}
+
+// operationSlug derives a filename-safe slug from an operation ID.
+func operationSlug(id string) string {
+	return strings.Trim(anchorRegex.ReplaceAllString(strings.ToLower(id), "-"), "-")
+}
+
+// constValueFor hard-codes the two fields Kubernetes manifests always carry
+// with fixed values (apiVersion and kind). Swagger does not tag them as const
+// so we derive them from the GVK.
+func constValueFor(fieldName, apiVersion, kind string) string {
+	switch fieldName {
+	case "apiVersion":
+		return apiVersion
+	case "kind":
+		return kind
+	}
+	return ""
+}
 
 func PrintInfo(config *api.Config) {
 	definitions := config.Definitions


### PR DESCRIPTION
Extends hugo backend to query, path and body parameters table and testdata

depends on https://github.com/kubernetes-sigs/reference-docs/pull/459

## Issue:

part of https://github.com/kubernetes-sigs/reference-docs/issues/440