### PR TITLE
gen-apidocs: split resource description into summary and body

### DIFF
--- a/gen-apidocs/generators/api/config.go
+++ b/gen-apidocs/generators/api/config.go
@@ -870,6 +870,7 @@ func (c *Config) mapOperationsToDefinitions() error {
 func (c *Config) escapeDescriptions() {
 	for _, d := range c.Definitions.All {
 		d.DescriptionWithEntities = html.EscapeString(d.Description())
+		d.SummaryWithEntities = html.EscapeString(d.Summary())
 
 		for _, f := range d.Fields {
 			f.DescriptionWithEntities = html.EscapeString(f.Description)

--- a/gen-apidocs/generators/api/definition.go
+++ b/gen-apidocs/generators/api/definition.go
@@ -423,6 +423,23 @@ func (d *Definition) Description() string {
 	return EscapeAsterisks(d.schema.Description)
 }
 
+// Summary returns a single-paragraph, front-matter-safe rendering of the
+// definition's description: only the text up to the first blank line, with
+// any remaining newlines collapsed to spaces. Mirrors the sanitization
+// already applied to field/parameter/response descriptions and prevents
+// embedded multi-line doc-comment examples (e.g. EndpointSubset's
+// struct-literal example) from being dumped verbatim into the page's
+// front-matter "description" field (rendered as the ".lead" intro on
+// kubernetes.io).
+func (d *Definition) Summary() string {
+	desc := d.schema.Description
+	if idx := strings.Index(desc, "\n\n"); idx != -1 {
+		desc = desc[:idx]
+	}
+	desc = strings.TrimSpace(strings.ReplaceAll(desc, "\n", " "))
+	return EscapeAsterisks(desc)
+}
+
 func (d *Definition) GetResourceName() string {
 	if len(d.Resource) > 0 {
 		return d.Resource

--- a/gen-apidocs/generators/api/definition_test.go
+++ b/gen-apidocs/generators/api/definition_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/spec"
+)
+
+// endpointSubsetDescription mirrors the real doc comment on
+// k8s.io/api/core/v1's EndpointSubset: a summary sentence, a blank line, an
+// indented struct-literal example, another blank line, then more prose. This
+// is the shape that produced the garbled front-matter ".lead" reported in
+// kubernetes/website#56418.
+const endpointSubsetDescription = "Endpoints is a collection of endpoints that implement the actual service. Example:\n" +
+	"\n" +
+	"\t Name: \"mysvc\",\n" +
+	"\t Subsets: [\n" +
+	"\t   {\n" +
+	"\t     Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n" +
+	"\t     Ports: [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n" +
+	"\t   },\n" +
+	"\t ]\n" +
+	"\n" +
+	"Endpoints is a legacy API and does not contain information about all Service features."
+
+func TestDefinitionSummaryVsDescription(t *testing.T) {
+	d := &Definition{schema: spec.Schema{
+		SchemaProps: spec.SchemaProps{Description: endpointSubsetDescription},
+	}}
+
+	wantSummary := "Endpoints is a collection of endpoints that implement the actual service. Example:"
+	if got := d.Summary(); got != wantSummary {
+		t.Errorf("Summary() = %q, want %q", got, wantSummary)
+	}
+	if strings.Contains(d.Summary(), "\n") || strings.Contains(d.Summary(), "\t") {
+		t.Errorf("Summary() must not contain embedded newlines/tabs, got %q", d.Summary())
+	}
+	if strings.Contains(d.Summary(), "mysvc") {
+		t.Errorf("Summary() must not include the embedded example, got %q", d.Summary())
+	}
+
+	// Description() (used for the page body) must still carry the full text,
+	// including the example — only the front-matter Summary() is trimmed.
+	if got := d.Description(); got != endpointSubsetDescription {
+		t.Errorf("Description() = %q, want the untouched original description", got)
+	}
+	if !strings.Contains(d.Description(), "mysvc") {
+		t.Errorf("Description() must still include the embedded example")
+	}
+}
+
+func TestDefinitionSummarySingleParagraph(t *testing.T) {
+	// A description with no embedded example (the common case) should pass
+	// through Summary() unchanged aside from trimming.
+	d := &Definition{schema: spec.Schema{
+		SchemaProps: spec.SchemaProps{Description: "PodSpec describes how the pod will look."},
+	}}
+	want := "PodSpec describes how the pod will look."
+	if got := d.Summary(); got != want {
+		t.Errorf("Summary() = %q, want %q", got, want)
+	}
+}

--- a/gen-apidocs/generators/api/types.go
+++ b/gen-apidocs/generators/api/types.go
@@ -199,6 +199,7 @@ type Definition struct {
 	Version                 ApiVersion
 	Kind                    ApiKind
 	DescriptionWithEntities string
+	SummaryWithEntities     string
 	GroupFullName           string
 
 	// InToc is true if this definition should appear in the table of contents

--- a/gen-apidocs/generators/markdown.go
+++ b/gen-apidocs/generators/markdown.go
@@ -460,7 +460,7 @@ func (m *MarkdownWriter) buildDefinitionPage(d *api.Definition, currentCategory 
 		Title:       d.Name,
 		Weight:      m.nextResourceWeight(),
 		Anchor:      anchor(d.Name),
-		Description: d.DescriptionWithEntities,
+		Description: d.SummaryWithEntities,
 	}
 
 	// Inline closure rooted at d gates which types may flatten inline;

--- a/gen-apidocs/generators/markdown_test.go
+++ b/gen-apidocs/generators/markdown_test.go
@@ -149,6 +149,31 @@ func TestWriteResourceGolden(t *testing.T) {
 		"testdata/deployment-v1.golden.md")
 }
 
+// TestWriteResourceGoldenMultilineDescription guards against
+// kubernetes/website#56418: a resource whose Go doc comment embeds a
+// multi-line example (like core/v1's EndpointSubset) must get a short,
+// single-line front-matter "description" (rendered as the page's ".lead"
+// intro on kubernetes.io), while the full example is preserved in the page
+// body.
+func TestWriteResourceGoldenMultilineDescription(t *testing.T) {
+	m, cleanup := newTestWriter(t)
+	defer cleanup()
+
+	if err := os.MkdirAll(filepath.Join(m.OutputDir, testCategorySlug), 0755); err != nil {
+		t.Fatal(err)
+	}
+	m.currentCategory = mdCategory{name: testCategoryName, slug: testCategorySlug}
+
+	r := fabricateEndpointsResource()
+	if err := m.WriteResource(r); err != nil {
+		t.Fatalf("WriteResource: %v", err)
+	}
+
+	compareWithGolden(t,
+		filepath.Join(m.OutputDir, testCategorySlug, "endpoints-v1.md"),
+		"testdata/endpoints-v1.golden.md")
+}
+
 func TestWriteOperationGolden(t *testing.T) {
 	m, cleanup := newTestWriter(t)
 	defer cleanup()
@@ -451,6 +476,7 @@ func fabricateDeploymentResource() *api.Resource {
 			Version:                 api.ApiVersion("v1"),
 			Kind:                    api.ApiKind("Deployment"),
 			DescriptionWithEntities: "Deployment enables declarative updates for Pods and ReplicaSets.",
+			SummaryWithEntities:     "Deployment enables declarative updates for Pods and ReplicaSets.",
 			SwaggerKey:              "io.k8s.api.apps.v1.Deployment",
 			Fields: api.Fields{
 				{Name: "apiVersion", Type: "string", Description: "APIVersion defines the versioned schema of this representation of an object."},
@@ -458,6 +484,42 @@ func fabricateDeploymentResource() *api.Resource {
 				{Name: "metadata", Type: "ObjectMeta", Description: "Standard object's metadata."},
 				{Name: "spec", Type: "DeploymentSpec", Description: "Specification of the desired behavior of the Deployment."},
 				{Name: "status", Type: "DeploymentStatus", Description: "Most recently observed status of the Deployment."},
+			},
+		},
+	}
+}
+
+// endpointSubsetExampleDescription mirrors the real doc comment on core/v1's
+// EndpointSubset: a summary sentence followed by a blank line and an indented
+// struct-literal example — the shape that produced the garbled front-matter
+// ".lead" reported in kubernetes/website#56418.
+const endpointSubsetExampleDescription = "Endpoints is a collection of endpoints that implement the actual service. Example:\n" +
+	"\n" +
+	"\t Name: \"mysvc\",\n" +
+	"\t Subsets: [\n" +
+	"\t   {\n" +
+	"\t     Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n" +
+	"\t     Ports: [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n" +
+	"\t   },\n" +
+	"\t ]"
+
+func fabricateEndpointsResource() *api.Resource {
+	return &api.Resource{
+		Name: "Endpoints",
+		Definition: &api.Definition{
+			Name:                    "Endpoints",
+			Group:                   api.ApiGroup(""),
+			GroupFullName:           "",
+			Version:                 api.ApiVersion("v1"),
+			Kind:                    api.ApiKind("Endpoints"),
+			DescriptionWithEntities: endpointSubsetExampleDescription,
+			SummaryWithEntities:     "Endpoints is a collection of endpoints that implement the actual service. Example:",
+			SwaggerKey:              "io.k8s.api.core.v1.Endpoints",
+			Fields: api.Fields{
+				{Name: "apiVersion", Type: "string", Description: "APIVersion defines the versioned schema of this representation of an object."},
+				{Name: "kind", Type: "string", Description: "Kind is a string value representing the REST resource."},
+				{Name: "metadata", Type: "ObjectMeta", Description: "Standard object's metadata."},
+				{Name: "subsets", Type: "[]EndpointSubset", Description: "The set of all endpoints is the union of all subsets."},
 			},
 		},
 	}

--- a/gen-apidocs/generators/testdata/endpoints-v1.golden.md
+++ b/gen-apidocs/generators/testdata/endpoints-v1.golden.md
@@ -1,0 +1,74 @@
+---
+api_metadata:
+  apiVersion: "v1"
+  import: "k8s.io/api/core/v1"
+  kind: "Endpoints"
+content_type: "api_reference"
+description: "Endpoints is a collection of endpoints that implement the actual service. Example:"
+title: "Endpoints"
+weight: 10
+auto_generated: true
+---
+
+<!--
+The file is auto-generated from the Go source code of the component using a generic
+[generator](https://github.com/kubernetes-sigs/reference-docs/). To learn how
+to generate the reference documentation, please read
+[Contributing to the reference documentation](/docs/contribute/generate-ref-docs/).
+To update the reference content, please follow the
+[Contributing upstream](/docs/contribute/generate-ref-docs/contribute-upstream/)
+guide. You can file document formatting bugs against the
+[reference-docs](https://github.com/kubernetes-sigs/reference-docs/) project.
+-->
+
+`apiVersion: v1`
+
+`import "k8s.io/api/core/v1"`
+
+
+## Endpoints {#Endpoints}
+
+Endpoints is a collection of endpoints that implement the actual service. Example:
+
+	 Name: "mysvc",
+	 Subsets: [
+	   {
+	     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+	     Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+	   },
+	 ]
+
+<hr>
+
+<table>
+  <thead><tr><th>Field</th><th>Description</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>apiVersion</code><br/><em>string</em></td>
+      <td>APIVersion defines the versioned schema of this representation of an object.</td>
+    </tr>
+    <tr>
+      <td><code>kind</code><br/><em>string</em></td>
+      <td>Kind is a string value representing the REST resource.</td>
+    </tr>
+    <tr>
+      <td><code>metadata</code><br/><em>ObjectMeta</em></td>
+      <td>Standard object's metadata.</td>
+    </tr>
+    <tr>
+      <td><code>subsets</code><br/><em>[]EndpointSubset</em></td>
+      <td>The set of all endpoints is the union of all subsets.</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
**Problem:** 

Generated API-reference pages (e.g. `endpoints-v1`) render a type's *entire* Go doc comment as the page's `.lead` intro, including embedded multi-line examples. `EndpointSubset`'s struct-literal example gets dumped verbatim into the intro paragraph instead of a clean summary sentence. See kubernetes/website#56418.

**Fix:** 

`Definition.Description()` had no paragraph/newline handling, unlike field/param/response descriptions elsewhere in the generator, which already collapse newlines. Adds `Definition.Summary()` (first paragraph only, newlines collapsed) and uses it just for the front-matter `description:` field. The full description — including the example — still renders in the page body, so nothing is lost.

**Testing:**

 New unit test + end-to-end golden-file test built from `EndpointSubset`'s real doc comment. `go vet`/`go test ./...` pass.